### PR TITLE
Fix pay later is not properly set by the confirmation api

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -258,6 +258,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $template = CRM_Core_Smarty::singleton();
       $template->assign('dataArray', array( "{$this->tax_rate}" => $this->tax_rate/100 ));
     }
+    if ($this->contributionIsIncomplete) {
+      $template = CRM_Core_Smarty::singleton();
+      $template->assign('is_pay_later', 1);
+    }
     $contribute_id = $this->ent['contribution'][1]['id'];
     wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $contribute_id) + $this->contribution_page);
   }


### PR DESCRIPTION
https://www.drupal.org/node/2593357
The fix is to set "is_pay_later" to True for confirmation email if the contribution is pending after all. 

The sendconfirmation api call does not always set this variable. Also "is_pay_later" variable in message template is getting a bit confusing after the invoice is launched. This should be potentially set to be "Pending" in order to make it more accurate. Probably something to be fixed in the core later.
