### PR TITLE
Fix IPN payments marked as paid by cheque

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1672,8 +1672,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['is_pay_later'] = $this->contributionIsPayLater;
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
-      if ($params['payment_processor_id'] != 0 && $this->contribution_page['is_monetary'] == 1) {
-        $params['payment_instrument_id'] = 1;
+      if ($params['payment_processor_id'] && $this->contribution_page['is_monetary']) {
+        $params['payment_instrument_id'] = 'Check';
       }
     }
     $result = wf_civicrm_api('contribution', 'create', $params);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -238,17 +238,17 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (empty($this->submission->is_draft) && !empty($this->ent['contribution'][1]['id']) && $this->contributionIsIncomplete && !$this->contributionIsPayLater) {
       $this->submitIPNPayment();
     }
-      // Send receipt 
-    if (empty($this->submission->is_draft) 
-        && !empty($this->ent['contribution'][1]['id']) 
-        && !empty($this->contribution_page['is_email_receipt']) 
+      // Send receipt
+    if (empty($this->submission->is_draft)
+        && !empty($this->ent['contribution'][1]['id'])
+        && !empty($this->contribution_page['is_email_receipt'])
         && (!$this->contributionIsIncomplete || $this->contributionIsPayLater) ) {
       $this->sendReceipt();
     }
   }
 
   /**
-   * Send receipt 
+   * Send receipt
    */
   private function sendReceipt(){
     // tax integration
@@ -1670,6 +1670,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params = $this->contributionParams();
     $params['contribution_status_id'] = 'Pending';
     $params['is_pay_later'] = $this->contributionIsPayLater;
+    //Fix IPN payments marked as paid by cheque
+    if (empty($params['payment_instrument_id'])) {
+      if ($params['payment_processor_id'] != 0 && $this->contribution_page['is_monetary'] == 1) {
+        $params['payment_instrument_id'] = 1;
+      }
+    }
     $result = wf_civicrm_api('contribution', 'create', $params);
     $this->ent['contribution'][1]['id'] = $result['id'];
   }


### PR DESCRIPTION
Currently all offsite payments done through webform are marked as paid by cheque. The fix is to simply replicate the logic in CiviCRM contribution page workflow plus a more straightforward condition "if pay_later is selected".
- "is_monetary" is added just to keep consistency but might be a bit redundant. 
- The fix can be enhanced further in the future to acquire the payment instrument for different payment processors
