### PR TITLE
Civipostcode integration

### DIFF
--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -37,6 +37,7 @@ function _webform_display_civipostcode($component, $value, $format = 'html') {
 }
 
 function _webform_render_civipostcode($component, $value = NULL, $filter = TRUE) {
+
    $element['postcode'] = array(
     '#type' => 'textfield',
     '#title' => $filter ? webform_filter_xss($component['name']) : $component['name'],
@@ -46,11 +47,6 @@ function _webform_render_civipostcode($component, $value = NULL, $filter = TRUE)
     '#attributes' => array(),
     '#theme_wrappers' => array('webform_element'),
     '#webform_component' => array('type' => $component['type'] . '_civipostcode') + $component,
-    '#attached' => array(
-      'js' => array(
-        drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js',
-      ),
-    )
   );
 
   return $element;

--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -1,0 +1,57 @@
+<?php
+
+function _webform_edit_civipostcode($component) { 
+  $form = array();
+
+  $form['#attached']['js'][] = wf_crm_tokeninput_path();
+  $form['#attached']['js'][] = drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js';
+  return $form;
+}
+
+function _webform_defaults_civipostcode() {
+  return array(
+    'name' => '',
+    'form_key' => NULL,
+    'pid' => 0,
+    'weight' => 0,
+    'value' => '',
+    'mandatory' => 0,
+    'extra' => array(
+      'widget' => 'textfield',
+      'attributes' => array(),
+      'title_display' => 'before',
+    ),
+  );
+}
+
+function _webform_display_civipostcode($component, $value, $format = 'html') {
+  return array(
+    '#title' => $component['extra']['field_prefix'] .' / '. $component['extra']['field_suffix'],
+    '#weight' => $component['weight'],
+    '#theme' => 'webform_display_civipostcode',
+    '#theme_wrappers' => $format == 'html' ? array('webform_element') : array('webform_element_text'),
+    '#format' => $format,
+    '#value' => isset($value[0]) ? $value[0] : '',
+    '#translatable' => array('title', 'field_prefix', 'field_suffix'),
+  );
+}
+
+function _webform_render_civipostcode($component, $value = NULL, $filter = TRUE) {
+   $element['postcode'] = array(
+    '#type' => 'textfield',
+    '#title' => $filter ? webform_filter_xss($component['name']) : $component['name'],
+    '#title_display' => $component['extra']['title_display'] ? $component['extra']['title_display'] : 'before',
+    '#default_value' => isset($value['city']) ? $value['city'] : '',
+    '#required' => $component['required'],
+    '#attributes' => array(),
+    '#theme_wrappers' => array('webform_element'),
+    '#webform_component' => array('type' => $component['type'] . '_civipostcode') + $component,
+    '#attached' => array(
+      'js' => array(
+        drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js',
+      ),
+    )
+  );
+
+  return $element;
+}

--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -2,9 +2,7 @@
 
 function _webform_edit_civipostcode($component) { 
   $form = array();
-
   $form['#attached']['js'][] = wf_crm_tokeninput_path();
-  $form['#attached']['js'][] = drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js';
   return $form;
 }
 

--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -1,11 +1,4 @@
 <?php
-
-function _webform_edit_civipostcode($component) { 
-  $form = array();
-  $form['#attached']['js'][] = wf_crm_tokeninput_path();
-  return $form;
-}
-
 function _webform_defaults_civipostcode() {
   return array(
     'name' => '',
@@ -24,13 +17,13 @@ function _webform_defaults_civipostcode() {
 
 function _webform_display_civipostcode($component, $value, $format = 'html') {
   return array(
-    '#title' => $component['extra']['field_prefix'] .' / '. $component['extra']['field_suffix'],
+    '#title' => $component['name'],
     '#weight' => $component['weight'],
-    '#theme' => 'webform_display_civipostcode',
+    '#theme' => 'webform_display_textfield',
     '#theme_wrappers' => $format == 'html' ? array('webform_element') : array('webform_element_text'),
     '#format' => $format,
     '#value' => isset($value[0]) ? $value[0] : '',
-    '#translatable' => array('title', 'field_prefix', 'field_suffix'),
+    '#translatable' => array('title'),
   );
 }
 
@@ -46,5 +39,9 @@ function _webform_render_civipostcode($component, $value = NULL, $filter = TRUE)
     '#theme_wrappers' => array('webform_element'),
   );
 
+  // Preseve value during pagebreaks
+  if (isset($value)) {
+    $element['#default_value'] = $value[0];
+  }
   return $element;
 }

--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -38,15 +38,14 @@ function _webform_display_civipostcode($component, $value, $format = 'html') {
 
 function _webform_render_civipostcode($component, $value = NULL, $filter = TRUE) {
 
-   $element['postcode'] = array(
+   $element = array(
     '#type' => 'textfield',
     '#title' => $filter ? webform_filter_xss($component['name']) : $component['name'],
     '#title_display' => $component['extra']['title_display'] ? $component['extra']['title_display'] : 'before',
-    '#default_value' => isset($value['city']) ? $value['city'] : '',
     '#required' => $component['required'],
+    '#weight' => $component['weight'],
     '#attributes' => array(),
     '#theme_wrappers' => array('webform_element'),
-    '#webform_component' => array('type' => $component['type'] . '_civipostcode') + $component,
   );
 
   return $element;

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -700,7 +700,8 @@ function wf_crm_get_fields($var = 'fields') {
       'data_type' => 'state_province_abbr',
     );
 
-    // add postcode lookup field if civicrmpostcodelookup extension is enabled.
+    // add postcode autocomplete checkbox to address field selection section
+    // in webform_civicrm screen when civipostcode extension is installed and enabled
     if(isPostcodeLookupExtensionEnabled()) {
       $fields['address_webform_civipostcode'] = array(
         'name' => t('Postcode Autocomplete'),

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -699,6 +699,22 @@ function wf_crm_get_fields($var = 'fields') {
       ),
       'data_type' => 'state_province_abbr',
     );
+
+    // add postcode lookup field if civicrmpostcodelookup extension is enabled.
+    $isPostcodeLookupEnabled = CRM_Core_DAO::getFieldValue(
+      'CRM_Core_DAO_Extension',
+      'uk.co.vedaconsulting.module.civicrmpostcodelookup',
+      'is_active',
+      'full_name'
+    );
+
+    if($isPostcodeLookupEnabled) {
+      $fields['address_webform_civipostcode'] = array(
+        'name' => t('Postcode Autocomplete'),
+        'type' => 'civipostcode',
+      );
+    }
+
     $fields['address_county_id'] = array(
       'name' => t('District/County'),
       'type' => 'textfield',

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -701,14 +701,7 @@ function wf_crm_get_fields($var = 'fields') {
     );
 
     // add postcode lookup field if civicrmpostcodelookup extension is enabled.
-    $isPostcodeLookupEnabled = CRM_Core_DAO::getFieldValue(
-      'CRM_Core_DAO_Extension',
-      'uk.co.vedaconsulting.module.civicrmpostcodelookup',
-      'is_active',
-      'full_name'
-    );
-
-    if($isPostcodeLookupEnabled) {
+    if(isPostcodeLookupExtensionEnabled()) {
       $fields['address_webform_civipostcode'] = array(
         'name' => t('Postcode Autocomplete'),
         'type' => 'civipostcode',

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -699,16 +699,6 @@ function wf_crm_get_fields($var = 'fields') {
       ),
       'data_type' => 'state_province_abbr',
     );
-
-    // add postcode autocomplete checkbox to address field selection section
-    // in webform_civicrm screen when civipostcode extension is installed and enabled
-    if(isPostcodeLookupExtensionEnabled()) {
-      $fields['address_webform_civipostcode'] = array(
-        'name' => t('Postcode Autocomplete'),
-        'type' => 'civipostcode',
-      );
-    }
-
     $fields['address_county_id'] = array(
       'name' => t('District/County'),
       'type' => 'textfield',

--- a/js/civipostcode_component.js
+++ b/js/civipostcode_component.js
@@ -1,0 +1,43 @@
+jQuery(document).ready(function () {
+    var sourceUrl = "http://localhost:7777/civicrm/civipostcode/ajax/search?json=1&term=E1+6LA";
+    var postcodeElement = "#edit-submitted-civicrm-1-contact-1-fieldset-fieldset-civicrm-1-contact-1-address-webform-civipostcode-postcode";
+    jQuery(postcodeElement).autocomplete({
+        source: sourceUrl,
+        minLength: 3,
+        search: function (event, ui) {
+            //$('#loaderimage_'+blockNo).show();
+        },
+        response: function (event, ui) {
+            //$('#loaderimage_'+blockNo).hide();
+        },
+        select: function (event, ui) {
+            var id = ui.item.id;
+            var sourceUrl = 'http://localhost:7777/civicrm/civipostcode/ajax/get?json=1';
+
+            jQuery.ajax({
+                dataType: 'json',
+                data: {id: id},
+                url: sourceUrl,
+                success: function (data) {
+                    console.log(data.address);
+                    var streetAddressElement = "#edit-submitted-civicrm-1-contact-1-fieldset-fieldset-civicrm-1-contact-1-address-street-address";
+                    var cityElement = "#edit-submitted-civicrm-1-contact-1-fieldset-fieldset-civicrm-1-contact-1-address-city";
+                    var postalCodeElement = "#edit-submitted-civicrm-1-contact-1-fieldset-fieldset-civicrm-1-contact-1-address-postal-code";
+                    jQuery(streetAddressElement).val(data.address.street_address);
+                    jQuery(cityElement).val(data.address.town);
+                    jQuery(postalCodeElement).val(data.address.postcode);
+                    //setAddressFields(data.address, blockNo);
+                    //setAddressFields(true, blockNo);
+                    //jQuery('#loaderimage_' + blockNo).hide();
+                }
+            });
+            return false;
+        },
+        //optional (if other layers overlap autocomplete list)
+        open: function (event, ui) {
+            jQuery(".ui-autocomplete").css("z-index", 1000);
+        }
+    });
+});
+
+

--- a/js/civipostcode_component.js
+++ b/js/civipostcode_component.js
@@ -1,12 +1,13 @@
 jQuery(document).ready(function ($) {
-  var sourceUrl = Drupal.settings.baseUrl + "/civicrm/civipostcode/ajax/search?json=1&term=";
+  var civiPostCodeLookupProvider = Drupal.settings.civiPostCodeLookupProvider;
+  var sourceUrl = Drupal.settings.baseUrl + "/civicrm/" + civiPostCodeLookupProvider + "/ajax/search?json=1&term=";
   $('[id*="address-webform-civipostcode"]').each(function () {
     $(this).autocomplete({
       source: sourceUrl + $(this).val().replace(" ", "+"),
       minLength: 3,
       select: function (event, ui) {
                 var id = ui.item.id;
-                var sourceUrl = Drupal.settings.baseUrl + '/civicrm/civipostcode/ajax/get?json=1';
+                var sourceUrl = Drupal.settings.baseUrl + '/civicrm/' + civiPostCodeLookupProvider + '/ajax/get?json=1';
                 var postcodeElementId = $(this).attr('id');
                 var result = getCivicrmAndContactSequence(postcodeElementId);
 

--- a/js/civipostcode_component.js
+++ b/js/civipostcode_component.js
@@ -1,14 +1,15 @@
 jQuery(document).ready(function ($) {
   var civiPostCodeLookupProvider = Drupal.settings.civiPostCodeLookupProvider;
-  var sourceUrl = Drupal.settings.baseUrl + "/civicrm/" + civiPostCodeLookupProvider + "/ajax/search?json=1&term=";
-  $('[id*="address-webform-civipostcode"]').each(function () {
-    $(this).autocomplete({
-      source: sourceUrl + $(this).val().replace(" ", "+"),
+  var civiPostCodeFields = Drupal.settings.civiPostCodeFields;
+  var sourceUrl = Drupal.settings.baseUrl + "/civicrm/" + civiPostCodeLookupProvider + "/ajax/search?json=1";
+  $.each(civiPostCodeFields, function (key, value) {
+    $('[id*="'+value+'"]').autocomplete({
+      source: sourceUrl,
       minLength: 3,
       select: function (event, ui) {
                 var id = ui.item.id;
                 var sourceUrl = Drupal.settings.baseUrl + '/civicrm/' + civiPostCodeLookupProvider + '/ajax/get?json=1';
-                var postcodeElementId = $(this).attr('id');
+                var postcodeElementId = value;
                 var result = getCivicrmAndContactSequence(postcodeElementId);
 
                 $.ajax({

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -87,6 +87,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
 
       drupal_add_library('system', 'ui.autocomplete');
 
+      $civiPostcodeFields = getCivipostcodeFieldIds($form['#node']->webform['components']);
       // Assign the postcode lookup provider to form, so that we can call the related function in AJAX
       $settingsStr = CRM_Core_BAO_Setting::getItem('CiviCRM Postcode Lookup', 'api_details');
       $settingsArray = unserialize($settingsStr);
@@ -98,6 +99,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
           'data' => array(
             'baseUrl' => $base_url,
             'civiPostCodeLookupProvider' => $settingsArray['provider'],
+            'civiPostCodeFields' => $civiPostcodeFields,
           ),
           'type' => 'setting',
          ),
@@ -657,6 +659,7 @@ function _webform_civicrm_status() {
  * @return boolean
  */
 function isPostcodeLookupExtensionEnabled() {
+  civicrm_initialize(true);
   $isPostcodeLookupEnabled = CRM_Core_DAO::getFieldValue(
     'CRM_Core_DAO_Extension',
     'uk.co.vedaconsulting.module.civicrmpostcodelookup',
@@ -665,4 +668,21 @@ function isPostcodeLookupExtensionEnabled() {
   );
 
   return $isPostcodeLookupEnabled;
+}
+
+/**
+ * Get list of fields which are of type 'civipostcode'
+ *
+ * @param array $components
+ * @return array $civiPostcodeFields
+ */
+function getCivipostcodeFieldIds($components) {
+  $civiPostcodeFields = array();
+  foreach($components as $component) {
+    if($component['type'] == 'civipostcode') {
+      $civiPostcodeFields[] = str_replace("_", "-", $component['form_key']);
+    }
+  }
+
+  return $civiPostcodeFields;
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -81,7 +81,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
   elseif (strpos($form_id, 'webform_client_form_') !== FALSE
     && !empty($form['#node']->webform_civicrm)) {
 
-      // attach javascript needed for postcode lookup when civipostcode extension is installed and enabled
+    // attach javascript needed for postcode lookup when civipostcode extension is installed and enabled
     if(isPostcodeLookupExtensionEnabled()) {
       global $base_url;
 
@@ -92,17 +92,15 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
       $settingsStr = CRM_Core_BAO_Setting::getItem('CiviCRM Postcode Lookup', 'api_details');
       $settingsArray = unserialize($settingsStr);
 
-      $form['#attached']['js'] = array(
-        drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js' => array(),
-          array(
-          // Pass PHP variables to Drupal.settings.
-          'data' => array(
-            'baseUrl' => $base_url,
-            'civiPostCodeLookupProvider' => $settingsArray['provider'],
-            'civiPostCodeFields' => $civiPostcodeFields,
-          ),
-          'type' => 'setting',
-         ),
+      $form['#attached']['js'][] = drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js';
+      $form['#attached']['js'][] = array(
+        // Pass PHP variables to Drupal.settings.
+        'data' => array(
+          'baseUrl' => $base_url,
+          'civiPostCodeLookupProvider' => $settingsArray['provider'],
+          'civiPostCodeFields' => $civiPostcodeFields,
+        ),
+        'type' => 'setting',
       );
     }
 

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -190,6 +190,10 @@ function webform_civicrm_webform_component_info() {
       ),
       'file' => 'includes/contact_component.inc',
     ),
+    'civipostcode' => array(
+       'label' => t('Civi Postcode'),
+       'file' => 'includes/civipostcode_component.inc',
+    ),
   );
 }
 

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -82,6 +82,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
     && !empty($form['#node']->webform_civicrm)) {
 
       // attach javascript needed for postcode lookup when civipostcode extension is installed and enabled
+    if(isPostcodeLookupExtensionEnabled()) {
       global $base_url;
 
       drupal_add_library('system', 'ui.autocomplete');

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -83,12 +83,22 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
 
     // attach javascript needed if civipostcode lookup is enabled
     if(isPostcodeLookupExtensionEnabled()) {
+      global $base_url;
+
       drupal_add_library('system', 'ui.autocomplete');
+
+      // Assign the postcode lookup provider to form, so that we can call the related function in AJAX
+      $settingsStr = CRM_Core_BAO_Setting::getItem('CiviCRM Postcode Lookup', 'api_details');
+      $settingsArray = unserialize($settingsStr);
+
       $form['#attached']['js'] = array(
         drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js' => array(),
           array(
           // Pass PHP variables to Drupal.settings.
-          'data' => array('baseUrl' => $base_url),
+          'data' => array(
+            'baseUrl' => $base_url,
+            'civiPostCodeLookupProvider' => $settingsArray['provider'],
+          ),
           'type' => 'setting',
          ),
       );

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -81,8 +81,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
   elseif (strpos($form_id, 'webform_client_form_') !== FALSE
     && !empty($form['#node']->webform_civicrm)) {
 
-    // attach javascript needed if civipostcode lookup is enabled
-    if(isPostcodeLookupExtensionEnabled()) {
+      // attach javascript needed for postcode lookup when civipostcode extension is installed and enabled
       global $base_url;
 
       drupal_add_library('system', 'ui.autocomplete');
@@ -216,6 +215,7 @@ function webform_civicrm_webform_component_info() {
     'file' => 'includes/contact_component.inc',
   );
 
+  // when civipostcode extension is installed and enabled, civipostcode webform component will be made available
   if(isPostcodeLookupExtensionEnabled()) {
     $components['civipostcode'] = array(
       'label' => t('Civi Postcode'),

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -80,16 +80,20 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
   // Alter front-end of webforms
   elseif (strpos($form_id, 'webform_client_form_') !== FALSE
     && !empty($form['#node']->webform_civicrm)) {
-    // attach javascript needed for civipostcode lookup
-    drupal_add_library('system', 'ui.autocomplete');
-    $form['#attached']['js'] = array(
-      drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js' => array(),
-        array(
-        // Pass PHP variables to Drupal.settings.
-        'data' => array('baseUrl' => $base_url),
-        'type' => 'setting',
-       ),
-    );
+
+    // attach javascript needed if civipostcode lookup is enabled
+    if(isPostcodeLookupExtensionEnabled()) {
+      drupal_add_library('system', 'ui.autocomplete');
+      $form['#attached']['js'] = array(
+        drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js' => array(),
+          array(
+          // Pass PHP variables to Drupal.settings.
+          'data' => array('baseUrl' => $base_url),
+          'type' => 'setting',
+         ),
+      );
+    }
+
     form_load_include($form_state, 'inc', 'webform_civicrm', 'includes/wf_crm_webform_preprocess');
     $processor = new wf_crm_webform_preprocess($form, $form_state);
     $processor->alterForm();
@@ -191,20 +195,25 @@ function webform_civicrm_theme() {
  * @return array
  */
 function webform_civicrm_webform_component_info() {
-  return array(
-    'civicrm_contact' => array(
-      'label' => t('CiviCRM Contact'),
-      'description' => t('Choose existing contact.'),
-      'features' => array(
-        'email_name' => TRUE,
-      ),
-      'file' => 'includes/contact_component.inc',
+  $components = array();
+
+  $components['civicrm_contact'] = array(
+    'label' => t('CiviCRM Contact'),
+    'description' => t('Choose existing contact.'),
+    'features' => array(
+      'email_name' => TRUE,
     ),
-    'civipostcode' => array(
-       'label' => t('Civi Postcode'),
-       'file' => 'includes/civipostcode_component.inc',
-    ),
+    'file' => 'includes/contact_component.inc',
   );
+
+  if(isPostcodeLookupExtensionEnabled()) {
+    $components['civipostcode'] = array(
+      'label' => t('Civi Postcode'),
+      'file' => 'includes/civipostcode_component.inc',
+    );
+  }
+
+  return $components;
 }
 
 /**
@@ -629,4 +638,20 @@ function _webform_civicrm_status() {
   }
 
   return $status;
+}
+
+/**
+ * check if civipostcodelookup extension is enabled.
+ *
+ * @return boolean
+ */
+function isPostcodeLookupExtensionEnabled() {
+  $isPostcodeLookupEnabled = CRM_Core_DAO::getFieldValue(
+    'CRM_Core_DAO_Extension',
+    'uk.co.vedaconsulting.module.civicrmpostcodelookup',
+    'is_active',
+    'full_name'
+  );
+
+  return $isPostcodeLookupEnabled;
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -80,6 +80,16 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
   // Alter front-end of webforms
   elseif (strpos($form_id, 'webform_client_form_') !== FALSE
     && !empty($form['#node']->webform_civicrm)) {
+    // attach javascript needed for civipostcode lookup
+    drupal_add_library('system', 'ui.autocomplete');
+    $form['#attached']['js'] = array(
+      drupal_get_path('module', 'webform_civicrm') . '/js/civipostcode_component.js' => array(),
+        array(
+        // Pass PHP variables to Drupal.settings.
+        'data' => array('baseUrl' => $base_url),
+        'type' => 'setting',
+       ),
+    );
     form_load_include($form_state, 'inc', 'webform_civicrm', 'includes/wf_crm_webform_preprocess');
     $processor = new wf_crm_webform_preprocess($form, $form_state);
     $processor->alterForm();


### PR DESCRIPTION
Hello @colemanw , 

Hope you are well.

**Requirement:** Integrate [CiviPostcode Exntension](https://github.com/veda-consulting/uk.co.vedaconsulting.module.civicrmpostcodelookup) with webform_civicrm.

**What this PR does:** This PR integrates functionality of civipostcode extension to webform civicrm by adding a webform component called "Civi Postcode". 
Administrators can change widget type of "postal code" fields to Civi Postcode to transform it from a _regular textfield_ to a _Postcode lookup field_ which makes use of the resources provided by  [CiviPostcode Exntension](https://github.com/veda-consulting/uk.co.vedaconsulting.module.civicrmpostcodelookup).

**Test Results:**
1. Check if postcode can be looked up in the Postal code field - Passed
2. Check if both capital and small letters can be used in the postal code field - Passed
3. Check if you enter name and email, etc, the post code lookup still works - Passed
4. Check if you can select an address and it gets populated in the fields - Passed
5. Check if you select an address and then change the postcode, and select another address, the new address gets populated - Passed
6. Check if an address has a company name before the address, if that is getting populated too as in the civicrm version - Passed
7. Check if you can change the widget type back to textfield - Passed
8. Check if you add 2 civi contacts with addresses, in both cases civi postcode works - Passed
9. When you go to the preview page, and check the addresses for the contacts, you will be able to see the postcode - Passed
10. When you go to the preview (next) page and then go back to the previous one, the postcode is still there - Passed
11. Check if the lookup is working when address sharing is enabled for 2 contacts - Passed

**Demo GIF:** ![civipostcode-webform-integration-demo-after-changi](https://cloud.githubusercontent.com/assets/7393885/24405898/16d806ac-13e4-11e7-8ec2-078566ecdc3b.gif)

Many Thanks.

Kind Regards,
Nishant Bhorodia
