### PR TITLE
Daynamic custom fields improvments

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -23,7 +23,9 @@ function wf_crm_field_options($field, $context, $data) {
   if ($pieces = wf_crm_explode_key($field['form_key'])) {
     list( , $c, $ent, $n, $table, $name) = $pieces;
     // Ensure we have complete info for this field
-    $field += $fields[$table . '_' . $name];
+    if(isset($fields[$table . '_' . $name])) {
+      $field += $fields[$table . '_' . $name];
+    }
     if ($name === 'contact_sub_type') {
       list($contact_types, $sub_types) = wf_crm_get_contact_types();
       $ret = wf_crm_aval($sub_types, $data['contact'][$c]['contact'][1]['contact_type'], array());
@@ -448,9 +450,14 @@ function wf_crm_enabled_fields($node, $submission = NULL, $show_all = FALSE) {
     $fields = wf_crm_get_fields();
     foreach ($node->webform['components'] as $c) {
       $exp = explode('_', $c['form_key'], 5);
+      $customGroupFieldsetKey = "";
       if (count($exp) == 5) {
         list($lobo, $i, $ent, $n, $id) = $exp;
-        if ((isset($fields[$id]) || $id == 'fieldset_fieldset') && $lobo == 'civicrm' && is_numeric($i) && is_numeric($n)) {
+        $explodedId = explode('_', $id);
+        if($explodedId[1] == 'fieldset' && $explodedId[0] != 'fieldset') {
+          $customGroupFieldsetKey = $explodedId[0];
+        }
+        if ((isset($fields[$id]) || $id == 'fieldset_fieldset' || $id == $customGroupFieldsetKey . '_fieldset') && $lobo == 'civicrm' && is_numeric($i) && is_numeric($n)) {
           if (!$show_all && ($ent == 'contact' || $ent == 'participant') && empty($node->webform_civicrm['data']['contact'][$i])) {
             continue;
           }
@@ -1250,24 +1257,7 @@ function wf_crm_get_fields($var = 'fields') {
     );
 
     // Pull custom fields and match to Webform element types
-    $custom_types = array(
-      'Select' => array('type' => 'select'),
-      'Multi-Select' => array('type' => 'select', 'extra' => array('multiple' => 1)),
-      'AdvMulti-Select' => array('type' => 'select', 'extra' => array('multiple' => 1)),
-      'Radio' => array('type' => 'select', 'extra' => array('aslist' => 0)),
-      'CheckBox' => array('type' => 'select', 'extra' => array('multiple' => 1)),
-      'Text'  => array('type' => 'textfield'),
-      'TextArea' => array('type' => 'textarea'),
-      'RichTextEditor' => array('type' => module_exists('webform_html_textarea') ? 'html_textarea' : 'textarea'),
-      'Select Date' => array('type' => 'date'),
-      'Link'  => array('type' => 'textfield'),
-      'Select Country' => array('type' => 'select'),
-      'Multi-Select Country' => array('type' => 'select', 'extra' => array('multiple' => 1)),
-      'Select State/Province' => array('type' => 'select'),
-      'Multi-Select State/Province' => array('type' => 'select', 'extra' => array('multiple' => 1)),
-      'Autocomplete-Select' => array('type' => 'select'),
-      'File' => array('type' => 'file'),
-    );
+    $custom_types = wf_crm_custom_types_map_array();
     list($contact_types) = wf_crm_get_contact_types();
     $custom_extends = "'" . implode("','", array_keys($contact_types + $sets)) . "'";
     $sql = "
@@ -1363,6 +1353,7 @@ function wf_crm_get_fields($var = 'fields') {
         }
       }
     }
+    $sets += wf_crm_get_empty_sets();
     $dao->free();
   }
   return $$var;
@@ -1695,4 +1686,65 @@ function wf_crm_explode_multivalue_str($str) {
  */
 function wf_crm_is_positive($val) {
   return is_numeric($val) && $val > 0 && round($val) == $val;
+}
+
+/**
+ * Returns empty custom civicrm field sets
+ *
+ * @return array $sets
+ */
+function wf_crm_get_empty_sets() {
+  $sets = array();
+
+  $sql = "SELECT cg.id, cg.title, cg.help_pre, cg.extends, SUM(cf.is_active) as custom_field_sum
+          FROM civicrm_custom_group cg
+          LEFT OUTER JOIN civicrm_custom_field cf
+          ON (cg.id = cf.custom_group_id)
+          GROUP By cg.id";
+
+  $dao = CRM_Core_DAO::executeQuery($sql);
+
+  while($dao->fetch()) {
+    if(empty($dao->custom_field_sum)) { // because a set with all fields disabled = empty set
+      $set = 'cg' . $dao->id;
+      if ($dao->extends == 'address' || $dao->extends == 'relationship' || $dao->extends == 'membership') {
+        $set = $dao->extends;
+      }
+      $sets[$set] = array(
+        'label' => $dao->title,
+        'entity_type' => strtolower($dao->extends),
+        'help_text' => $dao->help_pre,
+      );
+    }
+  }
+
+  return $sets;
+}
+
+/**
+ * Pull custom fields to match with Webform element types
+ *
+ * @return array
+ */
+function wf_crm_custom_types_map_array() {
+  $custom_types = array(
+    'Select' => array('type' => 'select'),
+    'Multi-Select' => array('type' => 'select', 'extra' => array('multiple' => 1)),
+    'AdvMulti-Select' => array('type' => 'select', 'extra' => array('multiple' => 1)),
+    'Radio' => array('type' => 'select', 'extra' => array('aslist' => 0)),
+    'CheckBox' => array('type' => 'select', 'extra' => array('multiple' => 1)),
+    'Text'  => array('type' => 'textfield'),
+    'TextArea' => array('type' => 'textarea'),
+    'RichTextEditor' => array('type' => module_exists('webform_html_textarea') ? 'html_textarea' : 'textarea'),
+    'Select Date' => array('type' => 'date'),
+    'Link'  => array('type' => 'textfield'),
+    'Select Country' => array('type' => 'select'),
+    'Multi-Select Country' => array('type' => 'select', 'extra' => array('multiple' => 1)),
+    'Select State/Province' => array('type' => 'select'),
+    'Multi-Select State/Province' => array('type' => 'select', 'extra' => array('multiple' => 1)),
+    'Autocomplete-Select' => array('type' => 'select'),
+    'File' => array('type' => 'file'),
+  );
+
+  return $custom_types;
 }

--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -40,6 +40,11 @@ class wf_crm_admin_component {
     }
     list(, $i, $ent, $n, $table, $name) = $pieces;
     $this->field = wf_crm_aval(wf_crm_get_fields(), $table . '_' . $name);
+    // Is this a crm custom group fieldset?
+    if(isCustomGroupFieldset($fid)) {
+      $this->form['form_key']['#disabled'] = TRUE;
+      $this->form['form_key']['#value'] = $fid;
+    }
     // Is this a crm field or fieldset?
     if (!$this->field && $table != 'fieldset') {
       return;
@@ -746,4 +751,12 @@ function wf_crm_components_form_validate($form, &$form_state) {
       }
     }
   }
+}
+
+function isCustomGroupFieldset($fid) {
+  $pieces = wf_crm_explode_key($fid);
+  if($pieces[0] == 'civicrm' && strpos($pieces[4], 'cg') !== FALSE && $pieces[5] == 'fieldset') {
+    return true;
+  }
+  return false;
 }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -310,14 +310,16 @@ class wf_crm_admin_form {
         else {
           $this->addDynamicCustomSetting($fieldset, $sid, 'contact', $n);
         }
-        foreach ($set['fields'] as $fid => $field) {
-          if ($fid == 'contact_contact_sub_type' ||
-            ($fid == 'address_master_id' && count($this->data['contact']) == 1) ||
-            (isset($field['contact_type']) && $field['contact_type'] != $c['contact'][1]['contact_type'])) {
-            continue;
+        if(isset($set['fields'])) {
+          foreach ($set['fields'] as $fid => $field) {
+            if ($fid == 'contact_contact_sub_type' ||
+              ($fid == 'address_master_id' && count($this->data['contact']) == 1) ||
+              (isset($field['contact_type']) && $field['contact_type'] != $c['contact'][1]['contact_type'])) {
+              continue;
+            }
+            $fid = 'civicrm_' . $n . '_contact_' . $i . '_' . $fid;
+            $fieldset[$fid] = $this->addItem($fid, $field);
           }
-          $fid = 'civicrm_' . $n . '_contact_' . $i . '_' . $fid;
-          $fieldset[$fid] = $this->addItem($fid, $field);
         }
         if (isset($set['max_instances'])) {
           $pos[$n . $sid . '_wrapper'][$n . $sid . $i . '_fieldset'] = $fieldset;
@@ -538,9 +540,11 @@ class wf_crm_admin_form {
             'js_select' => $this->addToggle($fs1),
           );
           $this->addDynamicCustomSetting($wrap['custom'][$fs1], $sid, 'activity', $n);
-          foreach ($set['fields'] as $fid => $field) {
-            $fid = "civicrm_{$n}_activity_1_$fid";
-            $wrap['custom'][$fs1][$fid] = $this->addItem($fid, $field);
+          if(isset($set['fields'])) {
+            foreach ($set['fields'] as $fid => $field) {
+              $fid = "civicrm_{$n}_activity_1_$fid";
+              $wrap['custom'][$fs1][$fid] = $this->addItem($fid, $field);
+            }
           }
         }
       }
@@ -622,10 +626,12 @@ class wf_crm_admin_form {
           'js_select' => $this->addToggle($fs1),
         );
         $this->addDynamicCustomSetting($pos[$fs1], $sid, 'case', $n);
-        foreach ($set['fields'] as $fid => $field) {
-          $fid = "civicrm_{$n}_case_1_$fid";
-          if (!$case_type || empty($field['case_types']) || in_array($case_type, $field['case_types'])) {
-            $pos[$fs1][$fid] = $this->addItem($fid, $field);
+        if(isset($set['fields'])) {
+          foreach ($set['fields'] as $fid => $field) {
+            $fid = "civicrm_{$n}_case_1_$fid";
+            if (!$case_type || empty($field['case_types']) || in_array($case_type, $field['case_types'])) {
+              $pos[$fs1][$fid] = $this->addItem($fid, $field);
+            }
           }
         }
       }
@@ -969,9 +975,11 @@ class wf_crm_admin_form {
           'js_select' => $this->addToggle($sid),
         );
         $this->addDynamicCustomSetting($this->form['contribution']['sets'][$sid], $sid, 'contribution', 1);
-        foreach ($set['fields'] as $fid => $field) {
-          $fid = "civicrm_1_contribution_1_$fid";
-          $this->form['contribution']['sets'][$sid][$fid] = $this->addItem($fid, $field);
+        if(isset($set['fields'])) {
+          foreach ($set['fields'] as $fid => $field) {
+            $fid = "civicrm_1_contribution_1_$fid";
+            $this->form['contribution']['sets'][$sid][$fid] = $this->addItem($fid, $field);
+          }
         }
       }
     }
@@ -1033,9 +1041,11 @@ class wf_crm_admin_form {
             'js_select' => $this->addToggle($fs1),
           );
           $this->addDynamicCustomSetting($pos[$fs1], $sid, 'grant', $n);
-          foreach ($set['fields'] as $fid => $field) {
-            $fid = "civicrm_{$n}_grant_1_$fid";
-            $pos[$fs1][$fid] = $this->addItem($fid, $field);
+          if(isset($set['fields'])) {
+            foreach ($set['fields'] as $fid => $field) {
+              $fid = "civicrm_{$n}_grant_1_$fid";
+              $pos[$fs1][$fid] = $this->addItem($fid, $field);
+            }
           }
         }
       }
@@ -1600,6 +1610,23 @@ class wf_crm_admin_form {
             webform_component_update($component);
           }
         }
+        // add empty fieldsets for custom civicrm sets with no fields, if "add dynamically" is checked
+        elseif (strpos($key, 'settings_dynamic_custom') && $val == 1) {
+          $emptySets = wf_crm_get_empty_sets();
+          list($ent, $n, , , ,$cgId) = explode('_', $key, 6);
+          $fieldsetKey = "civicrm_{$n}_{$ent}_1_{$cgId}_fieldset";
+          if(array_key_exists($cgId, $emptySets) && !isset($existing[$fieldsetKey])) {
+            $fieldset = array (
+              'nid' => $nid,
+              'pid' => 0,
+              'form_key' => $fieldsetKey,
+              'name' => $emptySets[$cgId]['label'],
+              'type' => 'fieldset',
+              'weight' => $i,
+            );
+            webform_component_insert($fieldset);
+          }
+        }
       }
       if (count($created) == 1) {
         drupal_set_message(t('Added field: %name', array('%name' => $created[0])));
@@ -1823,7 +1850,15 @@ class wf_crm_admin_form {
    */
   public static function addFieldset($c, &$field, &$enabled, $settings, $ent = 'contact', $allow_create = FALSE) {
     $type = in_array($ent, self::$fieldset_entities) ? $ent : 'contact';
-    $sid = "civicrm_{$c}_{$type}_1_fieldset_fieldset";
+    if(strpos($field['form_key'], "_custom_")) {
+      $sid = explode('_custom', $field['form_key'])[0] . '_fieldset';
+      $customGroupKey = explode('_', $field['form_key'])[4];
+      $allow_create = TRUE;
+      $isCustom = TRUE; // for custom fields only
+    }
+    else {
+      $sid = "civicrm_{$c}_{$type}_1_fieldset_fieldset";
+    }
     if (!empty($settings['create_fieldsets']) && !isset($enabled[$sid]) && $allow_create) {
       $new_set = array(
         'nid' => $field['nid'],
@@ -1831,11 +1866,15 @@ class wf_crm_admin_form {
         'type' => 'fieldset',
         'weight' => $c,
       );
-      if ($type == 'contact') {
+      $sets = wf_crm_get_fields('sets');
+      if(isset($isCustom)) {
+        $new_set['name'] = $sets[$customGroupKey]['label'];
+        $new_set['weight'] = 200 + (array_search($type, self::$fieldset_entities) * 10 + $c);
+      }
+      elseif ($type == 'contact') {
         $new_set['name'] = wf_crm_contact_label($c, $settings['data']);
       }
       else {
-        $sets = wf_crm_get_fields('sets');
         $new_set['name'] = $sets[$type]['label'] . ($c > 1 ? " $c" : '');
         $new_set['weight'] = 200 + (array_search($type, self::$fieldset_entities) * 10 + $c);
       }
@@ -1947,7 +1986,7 @@ class wf_crm_admin_form {
           if ($pieces = wf_crm_explode_key($component['form_key'])) {
             list(, $c, $ent, $n, $table, $name) = $pieces;
             if (!empty($node->webform_civicrm['data'][$ent][$c]["dynamic_custom_cg$gid"])) {
-              if ($op == 'delete') {
+              if ($op == 'delete' || $op == 'disable') {
                 webform_component_delete($node, $component);
               }
               else {
@@ -1964,7 +2003,7 @@ class wf_crm_admin_form {
         }
       }
       // Handle create new components
-      if ($op == 'create') {
+      if ($op == 'create' || $op == 'enable') {
         $ent = $sets["cg$gid"]['entity_type'];
         foreach ($node->webform_civicrm['data'][$ent] as $c => $item) {
           if (!empty($item["dynamic_custom_cg$gid"]) && empty($updated[$ent][$c])) {
@@ -1977,6 +2016,22 @@ class wf_crm_admin_form {
                 $new['weight'] = $component['weight'] + 1;
                 $new['pid'] = $component['pid'];
               }
+            }
+            if($op == 'enable') {
+              $queryParams = array(
+                'sequential' => 1,
+                'id' => $fid,
+                'options' => array('limit' => 1),
+              );
+              $result = civicrm_api3('CustomField', 'get', $queryParams);
+              $val = $result['values'][0];
+              $new['name'] = $val['label'];
+              $new['required'] = $val['is_required'];
+              $new['value'] = implode(',', wf_crm_explode_multivalue_str($val['default_value']));
+              $new['data_type'] = $val['data_type'];
+
+              $custom_types = wf_crm_custom_types_map_array();
+              $new['type'] = $custom_types[$val['html_type']]['type'];
             }
             wf_crm_admin_form::insertComponent($new, $enabled, $node->webform_civicrm);
           }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -376,6 +376,38 @@ function webform_civicrm_civicrm_post($op, $name, $id, $dao) {
 }
 
 /**
+ * Implements hook_civicrm_postSave_tableName().
+ *
+ * Handles adding/editing a custom group.
+ *
+ * @param CRM_Core_DAO_CustomGroup $dao
+ */
+function webform_civicrm_civicrm_postSave_civicrm_custom_group($dao) {
+  module_load_include('inc', 'webform', 'includes/webform.components');
+
+  // get all fieldsets with custom group ID
+  $customGroupId = $dao->id;
+  $dbResource = db_query("SELECT * FROM {webform_component} WHERE type ='fieldset' "
+          . "AND form_key LIKE '%cg{$customGroupId}_fieldset'");
+  $fieldsets = $dbResource->fetchAll(PDO::FETCH_ASSOC);
+
+  // run only if the title of the custom group has changed in civicrm
+  if($fieldsets[0]['name'] != $dao->title) {
+    foreach($fieldsets as $field_info) {
+      $component = array();
+      $component['name'] = $dao->title;
+      $component['type'] = $field_info['type'];
+      $component['form_key'] = $field_info['form_key'];
+      $component['weight'] = $field_info['weight'];
+      $component['nid'] = $field_info['nid'];
+      $component['cid'] = $field_info['cid'];
+      $component['pid'] = $field_info['pid'];
+      webform_component_update($component);
+    }
+  }
+}
+
+/**
  * Implements hook_civicrm_buildForm().
  * @param string $formName
  * @param CRM_Core_Form $form
@@ -636,6 +668,7 @@ function _webform_civicrm_status() {
 }
 
 /**
+<<<<<<< HEAD
  * Implements hook_token_info().
  */
 function webform_civicrm_token_info() {
@@ -831,4 +864,46 @@ function _webform_civicrm_getCaseContactID($caseID) {
   }
 
   return $caseContactID;
+}
+
+/**
+ * Implementation of hook_civicrm_pre()
+ *
+ * Handles enabling/disabling of custom fields
+ *
+ *
+ * @param string $op
+ * @param string $objectName
+ * @param integer $id
+ * @param array $params
+ */
+function webform_civicrm_civicrm_pre($op, $objectName, $id, &$params) {
+  if($op == 'edit' && $objectName == 'CustomField') {
+    // Run only if is_active is set, i.e. custom field is being enabled/disabled
+    if(isset($params['is_active'])) {
+      $statusToSet = $params['is_active'];
+      $queryParams = array(
+        'sequential' => 1,
+        'return' => "custom_group_id, is_active",
+        'id' => $id,
+        'options' => array('limit' => 1),
+      );
+      $result = civicrm_api3('CustomField', 'get', $queryParams);
+      // run only if this field already exist in db to make sure we donot run it for create op
+      if($result['count'] == 1) {
+        module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_admin_form');
+        $previousStatus = $result['values'][0]['is_active'];
+        $customGroupId = $result['values'][0]['custom_group_id'];
+        if($statusToSet == FALSE && $previousStatus == TRUE) {
+          $opName = 'disable';
+        }
+        else {
+          $opName = 'enable';
+        }
+        if(isset($opName)) {
+          wf_crm_admin_form::handleDynamicCustomField($opName, $id, $customGroupId);
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
This is work done by my colleague @nishant-bhorodia  .

This patch implements the following : 


1. When you click add fields dynamically on webforms civicrm tab, a webform field set for that custom field set is created in the webform tab.
* The field set on Webform tab takes the name of the civicrm fieldset (reflected on CiviCRM tab)
* the fields on the Webform tab take the name of the civicrm fields and is added under the specific field set as configured in CiviCRM (currently it puts them under an entity field set - webform 4.18 module).

2. Even if the custom field set doesn't have any custom fields in it yet and 'Add dynamically' is clicked, you should still see the field set in:
* CiviCRM tab (_Note: you still see the field set on CiviCRM tab even if 'Add dynamically' is not clicked_)
* webforms tab (_Note: you see all the changes to a field set and its fields once 'Add Dynamically' is clicked_)

3. From CiviCRM Admin > Custom data when you:
* add
* edit e.g.: rename, add/delete options for select lists etc.
* delete
* disable 

the fields from the CiviCRM field set, this is going to be reflected on both Webform tab and CiviCRM tab.

4. When you disable/ delete all fields in a field set in CiviCRM, the field set should still appear on CiviCRM tab and webform tab, and remain empty.

5. User is able to edit all details of field set other than machine name on the webform tab

6. If you untick 'Add dynamically' - it doesn't need to remove the fields from webform and civicrm tab if the fields are still ticked on civicrm tab. User needs to remove fields individually and save (default behaviour that can stay).

7. If the field sets are on different pages, when adding new fields to a field set in CiviCRM, these should be placed in the correct field set under its respective page.