### PR TITLE
Call validatePaymentInstrument instead of validateCreditCard directly

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1614,7 +1614,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     // Validate credit card number & cvv2
-    CRM_Core_Payment_Form::validateCreditCard($params, $card_errors, wf_crm_aval($this->data, 'contribution:1:contribution:1:payment_processor_id'));
+    CRM_Core_Payment_Form::validatePaymentInstrument(wf_crm_aval($this->data, 'contribution:1:contribution:1:payment_processor_id'), $params, $card_errors, NULL);
     foreach ($card_errors as $field => $msg) {
       form_set_error($field, $msg);
       $valid = FALSE;


### PR DESCRIPTION
This replaces PR #88 as I did that on the main branch...

validateCreditCard should not be called directly, but should be called via the overrideable base class in CRM_Core_Payment_Form::validatePaymentInstrument.

This was breaking stripe via webform as we don't validate credit card fields for stripe (a token is passed instead).