### PR TITLE
Add token to show a link for created case after webform submission

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -15,6 +15,8 @@ define('WEBFORM_CIVICRM_CIVICRM_VERSION_MAX', FALSE);
 
 define('WEBFORM_CIVICRM_WEBFORM_VERSION', '4.12');
 
+define('WEBFORM_CIVICRM_DEFAULT_CONTACT_ID', 1);
+
 /**
  * Implements hook_menu().
  *
@@ -637,10 +639,22 @@ function _webform_civicrm_status() {
  * Implements hook_token_info().
  */
 function webform_civicrm_token_info() {
-  // Create case link token
-  $info['tokens']['submission']['case_link'] = array(
-    'name' => t('Case Link'),
-    'description' => t('The link to case that got created after submission.'),
+  $info['tokens']['submission']['contact-links'] = array(
+    'name' => t('Webform CiviCRM Contacts Links'),
+    'description' => t('The links to Contacts that got created after submission the webform. Replace the "?" with the contact number starting from 1'),
+    'dynamic' => TRUE,
+  );
+
+  $info['tokens']['submission']['activity-links'] = array(
+    'name' => t('Webform CiviCRM Activity Links'),
+    'description' => t('The links to activities that got created after submission webform. Replace the "?" with the activity number starting from 1'),
+    'dynamic' => TRUE,
+  );
+
+  $info['tokens']['submission']['case-links'] = array(
+    'name' => t('Webform CiviCRM Case Links'),
+    'description' => t('The links to cases that got created after submission webform. Replace the "?" with the case number starting from 1'),
+    'dynamic' => TRUE,
   );
 
   return $info;
@@ -649,32 +663,171 @@ function webform_civicrm_token_info() {
 /**
  * Implements hook_tokens().
  */
-function webform_civicrm_tokens($type, $tokens, array $data = array(), array $options = array()) {
-  global $base_url;
-
-  // Return early unless submission tokens are needed and there is a submission.
-  if ($type != 'submission' || empty($data['webform-submission']) || !webform_variable_get('webform_token_access')) {
-    return array();
+function webform_civicrm_tokens($type, $tokens = '', array $data = array(), array $options = array()) {
+  // Skip token processing if this is not a webform submission
+  if (!_webform_civicrm_isWebformSubmission($type, $data)) {
+    return [];
   }
 
-  // Generate Webform tokens.
-  $replacements = array();
+  $replacedTokens = array();
+  $webformSubmissionData = $data['webform-submission'];
 
-  $submission = $data['webform-submission'];
+  $contactLinksReplacedTokens = _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionData);
+  $replacedTokens = array_merge($replacedTokens, $contactLinksReplacedTokens);
 
-  // Replace individual tokens that have an exact replacement.
-  foreach ($tokens as $name => $original) {
-    switch ($name) {
-      case 'case_link': // replace case_link token with value
-        $caseId = $submission->civicrm['case'][1]['id'] ? $submission->civicrm['case'][1]['id'] : '';
-        $contactId = $submission->civicrm['contact'][1]['id'] ? $submission->civicrm['contact'][1]['id'] : '';
+  $activityLinksReplacedTokens = _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionData);
+  $replacedTokens = array_merge($replacedTokens, $activityLinksReplacedTokens);
 
-        $link = "{$base_url}/civicrm/contact/view/case?reset=1&id={$caseId}&cid={$contactId}&action=view";
+  $caseLinksReplacedTokens  = _webform_civicrm_replaceCaseLinksToken($tokens, $webformSubmissionData);
+  $replacedTokens = array_merge($replacedTokens, $caseLinksReplacedTokens);
 
-        $replacements[$original] = !empty($caseId) && !empty($contactId) ? l(t('Click here to manage case'), $link) : '';
-        break;
+  return $replacedTokens;
+}
+
+/**
+ * Determines if there is a webform get submitted
+ *
+ * @param $tokenType
+ * @param $webformData
+ *
+ * @return bool
+ *   True if this is a webform submisstion and false if not
+ */
+function _webform_civicrm_isWebformSubmission($tokenType, $webformData){
+  if (
+    $tokenType === 'submission' &&
+    !empty($webformData['webform-submission']) &&
+    webform_variable_get('webform_token_access')
+  ) {
+    return TRUE;
+  }
+
+  return FALSE;
+}
+
+/**
+ * Replaces contact-links tokens with civicrm contact page links
+ *
+ * @param array $tokens
+ *   Tokens to process
+ * @param array $webformSubmissionData
+ *   Data submitted by the webform
+ *
+ * @return array
+ *   List of replaced contact-links tokens replaced with actual contacts links
+ */
+function _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionData) {
+  $replacedTokens = array();
+
+  $tokenValues = token_find_with_prefix($tokens, 'contact-links');
+  if (!$tokenValues) {
+    return $replacedTokens;
+  }
+
+  foreach ($tokenValues as $entityID => $tokenName) {
+    $tokenNewValue = '';
+    if (!empty($webformSubmissionData->civicrm['contact'][$entityID]['id'])) {
+      $contactID = $webformSubmissionData->civicrm['contact'][$entityID]['id'];
+      $tokenNewValue = url("/civicrm/contact/view?reset=1&cid={$contactID}", array('absolute' => TRUE));
     }
+
+    $replacedTokens[$tokenName] = $tokenNewValue;
   }
 
-  return $replacements;
+
+  return $replacedTokens;
+}
+
+/**
+ * Replaces activity-links tokens with civicrm activity page links
+ *
+ * @param array $tokens
+ *   Tokens to process
+ * @param array $webformSubmissionData
+ *   Data submitted by the webform
+ *
+ * @return array
+ *   List of replaced activity-links tokens replaced with actual activity links
+ */
+function _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionData) {
+  $replacedTokens = array();
+
+  $tokenValues = token_find_with_prefix($tokens, 'activity-links');
+  if (!$tokenValues) {
+    return $replacedTokens;
+  }
+
+  foreach ($tokenValues as $entityID => $tokenName) {
+    $tokenNewValue = '';
+    if (!empty($webformSubmissionData->civicrm['activity'][$entityID]['id'])) {
+      $activityId = $webformSubmissionData->civicrm['activity'][$entityID]['id'];
+
+      $tokenNewValue = url("/civicrm/activity?action=view&reset=1&id={$activityId}", array('absolute' => TRUE));
+    }
+
+    $replacedTokens[$tokenName] = $tokenNewValue;
+  }
+
+
+  return $replacedTokens;
+}
+
+/**
+ * Replaces case-links tokens with civicrm case page links
+ *
+ * @param array $tokens
+ *   Tokens to process
+ * @param array $webformSubmissionData
+ *   Data submitted by the webform
+ *
+ * @return array
+ *   List of replaced case-links tokens replaced with actual case links
+ */
+function _webform_civicrm_replaceCaseLinksToken($tokens, $webformSubmissionData) {
+  $replacedTokens = array();
+
+  $tokenValues = token_find_with_prefix($tokens, 'case-links');
+  if (!$tokenValues) {
+    return $replacedTokens;
+  }
+
+  foreach ($tokenValues as $entityID => $tokenName) {
+    $tokenNewValue = '';
+    if (!empty($webformSubmissionData->civicrm['case'][$entityID]['id'])) {
+      $caseID = $webformSubmissionData->civicrm['case'][$entityID]['id'];
+      $caseContactID = _webform_civicrm_getCaseContactID($caseID);
+
+      $tokenNewValue = url("/civicrm/contact/view/case?reset=1&id={$caseID}&cid={$caseContactID}&action=view", array('absolute' => TRUE));
+    }
+
+    $replacedTokens[$tokenName] = $tokenNewValue;
+  }
+
+
+  return $replacedTokens;
+}
+
+/**
+ * Gets specified case contact ID or the default
+ * contact ID if the case contact ID is not found
+ *
+ * @param int $caseID
+ *
+ * @return int
+ */
+function _webform_civicrm_getCaseContactID($caseID) {
+  civicrm_initialize();
+
+  $caseEntity = civicrm_api3('Case', 'get', array(
+    'sequential' => 1,
+    'return' => array('contact_id'),
+    'id' => $caseID,
+  ));
+
+  $caseContactID = WEBFORM_CIVICRM_DEFAULT_CONTACT_ID;
+  if(!empty($caseEntity['values'][0]['contact_id'][1])) {
+    $caseContactID =  $caseEntity['values'][0]['contact_id'][1];
+  }
+
+  return $caseContactID;
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -632,3 +632,49 @@ function _webform_civicrm_status() {
 
   return $status;
 }
+
+/**
+ * Implements hook_token_info().
+ */
+function webform_civicrm_token_info() {
+  // Create case link token
+  $info['tokens']['submission']['case_link'] = array(
+    'name' => t('Case Link'),
+    'description' => t('The link to case that got created after submission.'),
+  );
+
+  return $info;
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function webform_civicrm_tokens($type, $tokens, array $data = array(), array $options = array()) {
+  global $base_url;
+
+  // Return early unless submission tokens are needed and there is a submission.
+  if ($type != 'submission' || empty($data['webform-submission']) || !webform_variable_get('webform_token_access')) {
+    return array();
+  }
+
+  // Generate Webform tokens.
+  $replacements = array();
+
+  $submission = $data['webform-submission'];
+
+  // Replace individual tokens that have an exact replacement.
+  foreach ($tokens as $name => $original) {
+    switch ($name) {
+      case 'case_link': // replace case_link token with value
+        $caseId = $submission->civicrm['case'][1]['id'] ? $submission->civicrm['case'][1]['id'] : '';
+        $contactId = $submission->civicrm['contact'][1]['id'] ? $submission->civicrm['contact'][1]['id'] : '';
+
+        $link = "{$base_url}/civicrm/contact/view/case?reset=1&id={$caseId}&cid={$contactId}&action=view";
+
+        $replacements[$original] = !empty($caseId) && !empty($contactId) ? l(t('Click here to manage case'), $link) : '';
+        break;
+    }
+  }
+
+  return $replacements;
+}

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -639,19 +639,20 @@ function _webform_civicrm_status() {
  * Implements hook_token_info().
  */
 function webform_civicrm_token_info() {
-  $info['tokens']['submission']['contact-links'] = array(
+  $info = array();
+  $info['tokens']['submission']['contact-link'] = array(
     'name' => t('Webform CiviCRM Contacts Links'),
     'description' => t('The links to Contacts that got created after submission the webform. Replace the "?" with the contact number starting from 1'),
     'dynamic' => TRUE,
   );
 
-  $info['tokens']['submission']['activity-links'] = array(
+  $info['tokens']['submission']['activity-link'] = array(
     'name' => t('Webform CiviCRM Activity Links'),
     'description' => t('The links to activities that got created after submission webform. Replace the "?" with the activity number starting from 1'),
     'dynamic' => TRUE,
   );
 
-  $info['tokens']['submission']['case-links'] = array(
+  $info['tokens']['submission']['case-link'] = array(
     'name' => t('Webform CiviCRM Case Links'),
     'description' => t('The links to cases that got created after submission webform. Replace the "?" with the case number starting from 1'),
     'dynamic' => TRUE,
@@ -672,13 +673,13 @@ function webform_civicrm_tokens($type, $tokens = '', array $data = array(), arra
   $replacedTokens = array();
   $webformSubmissionData = $data['webform-submission'];
 
-  $contactLinksReplacedTokens = _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionData);
+  $contactLinksReplacedTokens = _webform_civicrm_replaceContactLinkTokens($tokens, $webformSubmissionData);
   $replacedTokens = array_merge($replacedTokens, $contactLinksReplacedTokens);
 
-  $activityLinksReplacedTokens = _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionData);
+  $activityLinksReplacedTokens = _webform_civicrm_replaceActivityLinkTokens($tokens, $webformSubmissionData);
   $replacedTokens = array_merge($replacedTokens, $activityLinksReplacedTokens);
 
-  $caseLinksReplacedTokens  = _webform_civicrm_replaceCaseLinksToken($tokens, $webformSubmissionData);
+  $caseLinksReplacedTokens  = _webform_civicrm_replaceCaseLinkTokens($tokens, $webformSubmissionData);
   $replacedTokens = array_merge($replacedTokens, $caseLinksReplacedTokens);
 
   return $replacedTokens;
@@ -706,7 +707,7 @@ function _webform_civicrm_isWebformSubmission($tokenType, $webformData){
 }
 
 /**
- * Replaces contact-links tokens with civicrm contact page links
+ * Replaces contact-link tokens with civicrm contact page links
  *
  * @param array $tokens
  *   Tokens to process
@@ -714,12 +715,12 @@ function _webform_civicrm_isWebformSubmission($tokenType, $webformData){
  *   Data submitted by the webform
  *
  * @return array
- *   List of replaced contact-links tokens replaced with actual contacts links
+ *   List of replaced contact-link tokens replaced with actual contacts links
  */
-function _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionData) {
+function _webform_civicrm_replaceContactLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = array();
 
-  $tokenValues = token_find_with_prefix($tokens, 'contact-links');
+  $tokenValues = token_find_with_prefix($tokens, 'contact-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }
@@ -739,7 +740,7 @@ function _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionDa
 }
 
 /**
- * Replaces activity-links tokens with civicrm activity page links
+ * Replaces activity-link tokens with civicrm activity page links
  *
  * @param array $tokens
  *   Tokens to process
@@ -747,12 +748,12 @@ function _webform_civicrm_replaceContactLinksToken($tokens, $webformSubmissionDa
  *   Data submitted by the webform
  *
  * @return array
- *   List of replaced activity-links tokens replaced with actual activity links
+ *   List of replaced activity-link tokens replaced with actual activity links
  */
-function _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionData) {
+function _webform_civicrm_replaceActivityLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = array();
 
-  $tokenValues = token_find_with_prefix($tokens, 'activity-links');
+  $tokenValues = token_find_with_prefix($tokens, 'activity-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }
@@ -773,7 +774,7 @@ function _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionD
 }
 
 /**
- * Replaces case-links tokens with civicrm case page links
+ * Replaces case-link tokens with civicrm case page links
  *
  * @param array $tokens
  *   Tokens to process
@@ -781,12 +782,12 @@ function _webform_civicrm_replaceActivityLinksToken($tokens, $webformSubmissionD
  *   Data submitted by the webform
  *
  * @return array
- *   List of replaced case-links tokens replaced with actual case links
+ *   List of replaced case-link tokens replaced with actual case links
  */
-function _webform_civicrm_replaceCaseLinksToken($tokens, $webformSubmissionData) {
+function _webform_civicrm_replaceCaseLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = array();
 
-  $tokenValues = token_find_with_prefix($tokens, 'case-links');
+  $tokenValues = token_find_with_prefix($tokens, 'case-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }


### PR DESCRIPTION
This is another PR developed by my colleague @nishant-bhorodia .

This basically add new token called **[submission:case_link]**  that you can added on the webform submission Confirmation message to show a link for the case created by webform_civicrm  module (in case the webform creates a case).


to be honest I am a bit skeptical if this should be merged into webform_civicrm module but I thought that maybe we can add more tokens too later like (for activities , contacts .. etc) so users can use them  out of the box and without the need to do any customization  . What do you think @colemanw ? 


----------------------------------------------------------------------------------------------------------

# **Update 1 :**

Following the discussion below ,  I've implemented a support for case links token if there was more than one case and also added support for contact and activity link tokens .

**Usage :** 

If the webform is configured to create (2 contacts , 2 activities and 3 cases) , then we can use any of the following tokens :

_**Hence that these tokens will only work after submitting the webform only.**_


For the two contacts : 
- *[submission:contact-link:1]*
- *[submission:contact-link:2]*

For the two activities: 
- *[submission:activity-link:1]*
- *[submission:activity-link:2]*

For the three cases: 
- *[submission:case-link:1]*
- *[submission:case-link:2]*
- *[submission:case-link:3]*

so basically add the number of the entity (case, activity or contact) to the end of token. so if your webform is configured to created 11 cases , then you can show the link for case number 5 by using this token : 

- *[submission:case-link:5]*


**Usage in action:** 


1- Adding the tokens : (hence that these gifs is a bit outdated , token names now are following singular instead of plural form (so for example case-link:1 instead of case-link**s**:1)

![1](https://user-images.githubusercontent.com/6275540/28129010-b0400ff4-6729-11e7-9d85-01ad1edc9134.gif)


2- Submitting the form  : 

![2](https://user-images.githubusercontent.com/6275540/28128507-d24149b2-6727-11e7-9263-690d324d7a0b.gif)
