### PR TITLE
create new webform field only if is_active is true

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1989,7 +1989,7 @@ class wf_crm_admin_form {
               if ($op == 'delete' || $op == 'disable') {
                 webform_component_delete($node, $component);
               }
-              else {
+              elseif (isset($field_info)) {
                 $component['name'] = $field_info['name'];
                 $component['required'] = $field_info['required'];
                 $component['value'] = $field_info['value'];

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -352,7 +352,7 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_field($dao) {
   if (empty($dao->custom_group_id)) {
     $dao->find(TRUE);
   }
-  if($dao->is_active) {
+  if ($dao->is_active) {
     wf_crm_admin_form::handleDynamicCustomField('create', $dao->id, $dao->custom_group_id);
   }
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -352,7 +352,9 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_field($dao) {
   if (empty($dao->custom_group_id)) {
     $dao->find(TRUE);
   }
-  wf_crm_admin_form::handleDynamicCustomField('create', $dao->id, $dao->custom_group_id);
+  if($dao->is_active) {
+    wf_crm_admin_form::handleDynamicCustomField('create', $dao->id, $dao->custom_group_id);
+  }
 }
 
 /**


### PR DESCRIPTION
Hello @colemanw , 

**hook_civicrm_pre** was deleting the field but then **postSave_civicrm_custom_field** was creating it again. So in this PR fields are only created if **is_active** is true.

Thanks.