### PR TITLE
Issue #2914054: Re-initialize webform fields when creating new contact

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -31,9 +31,6 @@ var wfCivi = (function ($, D) {
           $(':input[name$="civicrm_'+num+'_contact_1_contact_'+i+'_name]"]', '.webform-client-form-'+nid).val(names[i]);
         }
       }
-
-      D.behaviors.webform_civicrmForm.attach();
-
       return;
     }
     resetFields(num, nid, true, 'hide', toHide, hideOrDisable, showEmpty, 500);
@@ -149,6 +146,10 @@ var wfCivi = (function ($, D) {
           var fn = (op === 'hide' && (!showEmpty || !isFormItemBlank($el))) ? 'hide' : 'show';
           $(':input', $el).webformProp('disabled', fn === 'hide');
           $(':input', $el).webformProp('readonly', fn === 'hide');
+          $('select.civicrm-enabled[name*="_address_state_province_id"]').each(function() {
+            $(this).webformProp('disabled', fn === 'hide');
+            $(this).webformProp('readonly', fn === 'hide');
+          });
           if (hideOrDisable === 'hide') {
             $el[fn](speed, function() {$el[fn];});
           }
@@ -357,23 +358,29 @@ var wfCivi = (function ($, D) {
         var key = parseName($el.attr('name'));
         var countrySelect = $el.parents('form').find('.civicrm-enabled[name*="['+(key.replace('state_province', 'country'))+']"]');
         var $county = $el.parents('form').find('.civicrm-enabled[name*="['+(key.replace('state_province', 'county'))+']"]');
-        if (!$el.attr('readonly')) {
-          $el = makeSelect($el);
-          if ($county.length && !$county.attr('readonly')) {
-            $county = makeSelect($county);
-            $el.change(populateCounty);
-          }
 
-          var countryVal = 'default';
-          if (countrySelect.length === 1) {
-            countryVal = $(countrySelect).val();
-          }
-          else if (countrySelect.length > 1) {
-            countryVal = $(countrySelect).filter(':checked').val();
-          }
-          countryVal || (countryVal = '');
+        var readOnly = $el.attr('readonly');
 
-          populateStates($el, countryVal);
+        $el = makeSelect($el);
+        if ($county.length && !$county.attr('readonly')) {
+          $county = makeSelect($county);
+          $el.change(populateCounty);
+        }
+
+        var countryVal = 'default';
+        if (countrySelect.length === 1) {
+          countryVal = $(countrySelect).val();
+        }
+        else if (countrySelect.length > 1) {
+          countryVal = $(countrySelect).filter(':checked').val();
+        }
+        countryVal || (countryVal = '');
+
+        populateStates($el, countryVal);
+
+        if (readOnly) {
+          $el.webformProp('readonly', true);
+          $el.webformProp('disabled', true);
         }
       });
 

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -31,6 +31,9 @@ var wfCivi = (function ($, D) {
           $(':input[name$="civicrm_'+num+'_contact_1_contact_'+i+'_name]"]', '.webform-client-form-'+nid).val(names[i]);
         }
       }
+
+      D.behaviors.webform_civicrmForm.attach();
+
       return;
     }
     resetFields(num, nid, true, 'hide', toHide, hideOrDisable, showEmpty, 500);


### PR DESCRIPTION
The issue is reported here : https://www.drupal.org/node/2914054

Basically, If there is a contact that is set as "existing contact" with "address" fields locked (hidden) then the statue/province field (which is an Ajax select field) will appear as a normal text input. This behavior was done here : https://github.com/colemanw/webform_civicrm/commit/8bb0173c6ccb080d98bdfab0d8b1a6b7d838f421

**Before**
![after1](https://user-images.githubusercontent.com/6275540/31228244-b54fe30a-a9d4-11e7-9992-d0c7519d49c3.gif)


But if the field is not a readonly field anymore which happen when you entering a details of a new contact inside (existing contact) field then the state/province should appear normally.

I fixed this by Re-initializing it after **pub.existingSelect** is called. 

**After**
![before](https://user-images.githubusercontent.com/6275540/31228113-353e0b2e-a9d4-11e7-90b7-b2a00815d39e.gif)

