### PR TITLE
Fix PHP notices when elements are not defined

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -60,7 +60,7 @@ abstract class wf_crm_webform_base {
           if ($this->contribution_page) {
             // tax integration
             $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-            $this->_tax_rate = $taxRates[$this->_contribution_page['financial_type_id']];
+            $this->_tax_rate = isset($taxRates[$this->_contribution_page['financial_type_id']]) ? $taxRates[$this->_contribution_page['financial_type_id']] : NULL;
           }
           return $this->_tax_rate;
         }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2364,7 +2364,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // address field contain many sub fields and should be handled differently
       if ($entity != 'address')  {
         $submittedLocationValues = self::unsetEmptyValueIndexes($submittedLocationValues, $entity);
-        $reorderedArray[$index][$entity] = $eValue[$entity];
+        if (isset($eValue[$entity])) {
+          $reorderedArray[$index][$entity] = $eValue[$entity];
+        }
+        else {
+          $reorderedArray[$index][$entity] = NULL;
+        }
       }
       else {
         foreach (wf_crm_address_fields() as $field)  {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2364,12 +2364,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // address field contain many sub fields and should be handled differently
       if ($entity != 'address')  {
         $submittedLocationValues = self::unsetEmptyValueIndexes($submittedLocationValues, $entity);
-        if (isset($eValue[$entity])) {
-          $reorderedArray[$index][$entity] = $eValue[$entity];
-        }
-        else {
-          $reorderedArray[$index][$entity] = NULL;
-        }
+        $reorderedArray[$index][$entity] = wf_crm_aval($eValue, $entity);
       }
       else {
         foreach (wf_crm_address_fields() as $field)  {


### PR DESCRIPTION
Not all financial types have a tax rate.  The array index is not defined if the specified financial type does not.
Also, fix a typo in "_contribution_page" variable name.