### PR TITLE
Event Id from URL + Hidden field issue

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -242,6 +242,16 @@ abstract class wf_crm_webform_base {
    */
   protected function getExposedOptions($field_key, $exclude = array()) {
     $field = $this->getComponent($field_key);
+    
+    if ($field && $field['type'] == 'hidden') {
+      // Fetch live options
+      $exposed = wf_crm_field_options($field, 'live_options', $this->data);
+      foreach ($exclude as $i) {
+       unset($exposed[$i]);
+      }
+      return $exposed;
+    }
+    
     if ($field && $field['type'] == 'select') {
       // Fetch static options
       if (empty($field['extra']['civicrm_live_options'])) {


### PR DESCRIPTION
This PR addresses the below mentioned issue.

**Issue:**
Webform CiviCRM event tab, there is an option called load event from url. This option allow a user-select event field to be loaded via a parameter in the url (like the contact autoload and checksum). This works fine if the event field is using the default widget. However, if the change to use Hidden widget, the autoload mechanism will stop working.
