### PR TITLE
Add contact labels when registering multiple participants

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -382,6 +382,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       else {
         continue;
       }
+      $participants = current(wf_crm_aval($this->data['contact'], "$c:contact", array()));
+      $firstName = CRM_Utils_Array::value('first_name', $participants);
+      $lastName = CRM_Utils_Array::value('last_name', $participants);
+
+      $pName = "{$firstName} {$lastName}";
+      if (empty(trim($pName))) {
+        $pName = CRM_Utils_Array::value('webform_label', $participants);
+      }
       foreach (wf_crm_aval($par, 'participant', array()) as $n => $p) {
         foreach (array_filter(wf_crm_aval($p, 'event_id', array())) as $id_and_type) {
           list($eid) = explode('-', $id_and_type);
@@ -397,6 +405,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'contact_ids' => $contacts,
                 'unit_price' => $p['fee_amount'],
                 'element' => "civicrm_{$c}_participant_{$n}_participant_{$id_and_type}",
+                'contact_label' => $pName,
               );
             }
           }
@@ -433,7 +442,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Add event info to line items
     $format = wf_crm_aval($this->data['reg_options'], 'title_display', 'title');
     foreach ($this->line_items as &$item) {
-      $item['label'] = wf_crm_format_event($this->events[$item['event_id']], $format);
+      $label = empty($item['contact_label']) ? '' : "{$item['contact_label']} - ";
+      $item['label'] = $label . wf_crm_format_event($this->events[$item['event_id']], $format);
       $item['financial_type_id'] = wf_crm_aval($this->events[$item['event_id']], 'financial_type_id', 'Event Fee');
     }
     // Form Validation
@@ -1846,17 +1856,17 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // @see webform_civicrm_civicrm_alterPaymentProcessorParams
     $params['webform_redirect_cancel'] = $this->getIpnRedirectUrl('cancel');
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
-    
+
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
       // doTransferCheckout is deprecated but some processors might still implement it.
-      // Somewhere around 4.6 it was replaced by doPayment as the method of choice, 
+      // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');
     }
     else {
       $paymentProcessor->doPayment($params);
-    }    
-    
+    }
+
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -386,9 +386,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $firstName = CRM_Utils_Array::value('first_name', $participants);
       $lastName = CRM_Utils_Array::value('last_name', $participants);
 
-      $pName = "{$firstName} {$lastName}";
-      if (empty(trim($pName))) {
-        $pName = CRM_Utils_Array::value('webform_label', $participants);
+      $participantName = "{$firstName} {$lastName}";
+      if (empty(trim($participantName))) {
+        $participantName = CRM_Utils_Array::value('webform_label', $participants);
+        if (!empty($this->existing_contacts[$c])) {
+          $participantName = CRM_Contact_BAO_Contact::displayName($this->existing_contacts[$c]);
+        }
       }
       foreach (wf_crm_aval($par, 'participant', array()) as $n => $p) {
         foreach (array_filter(wf_crm_aval($p, 'event_id', array())) as $id_and_type) {
@@ -405,7 +408,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'contact_ids' => $contacts,
                 'unit_price' => $p['fee_amount'],
                 'element' => "civicrm_{$c}_participant_{$n}_participant_{$id_and_type}",
-                'contact_label' => $pName,
+                'contact_label' => $participantName,
               );
             }
           }


### PR DESCRIPTION
Registering more than 1 participant through webform gives a list of event on the confirmation page. This PR adds information of which participant is chosen for a specific event on confirmation as well as line items shown on view contribution page.

![image](https://user-images.githubusercontent.com/5929648/32258514-da8a100c-bee0-11e7-8a4a-022d3c1c8abe.png)

![image](https://user-images.githubusercontent.com/5929648/32258598-66d72c8e-bee1-11e7-82ce-5b2bff2af762.png)
