### PR TITLE
Fix sending receipt proceed after payment processing

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -240,6 +240,26 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (empty($this->submission->is_draft) && !empty($this->ent['contribution'][1]['id']) && $this->contributionIsIncomplete && !$this->contributionIsPayLater) {
       $this->submitIPNPayment();
     }
+      // Send receipt 
+    if (empty($this->submission->is_draft) 
+        && !empty($this->ent['contribution'][1]['id']) 
+        && !empty($this->contribution_page['is_email_receipt']) 
+        && (!$this->contributionIsIncomplete || $this->contributionIsPayLater) ) {
+      $this->sendReceipt();
+    }
+  }
+
+  /**
+   * Send receipt 
+   */
+  private function sendReceipt(){
+    // tax integration
+    if (!is_null($this->tax_rate)) {
+      $template = CRM_Core_Smarty::singleton();
+      $template->assign('dataArray', array( "{$this->tax_rate}" => $this->tax_rate/100 ));
+    }
+    $contribute_id = $this->ent['contribution'][1]['id'];
+    wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $contribute_id) + $this->contribution_page);
   }
 
   /**
@@ -1839,15 +1859,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           'contribution_id' => $id,
         ));
       }
-    }
-    // Send receipt
-    if (!empty($this->contribution_page['is_email_receipt'])) {
-      // tax integration
-      if (!is_null($this->tax_rate)) {
-        $template = CRM_Core_Smarty::singleton();
-        $template->assign('dataArray', array( "{$this->tax_rate}" => $this->tax_rate/100 ));
-      }
-      wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $id) + $this->contribution_page);
     }
   }
 


### PR DESCRIPTION
Fix sending receipt proceed after payment processing and should not send out if payment failed.
Edit following suggestion in 
https://github.com/colemanw/webform_civicrm/pull/18
