### PR TITLE
Use default payment instrument when no instrument is specified

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1682,7 +1682,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
       if ($params['payment_processor_id'] && $this->contribution_page['is_monetary']) {
-        $params['payment_instrument_id'] = 'Check';
+        $params['payment_instrument_id'] = key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
       }
     }
     $result = wf_civicrm_api('contribution', 'create', $params);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1682,7 +1682,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
       if ($params['payment_processor_id'] && $this->contribution_page['is_monetary']) {
-        $params['payment_instrument_id'] = key(CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1'));
+        $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
+        $params['payment_instrument_id'] = key($defaultPaymentInstrument);
       }
     }
     $result = wf_civicrm_api('contribution', 'create', $params);


### PR DESCRIPTION
Change to use core mechanism to keep the consistency while fixing the instrument issue:
ref: civicrm/CRM/Contribute/Form/Contribution.php setDefaultValues() function
