### PR TITLE
Call doPayment if doTransferCheckout does not exist

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1846,8 +1846,17 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // @see webform_civicrm_civicrm_alterPaymentProcessorParams
     $params['webform_redirect_cancel'] = $this->getIpnRedirectUrl('cancel');
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
-
-    $paymentProcessor->doTransferCheckout($params, 'contribute');
+    
+    if (method_exists($paymentProcessor, 'doTransferCheckout')) {
+      // doTransferCheckout is deprecated but some processors might still implement it.
+      // Somewhere around 4.6 it was replaced by doPayment as the method of choice, 
+      // but to be safe still call it if it exists for now.
+      $paymentProcessor->doTransferCheckout($params, 'contribute');
+    }
+    else {
+      $paymentProcessor->doPayment($param);
+    }    
+    
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1854,7 +1854,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $paymentProcessor->doTransferCheckout($params, 'contribute');
     }
     else {
-      $paymentProcessor->doPayment($param);
+      $paymentProcessor->doPayment($params);
     }    
     
   }


### PR DESCRIPTION
Probably in 4.6 but definitely by 4.7 doPayment was the preferred method to call to do payments of any sort. Some processors might not fully support this, although in 4.7 & possibly 4.6 the parent class will handle that appropriately.

Least risky way is to still support doTransferPayment if it exists.