### PR TITLE
Include entire webform submission in activity details when updating an existing activity

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -444,7 +444,7 @@ class wf_crm_admin_form {
           'entire_result' => t('Include <em>entire</em> webform submission in activity details'),
           'view_link' => t('Include link to <em>view</em> webform submission in activity details'),
           'edit_link' => t('Include link to <em>edit</em> webform submission in activity details'),
-          'no_update_existing' => t('<strong>Do not </strong> update the details when an existing activity is updated'),
+          'update_existing' => t('Update the details when an existing activity is updated'),
         ),
         '#default_value' => wf_crm_aval($this->data, "activity:$n:details", array('view_link'), TRUE),
       );

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -444,6 +444,7 @@ class wf_crm_admin_form {
           'entire_result' => t('Include <em>entire</em> webform submission in activity details'),
           'view_link' => t('Include link to <em>view</em> webform submission in activity details'),
           'edit_link' => t('Include link to <em>edit</em> webform submission in activity details'),
+          'no_update_existing' => t('<strong>Do not </strong> update the details when an existing activity is updated'),
         ),
         '#default_value' => wf_crm_aval($this->data, "activity:$n:details", array('view_link'), TRUE),
       );

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1303,7 +1303,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $params['id'] = $this->ent['activity'][$n]['id'];
 
           // Update details when user has selected he wants to update the details
-          if (empty($this->data['activity'][$n]['details']['no_update_existing'])) {
+          if (!empty($this->data['activity'][$n]['details']['update_existing'])) {
             // Format details as html
             $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
             // Add webform results to details

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1301,6 +1301,30 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         // Update mode
         else {
           $params['id'] = $this->ent['activity'][$n]['id'];
+
+          // Update details when user has selected he wants to update the details
+          if (empty($this->data['activity'][$n]['details']['no_update_existing'])) {
+            // Format details as html
+            $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
+            // Add webform results to details
+            if (!empty($this->data['activity'][$n]['details']['entire_result'])) {
+              module_load_include('inc', 'webform', 'includes/webform.submissions');
+              $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
+              $params['details'] .= drupal_render($submission);
+            }
+            if (!empty($this->data['activity'][$n]['details']['view_link'])) {
+              $params['details'] .= '<p>' . l(t('View Webform Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}", array(
+                  'absolute' => TRUE,
+                  'alias' => TRUE
+                )) . '</p>';
+            }
+            if (!empty($this->data['activity'][$n]['details']['edit_link'])) {
+              $params['details'] .= '<p>' . l(t('Edit Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}/edit", array(
+                  'absolute' => TRUE,
+                  'alias' => TRUE
+                )) . '</p>';
+            }
+          }
         }
         // Allow "automatic" values to pass-thru if empty
         foreach ($params as $field => $value) {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1284,19 +1284,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             }
           }
           // Format details as html
-          $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
-          // Add webform results to details
-          if (!empty($this->data['activity'][$n]['details']['entire_result'])) {
-            module_load_include('inc', 'webform', 'includes/webform.submissions');
-            $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
-            $params['details'] .= drupal_render($submission);
-          }
-          if (!empty($this->data['activity'][$n]['details']['view_link'])) {
-            $params['details'] .= '<p>' . l(t('View Webform Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}", array('absolute' => TRUE, 'alias' => TRUE)) . '</p>';
-          }
-          if (!empty($this->data['activity'][$n]['details']['edit_link'])) {
-            $params['details'] .= '<p>' . l(t('Edit Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}/edit", array('absolute' => TRUE, 'alias' => TRUE)) . '</p>';
-          }
+          $this->formatSubmissionDetails($parmas, $n);
         }
         // Update mode
         else {
@@ -1305,25 +1293,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           // Update details when user has selected he wants to update the details
           if (!empty($this->data['activity'][$n]['details']['update_existing'])) {
             // Format details as html
-            $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
-            // Add webform results to details
-            if (!empty($this->data['activity'][$n]['details']['entire_result'])) {
-              module_load_include('inc', 'webform', 'includes/webform.submissions');
-              $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
-              $params['details'] .= drupal_render($submission);
-            }
-            if (!empty($this->data['activity'][$n]['details']['view_link'])) {
-              $params['details'] .= '<p>' . l(t('View Webform Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}", array(
-                  'absolute' => TRUE,
-                  'alias' => TRUE
-                )) . '</p>';
-            }
-            if (!empty($this->data['activity'][$n]['details']['edit_link'])) {
-              $params['details'] .= '<p>' . l(t('Edit Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}/edit", array(
-                  'absolute' => TRUE,
-                  'alias' => TRUE
-                )) . '</p>';
-            }
+            $this->formatSubmissionDetails($parmas, $n);
           }
         }
         // Allow "automatic" values to pass-thru if empty
@@ -1391,6 +1361,32 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
       }
+    }
+  }
+
+ /**
+  * Process the submission into the details of the activity.
+  */
+ private function formatSubmissionDetails(&$params, $activity_number) {
+    // Format details as html
+    $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
+    // Add webform results to details
+    if (!empty($this->data['activity'][$activity_number]['details']['entire_result'])) {
+      module_load_include('inc', 'webform', 'includes/webform.submissions');
+      $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
+      $params['details'] .= drupal_render($submission);
+    }
+    if (!empty($this->data['activity'][$activity_number]['details']['view_link'])) {
+      $params['details'] .= '<p>' . l(t('View Webform Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}", array(
+          'absolute' => TRUE,
+          'alias' => TRUE
+        )) . '</p>';
+    }
+    if (!empty($this->data['activity'][$activity_number]['details']['edit_link'])) {
+      $params['details'] .= '<p>' . l(t('Edit Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}/edit", array(
+          'absolute' => TRUE,
+          'alias' => TRUE
+        )) . '</p>';
     }
   }
 


### PR DESCRIPTION
Fixed issue 2837945 (https://www.drupal.org/node/2837945). Also update the detail of an existing activity and give the user the selection to disable this.
