### PR TITLE
Fix numeric name breaks custom fields creation

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -139,7 +139,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       unset($contact['contact'][1]['employer_id']);
 
       // Create new contact
-      if (empty($this->ent['contact'][$c]['id'])) {
+      if (empty($this->ent['contact'][$c]['id']) || $this->ent['contact'][$c]['id'] < 0 ) {
         $this->ent['contact'][$c]['id'] = $this->createContact($contact);
       }
       // Update existing contact


### PR DESCRIPTION
If a numeric name or a name starts with numbers is entered into autocomplete contact field in creation mode, when custom fields are updated/filled, a constraint violation is produced.
![error on submit](https://cloud.githubusercontent.com/assets/6278917/10433700/eb6a6572-710b-11e5-88d6-8657702e2a07.png)
