### PR TITLE
Phone, Email issue

### DIFF
--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -53,6 +53,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
     }
     list($nid, $fid) = explode('-', $key, 2);
     $this->node = node_load($nid);
+    $this->settings = $this->node->webform_civicrm;
     if (!$this->autocompleteAccess($fid)) {
       drupal_access_denied();
     }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -198,22 +198,53 @@ abstract class wf_crm_webform_base {
    * @param string $ent
    * @param array $values
    * @return array $reorderedArray
-   * @todo Handle user-select case
    */
   protected function reorderByLocationType($c, $ent, $values = array()){
     $reorderedArray = array();
-    // For every entity setting per contact
-    foreach ($this->settings['data']['contact'][$c][$ent] as $setting) {
+
+    if(isset($this->settings['data']['contact'][$c][$ent])){
+      // First pass
+      $reorderedArray = $this->matchLocationTypes($c, $ent, $values);
+
+      // Second pass
+      $reorderedArray = $this->handleRemainingValues($reorderedArray, $values);
+
+      return $reorderedArray;
+    } else {
+      return $values;
+    }
+  }
+
+  /**
+   * Organize values according to location types
+   *
+   * @param integer $c
+   * @param string $ent
+   * @param array $values
+   * @return array $reorderedArray
+   */
+  protected function matchLocationTypes($c, $ent, &$values){
+    // create temporary settings array to include 'user-select' fields
+    // on the right place in array
+    $settingsArray = $this->add_user_select_field_placeholder($ent, $this->settings['data']['contact'][$c]);
+
+    // Go through the array and match up locations by type
+    // Put placeholder 'user-select' where location_type_id == -1 for second pass
+    foreach ($settingsArray[$ent] as $setting) {
       $valueFound = false;
       foreach($values as $key => $value){
         if((in_array($ent, array('address', 'email')) && $value['location_type_id'] == $setting['location_type_id'])
            ||
           ($value['location_type_id'] == $setting['location_type_id'] && $value[$ent.'_type_id'] == $setting[$ent.'_type_id'])     
           ){
-          $reorderedArray[$key] = $value;
-          $valueFound = true;
-          unset($values[$key]);
-          break;
+            $reorderedArray[$key] = $value;
+            $valueFound = true;
+            unset($values[$key]);
+            break;
+        } else if($setting['location_type_id'] == -1) { // for 'user-select' fields
+            $valueFound = true;
+            $reorderedArray[] = 'user-select';
+            break;
         }
       }
 
@@ -224,6 +255,42 @@ abstract class wf_crm_webform_base {
       }
     }
     return $reorderedArray;
+  }
+
+  /**
+   * Put remaining values in 'user-select' fields
+   *
+   * @param array $reorderedArray
+   * @param array $values
+   * @return array $reorderedArray
+   */
+  protected function handleRemainingValues($reorderedArray, &$values){
+    // Put leftover values in fields marked as 'user-select'
+    foreach($reorderedArray as $key => $value){
+      if($reorderedArray[$key] == 'user-select'){
+        $reorderedArray[$key] = !empty($values) ? array_shift($values) : '';
+      }
+    }
+    return $reorderedArray;
+  }
+
+  /**
+   * Add location_type_id = -1 for user-select fields for identification later
+   *
+   * @param string $ent
+   * @param array $settings
+   * @return array $settings
+   */
+  protected function add_user_select_field_placeholder($ent, $settings = array()){
+    if($settings['number_of_'.$ent] > count($settings[$ent])){
+      for($i = 1; $i <= $settings['number_of_'.$ent]; $i++){
+        if(!array_key_exists($i, $settings[$ent])){
+          $settings[$ent][$i]['location_type_id'] = -1;
+        }
+      }
+      ksort($settings[$ent]);
+    }
+    return $settings;
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -85,6 +85,10 @@ abstract class wf_crm_webform_base {
           $params['options']['sort'] = 'is_primary DESC';
         }
         $result = wf_civicrm_api($ent, 'get', $params);
+        // Handle location field sorting
+        if(in_array($ent, wf_crm_location_fields())){
+          $result['values'] = $this->reorderByLocationType($ent, $result['values']);
+        }
         if (!empty($result['values'])) {
           // Index array from 1 instead of 0
           $result = array_merge(array(0), array_values($result['values']));
@@ -183,6 +187,36 @@ abstract class wf_crm_webform_base {
       }
     }
     return $info;
+  }
+
+  /**
+   * Reorder returned results according to settings chosen in wf_civicrm backend
+   *
+   * @param string $ent
+   * @param array $values
+   * @return array $reorderedArray
+   * @todo Handle user-select case
+   */
+  protected function reorderByLocationType($ent, $values = array()){
+    $reorderedArray = array();
+    // For every location field setting
+    foreach ($this->settings['data']['contact'] as $setting) {
+      // For every Entity
+      foreach($setting[$ent] as $e){
+        // For every result row
+        foreach($values as $key => $value){
+          if((in_array($ent, array('address', 'email')) && $value['location_type_id'] == $e['location_type_id'])
+            ||
+            ($value['location_type_id'] == $e['location_type_id'] && $value[$ent.'_type_id'] == $e[$ent.'_type_id'])     
+            ){
+              $reorderedArray[$key] = $value;
+              unset($values[$key]);
+              break;
+          }
+        }
+      }
+    }
+    return $reorderedArray;
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -229,7 +229,7 @@ abstract class wf_crm_webform_base {
     $settingsArray = $this->add_user_select_field_placeholder($ent, $this->settings['data']['contact'][$c]);
     $userSelectIndex = 0;
     // Go through the array and match up locations by type
-    // Put placeholder 'user-select' where location_type_id == -1 for second pass
+    // Put placeholder 'user-select' where location_type_id is empty for second pass
     foreach ($settingsArray[$ent] as $setting) {
       $valueFound = false;
       foreach($values as $key => $value){
@@ -241,7 +241,7 @@ abstract class wf_crm_webform_base {
             $valueFound = true;
             unset($values[$key]);
             break;
-        } else if($setting['location_type_id'] == -1) { // for 'user-select' fields
+        } else if(empty($setting['location_type_id'])) { // for 'user-select' fields
             $valueFound = true;
             $reorderedArray['us'.$userSelectIndex] = 'user-select';
             $userSelectIndex ++;
@@ -276,7 +276,7 @@ abstract class wf_crm_webform_base {
   }
 
   /**
-   * Add location_type_id = -1 for user-select fields for identification later
+   * Add location_type_id = NULL for user-select fields for identification later
    *
    * @param string $ent
    * @param array $settings
@@ -286,7 +286,7 @@ abstract class wf_crm_webform_base {
     if($settings['number_of_'.$ent] > count($settings[$ent])){
       for($i = 1; $i <= $settings['number_of_'.$ent]; $i++){
         if(!array_key_exists($i, $settings[$ent])){
-          $settings[$ent][$i]['location_type_id'] = -1;
+          $settings[$ent][$i]['location_type_id'] = NULL;
         }
       }
       ksort($settings[$ent]);

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -87,7 +87,7 @@ abstract class wf_crm_webform_base {
         $result = wf_civicrm_api($ent, 'get', $params);
         // Handle location field sorting
         if(in_array($ent, wf_crm_location_fields())){
-          $result['values'] = $this->reorderByLocationType($ent, $result['values']);
+          $result['values'] = $this->reorderByLocationType($c, $ent, $result['values']);
         }
         if (!empty($result['values'])) {
           // Index array from 1 instead of 0
@@ -192,27 +192,24 @@ abstract class wf_crm_webform_base {
   /**
    * Reorder returned results according to settings chosen in wf_civicrm backend
    *
+   * @param integer $c
    * @param string $ent
    * @param array $values
    * @return array $reorderedArray
    * @todo Handle user-select case
    */
-  protected function reorderByLocationType($ent, $values = array()){
+  protected function reorderByLocationType($c, $ent, $values = array()){
     $reorderedArray = array();
     // For every location field setting
-    foreach ($this->settings['data']['contact'] as $setting) {
-      // For every Entity
-      foreach($setting[$ent] as $e){
-        // For every result row
-        foreach($values as $key => $value){
-          if((in_array($ent, array('address', 'email')) && $value['location_type_id'] == $e['location_type_id'])
-            ||
-            ($value['location_type_id'] == $e['location_type_id'] && $value[$ent.'_type_id'] == $e[$ent.'_type_id'])     
-            ){
-              $reorderedArray[$key] = $value;
-              unset($values[$key]);
-              break;
-          }
+    foreach ($this->settings['data']['contact'][$c][$ent] as $setting) {
+      foreach($values as $key => $value){
+        if((in_array($ent, array('address', 'email')) && $value['location_type_id'] == $setting['location_type_id'])
+          ||
+          ($value['location_type_id'] == $setting['location_type_id'] && $value[$ent.'_type_id'] == $setting[$ent.'_type_id'])
+          ){
+          $reorderedArray[$key] = $value;
+          unset($values[$key]);
+          break;
         }
       }
     }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -227,7 +227,7 @@ abstract class wf_crm_webform_base {
     // create temporary settings array to include 'user-select' fields
     // on the right place in array
     $settingsArray = $this->add_user_select_field_placeholder($ent, $this->settings['data']['contact'][$c]);
-
+    $userSelectIndex = 0;
     // Go through the array and match up locations by type
     // Put placeholder 'user-select' where location_type_id == -1 for second pass
     foreach ($settingsArray[$ent] as $setting) {
@@ -243,7 +243,8 @@ abstract class wf_crm_webform_base {
             break;
         } else if($setting['location_type_id'] == -1) { // for 'user-select' fields
             $valueFound = true;
-            $reorderedArray[] = 'user-select';
+            $reorderedArray['us'.$userSelectIndex] = 'user-select';
+            $userSelectIndex ++;
             break;
         }
       }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -116,9 +116,11 @@ abstract class wf_crm_webform_base {
                 $address['state_province_id'] = wf_crm_state_abbr($address['state_province_id']);
               }
               // Load custom data
-              $custom = $this->getCustomData($address['id'], 'address');
-              if (!empty($custom['address'])) {
-                $address += $custom['address'][1];
+              if(isset($address['id'])){
+                $custom = $this->getCustomData($address['id'], 'address');
+                if (!empty($custom['address'])) {
+                  $address += $custom['address'][1];
+                }
               }
             }
           }
@@ -200,17 +202,25 @@ abstract class wf_crm_webform_base {
    */
   protected function reorderByLocationType($c, $ent, $values = array()){
     $reorderedArray = array();
-    // For every location field setting
+    // For every entity setting per contact
     foreach ($this->settings['data']['contact'][$c][$ent] as $setting) {
+      $valueFound = false;
       foreach($values as $key => $value){
         if((in_array($ent, array('address', 'email')) && $value['location_type_id'] == $setting['location_type_id'])
-          ||
-          ($value['location_type_id'] == $setting['location_type_id'] && $value[$ent.'_type_id'] == $setting[$ent.'_type_id'])
+           ||
+          ($value['location_type_id'] == $setting['location_type_id'] && $value[$ent.'_type_id'] == $setting[$ent.'_type_id'])     
           ){
           $reorderedArray[$key] = $value;
+          $valueFound = true;
           unset($values[$key]);
           break;
         }
+      }
+
+      // always keep number of returned values equal to chosen settings
+      // if value is not found then set an empty array
+      if(!$valueFound){
+        $reorderedArray[] = array();
       }
     }
     return $reorderedArray;

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -529,21 +529,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           // If the user has already entered a value for this field, don't change it
           if (isset($this->info[$ent][$c][$table][$n][$name])
             && !(isset($component['cid']) && isset($submitted[$component['cid']]))) {
-            // pick phone number and email according to selecte location type
-            if (($table == 'phone' && $name == 'phone')
-              || ($table == 'email' && $name == 'email')) {
-              $location_type_id = $this->node->webform_civicrm['data']['contact'][$c][$name][$n]['location_type_id'];
-              $cDetails = $this->info[$ent][$c][$table];
-              foreach($cDetails as $cDetail) {
-                if($cDetail['location_type_id'] == $location_type_id) {
-                  $val = $cDetail[$name];
-                  break;
-                }
-              }
-            }
-            else {
-              $val = $this->info[$ent][$c][$table][$n][$name];
-            }
+            $val = $this->info[$ent][$c][$table][$n][$name];
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
               $val = wf_crm_explode_multivalue_str($val);
             }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -529,7 +529,21 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           // If the user has already entered a value for this field, don't change it
           if (isset($this->info[$ent][$c][$table][$n][$name])
             && !(isset($component['cid']) && isset($submitted[$component['cid']]))) {
-            $val = $this->info[$ent][$c][$table][$n][$name];
+            // pick phone number and email according to selecte location type
+            if (($table == 'phone' && $name == 'phone')
+              || ($table == 'email' && $name == 'email')) {
+              $location_type_id = $this->node->webform_civicrm['data']['contact'][$c][$name][$n]['location_type_id'];
+              $cDetails = $this->info[$ent][$c][$table];
+              foreach($cDetails as $cDetail) {
+                if($cDetail['location_type_id'] == $location_type_id) {
+                  $val = $cDetail[$name];
+                  break;
+                }
+              }
+            }
+            else {
+              $val = $this->info[$ent][$c][$table][$n][$name];
+            }
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
               $val = wf_crm_explode_multivalue_str($val);
             }


### PR DESCRIPTION
Hello @colemanw 

This patch sorts the following issue:

Phone number and Email fields have associated "location_type_id". Webform is always picking up the ones that are set to primary in civi (primary phone, primary email). It ignores the location type chosen inside civicrm tab of the webform (home, work, etc.).

So for example, if admin choose "Home Phone"  field on webform_civicrm and in civi "work Phone" is marked as primary for a contact then the webform phone field will pick up the "work phone" even when the location type chosen is "Home Phone"
