### PR TITLE
PG-99 issue# 2. Handling of pay later option while renewing membership

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1058,6 +1058,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
     $existing = $this->findMemberships($cid);
     foreach (wf_crm_aval($this->data, "membership:$c:membership", array()) as $n => $params) {
+      $membershipStatus = "";
+      $is_active = FALSE;
+      
       if (empty($params['membership_type_id'])) {
         continue;
       }
@@ -1071,6 +1074,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $params['id'] = $mem['id'];
             // If we have an exact match, look no further
             if ($mem['membership_type_id'] == $params['membership_type_id']) {
+              $is_active = $mem['is_active'];
+              $membershipStatus = $mem['status'];
               break;
             }
           }
@@ -1090,7 +1095,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         // Pending payment status
         if ($this->contributionIsIncomplete && $this->getMembershipTypeField($params['membership_type_id'], 'minimum_fee')) {
           $params['is_pay_later'] = $this->contributionIsPayLater;
-          $params['status_id'] = 'Pending';
+          
+          if ($params['is_pay_later'] === TRUE) { // If user choose Pay later option.
+            if ($is_active == FALSE) {
+              $params['status_id'] = 'Pending';
+            } else {
+              $params['status_id'] = $membershipStatus;
+            }
+          }else{
+            $params['status_id'] = 'Pending';
+          }
         }
       }
       // Override status

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1059,6 +1059,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $existing = $this->findMemberships($cid);
     foreach (wf_crm_aval($this->data, "membership:$c:membership", array()) as $n => $params) {
       $membershipStatus = "";
+      $membershipEndDate = "";
       $is_active = FALSE;
       
       if (empty($params['membership_type_id'])) {
@@ -1076,6 +1077,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             if ($mem['membership_type_id'] == $params['membership_type_id']) {
               $is_active = $mem['is_active'];
               $membershipStatus = $mem['status'];
+              $membershipEndDate = $mem['end_date'];
               break;
             }
           }
@@ -1101,6 +1103,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               $params['status_id'] = 'Pending';
             } else {
               $params['status_id'] = $membershipStatus;
+              $params['end_date'] = $membershipEndDate;
             }
           }else{
             $params['status_id'] = 'Pending';


### PR DESCRIPTION
This PR handles the below mentioned issue:

**Issue:**
When a person who holds an active membership come to renew his membership via webform civicrm, he chose pay later on the payment method. This changes his current membership to be pending. Fix according to CiviCRM core behaviour.
