### PR TITLE
PG-99 issue#1

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1782,6 +1782,19 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (empty($item['contribution_id'])) {
         $item['contribution_id'] = $id;
       }
+      
+      if (!empty($item['membership_id'])) {
+                
+        // only update contribution_id in civicrm_line_item rather than creating a new record.
+        $item['entity_id'] = $item['membership_id'];
+        $lineItemId = wf_civicrm_api('LineItem', 'getsingle', array(
+                        'return' => "id",
+                        'entity_id' => $item['entity_id'],
+                        'entity_table' => 'civicrm_membership',
+                      ));
+        $item['id'] = $lineItemId['id'];
+      }
+      
       $line_result = wf_civicrm_api('line_item', 'create', $item);
       $item['id'] = $line_result['id'];
   

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1781,8 +1781,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // tax integration
       if (empty($item['contribution_id'])) {
         $item['contribution_id'] = $id;
-      }
-      
+      }   
       // Membership
       if (!empty($item['membership_id'])) {
         $item['entity_id'] = $item['membership_id'];
@@ -1790,9 +1789,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           'entity_table' => "civicrm_membership",
           'entity_id' => $item['entity_id'],
         ));
-
-        if($lineItemArray['count'] != 0){
-        
+        if($lineItemArray['count'] != 0){     
           // We only require first membership (signup) entry to make this work.
           $firstLineItem = array_shift($lineItemArray['values']);
           
@@ -1801,13 +1798,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           // Just need to upgrade contribution_id column in the record.
           if(!isset($firstLineItem['contribution_id'])){
             $item['id'] = $firstLineItem['id'];
-          }else{
-            // Membership renewal line item entry.
-            // These fields are NULL when renewal form is submitted.
-            // Below code will provide values as the Line Item record created by CiviCRM Core on Membership Renewal.
-            $item['price_field_id'] = $firstLineItem['price_field_id'];
-            $item['price_field_value_id'] = $firstLineItem['price_field_value_id'];
-          }           
+          }         
         }
       }
       

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1419,7 +1419,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'label' => $this->getMembershipTypeField($type, 'name'),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 // Seems strange to not be civicrm_membership, but this is how it's done in core
-                'entity_table' => 'civicrm_contribution',
+                'entity_table' => 'civicrm_membership',
               );
             }
           }
@@ -1783,16 +1783,32 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $item['contribution_id'] = $id;
       }
       
+      // Membership
       if (!empty($item['membership_id'])) {
-                
-        // only update contribution_id in civicrm_line_item rather than creating a new record.
         $item['entity_id'] = $item['membership_id'];
-        $lineItemId = wf_civicrm_api('LineItem', 'getsingle', array(
-                        'return' => "id",
-                        'entity_id' => $item['entity_id'],
-                        'entity_table' => 'civicrm_membership',
-                      ));
-        $item['id'] = $lineItemId['id'];
+        $lineItemArray = wf_civicrm_api('LineItem', 'get', array(
+          'entity_table' => "civicrm_membership",
+          'entity_id' => $item['entity_id'],
+        ));
+
+        if($lineItemArray['count'] != 0){
+        
+          // We only require first membership (signup) entry to make this work.
+          $firstLineItem = array_shift($lineItemArray['values']);
+          
+          // Membership signup line item entry.
+          // Line Item record is already present for membership by this stage.
+          // Just need to upgrade contribution_id column in the record.
+          if(!isset($firstLineItem['contribution_id'])){
+            $item['id'] = $firstLineItem['id'];
+          }else{
+            // Membership renewal line item entry.
+            // These fields are NULL when renewal form is submitted.
+            // Below code will provide values as the Line Item record created by CiviCRM Core on Membership Renewal.
+            $item['price_field_id'] = $firstLineItem['price_field_id'];
+            $item['price_field_value_id'] = $firstLineItem['price_field_value_id'];
+          }           
+        }
       }
       
       $line_result = wf_civicrm_api('line_item', 'create', $item);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1418,7 +1418,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
                 'label' => $this->getMembershipTypeField($type, 'name'),
                 'element' => "civicrm_{$c}_membership_{$n}",
-                // Seems strange to not be civicrm_membership, but this is how it's done in core
                 'entity_table' => 'civicrm_membership',
               );
             }


### PR DESCRIPTION
This PR addresses the following issue:

**Issue:**
When making a payment on webform civicrm, line items are always linked to Contribution entity rather than membership or participant.
