### PR TITLE
Change Tax rate to a floating point value

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -549,9 +549,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $taxSettings = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
 
         if ($taxSettings['tax_display_settings'] != 'Do_not_show') {
-          //strip trailing zeros from tax_rate e.g 20.00000% => 20.00%
-          $tax_rate = number_format($this->tax_rate, 2);
-          $item['label'] .= ' (' . t('includes !rate @tax', array('!rate' => $tax_rate . '%', '@tax' => $taxSettings['tax_term'])) . ')';
+          $item['label'] .= ' (' . t('includes !rate @tax', array('!rate' => (float)$this->tax_rate . '%', '@tax' => $taxSettings['tax_term'])) . ')';
         }
 
         // Add calculation for financial type that contains tax

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -549,7 +549,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $taxSettings = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
 
         if ($taxSettings['tax_display_settings'] != 'Do_not_show') {
-          $item['label'] .= ' (' . t('includes !rate @tax', array('!rate' => $this->tax_rate . '%', '@tax' => $taxSettings['tax_term'])) . ')';
+          $tax_rate = number_format($this->tax_rate, 2); //strip trailing zeros from tax_rate e.g 20.00000% => 20.00%
+          $item['label'] .= ' (' . t('includes !rate @tax', array('!rate' => $tax_rate . '%', '@tax' => $taxSettings['tax_term'])) . ')';
         }
 
         // Add calculation for financial type that contains tax

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -549,7 +549,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $taxSettings = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
 
         if ($taxSettings['tax_display_settings'] != 'Do_not_show') {
-          $tax_rate = number_format($this->tax_rate, 2); //strip trailing zeros from tax_rate e.g 20.00000% => 20.00%
+          //strip trailing zeros from tax_rate e.g 20.00000% => 20.00%
+          $tax_rate = number_format($this->tax_rate, 2);
           $item['label'] .= ' (' . t('includes !rate @tax', array('!rate' => $tax_rate . '%', '@tax' => $taxSettings['tax_term'])) . ')';
         }
 


### PR DESCRIPTION
VAT appears as 20.0000000000% no matter how many times you save it in civicrm "/civicrm/admin/financial/financialAccount?reset=1", this shows up on webforms as well. Fixed by changing the $this->tax_rate to a floating point value. This strips out the trailing zeros.