### PR TITLE
Allow thousand separator value a valid amount for money field

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2181,8 +2181,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $sum = 0;
           foreach ((array) $val as $k => $v) {
             //Strip any thousand separator for further calculation.
+            $separator = wf_civicrm_api('Setting', 'getvalue', array(
+              'name' => "monetaryThousandSeparator",
+            ));
             if ($field['data_type'] === 'Money') {
-              $v = preg_replace('/(?<=\d),(?=\d{3}\b)/', '', $v);
+              $v = preg_replace("/(?<=\d){$separator}(?=\d{3}\b)/", '', $v);
             }
             // Perform multiplication across grid elements
             if ($component['type'] == 'grid' && is_numeric($k)) {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -337,6 +337,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               form_error($element, t('Mismatch: "@state" is not a state/province of %country. Please enter a valid state/province abbreviation for %field.', array('@state' => $element['#value'], '%country' => $countries[$country_id], '%field' => $element['#title'])));
             }
           }
+          elseif ($dt == 'Money') {
+            if (CRM_Utils_Rule::money($element['#value']) == FALSE) {
+              form_error($element, t('Please enter a currency value for %field.', array('%field' => $element['#title'])));
+            }
+          }
           // Strings and files don't need any validation
           elseif ($dt !== 'String' && $dt !== 'Memo' && $dt !== 'File'
             && CRM_Utils_Type::escape($element['#value'], $dt, FALSE) === NULL) {
@@ -350,9 +355,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 break;
               case 'Link':
                 $dt = t('a web address starting with http://');
-                break;
-              case 'Money':
-                $dt = t('a currency value');
                 break;
             }
             form_error($element, t('Please enter @type for %field.', array('@type' => $dt, '%field' => $element['#title'])));
@@ -2178,6 +2180,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         elseif ($field['type'] === 'number') {
           $sum = 0;
           foreach ((array) $val as $k => $v) {
+            //Strip any thousand separator for further calculation.
+            if ($field['data_type'] === 'Money') {
+              $v = preg_replace('/(?<=\d),(?=\d{3}\b)/', '', $v);
+            }
             // Perform multiplication across grid elements
             if ($component['type'] == 'grid' && is_numeric($k)) {
               $v = $v * $k;

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -338,7 +338,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             }
           }
           elseif ($dt == 'Money') {
-            if (CRM_Utils_Rule::money($element['#value']) == FALSE) {
+            if (!preg_match('/^-?(?:0|[1-9]\d{0,2}(?:,?\d{3})*)(?:\.\d+)?$/', $element['#value'])) {
               form_error($element, t('Please enter a currency value for %field.', array('%field' => $element['#title'])));
             }
           }


### PR DESCRIPTION
Money field uses `CRM_Utils_Type::escape('Money', $dt, FALSE)` to validate its value. This function  checks [for numeric value](https://github.com/civicrm/civicrm-core/blob/master/CRM/Utils/Type.php#L260) and fails `1,000`  contribution from the webform.

<img width="575" alt="image" src="https://user-images.githubusercontent.com/5929648/28212845-093ab54e-68c1-11e7-96da-0b9930f8b4ab.png">


Either this needs fix in core to use `CRM_Utils_Rule::money()` instead of `numeric()` or an extra condition for Money datatype in `webform_civicrm.` 