### PR TITLE
add stripe cc fields using *sources*

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1562,6 +1562,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $billing_fields['credit_card_number'] = FALSE;
       $billing_fields['cvv2'] = FALSE;
     }
+    if (!empty($_POST['stripe_source'])) {
+      // Using Stripe payment processor - cc fields not posted using sources
+      $billing_fields['credit_card_number'] = FALSE;
+      $billing_fields['cvv2'] = FALSE;
+    }
     if (!empty($_POST['bank_account_type'])) {
       // unset/bypass the CC validation if we're doing Direct Debit (ACHEFT) - in that case we have a Bank Account Type
       $billing_fields['credit_card_number'] = FALSE;


### PR DESCRIPTION
In the Stripe extension, we're going to be adding support for Stripe [sources](https://stripe.com/docs/sources/payment-methods) sometime soon. Which is a way to process many different payment sources such as, iDEAL, Sofort, Giropay, Bancontact, ACH deposits, Bitcoin in addition to credit cards.

We're staring off modestly with sources by just taking credit cards and looking to pave the way here.  This merge would prevent the Stripe extension from breaking using the new sources method and webform_civicrm.

Thanks in advance!  :-)  

