### PR TITLE
CGP-904: Implementing 'Create mode' to Contact's custom fieldsets - WIP

### DIFF
--- a/css/webform_civicrm_admin.css
+++ b/css/webform_civicrm_admin.css
@@ -82,6 +82,21 @@ th div.form-type-radio {
   right: 15em;
 }
 
+#wf-crm-configure-form .multivalue-fieldset-create-mode > div {
+  float: none;
+  width: auto;
+  padding: .5em;
+  position: absolute;
+  right: 0;
+  top: 0;
+  border-left: 1px solid #CCC;
+  border-bottom: 1px solid #CCC;
+}
+
+.multivalue-fieldset-create-mode + .web-civi-js-select {
+  right: 15em;
+}
+
 .js fieldset:hover > div > .web-civi-js-select,
 .js fieldset:hover > .web-civi-js-select {
   display:block;

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -456,6 +456,11 @@ function wf_crm_enabled_fields($node, $submission = NULL, $show_all = FALSE) {
         $explodedId = explode('_', $id);
         if ($explodedId[1] == 'fieldset' && $explodedId[0] != 'fieldset') {
           $customGroupFieldsetKey = $explodedId[0];
+
+          // Automatically enable 'Create mode' field for Contact's custom group.
+          if ($ent === 'contact') {
+            $enabled[$lobo . '_' . $i . '_' . $ent . '_' . $n . '_' . $customGroupFieldsetKey . '_createmode'] = 1;
+          }
         }
         if ((isset($fields[$id]) || $id == 'fieldset_fieldset' || $id == $customGroupFieldsetKey . '_fieldset') && $lobo == 'civicrm' && is_numeric($i) && is_numeric($n)) {
           if (!$show_all && ($ent == 'contact' || $ent == 'participant') && empty($node->webform_civicrm['data']['contact'][$i])) {

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -324,8 +324,18 @@ class wf_crm_admin_form {
           }
         }
 
-        // Add 'Create mode' select field to custom group fieldset.
+        $isMultipleCustomGroup = FALSE;
+
         if (substr($sid, 0, 2) == 'cg') {
+          $customGroupId = (int) substr($sid, 2);
+          $customGroup = $this->getCustomGroup($customGroupId);
+          if (!empty($customGroup['is_multiple']) && (int) $customGroup['is_multiple']) {
+            $isMultipleCustomGroup = TRUE;
+          }
+        }
+
+        // Add 'Create mode' select field to multiple custom group fieldset.
+        if ($isMultipleCustomGroup) {
           $createModeKey = 'civicrm_' . $n . '_contact_' . $i . '_' . $sid . '_createmode';
 
           $createModeValue = isset($this->settings['data']['config']['create_mode'][$createModeKey]) ? $this->settings['data']['config']['create_mode'][$createModeKey] : NULL;
@@ -374,6 +384,17 @@ class wf_crm_admin_form {
         $this->help($rule_field, 'matching_rule');
       }
     }
+  }
+
+  /**
+   * Returns an array containing Custom Group properties.
+   *
+   * @param int $id
+   *
+   * @return array
+   */
+  private function getCustomGroup($id) {
+    return civicrm_api3('CustomGroup', 'getsingle', array('id' => $id));
   }
 
   /**

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -350,6 +350,7 @@ class wf_crm_admin_form {
               wf_crm_webform_base::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY => t('Create Only')
             ),
             '#title' => t('Create mode'),
+            '#weight' => -1,
           );
           $this->help($multivalueFieldsetCreateMode, 'multivalue_fieldset_create_mode', t('Multivalue fieldset create mode'));
           $fieldset[$createModeKey] = $multivalueFieldsetCreateMode;

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -5,8 +5,6 @@
  * Webform CiviCRM module's admin form.
  */
 
-module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_webform_base');
-
 class wf_crm_admin_form {
   private $form;
   private $form_state;
@@ -23,6 +21,7 @@ class wf_crm_admin_form {
   function __construct($form, &$form_state, $node) {
     module_load_include('inc', 'webform_civicrm', 'includes/utils');
     module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_admin_help');
+    module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_webform_base');
     civicrm_initialize();
     $this->form = $form;
     $this->form_state = &$form_state;
@@ -324,18 +323,8 @@ class wf_crm_admin_form {
           }
         }
 
-        $isMultipleCustomGroup = FALSE;
-
-        if (substr($sid, 0, 2) == 'cg') {
-          $customGroupId = (int) substr($sid, 2);
-          $customGroup = $this->getCustomGroup($customGroupId);
-          if (!empty($customGroup['is_multiple']) && (int) $customGroup['is_multiple']) {
-            $isMultipleCustomGroup = TRUE;
-          }
-        }
-
         // Add 'Create mode' select field to multiple custom group fieldset.
-        if ($isMultipleCustomGroup) {
+        if (substr($sid, 0, 2) == 'cg' && wf_crm_aval($set, 'max_instances') > 1) {
           $createModeKey = 'civicrm_' . $n . '_contact_' . $i . '_' . $sid . '_createmode';
 
           $createModeValue = isset($this->settings['data']['config']['create_mode'][$createModeKey]) ? $this->settings['data']['config']['create_mode'][$createModeKey] : NULL;
@@ -385,17 +374,6 @@ class wf_crm_admin_form {
         $this->help($rule_field, 'matching_rule');
       }
     }
-  }
-
-  /**
-   * Returns an array containing Custom Group properties.
-   *
-   * @param int $id
-   *
-   * @return array
-   */
-  private function getCustomGroup($id) {
-    return civicrm_api3('CustomGroup', 'getsingle', array('id' => $id));
   }
 
   /**

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1636,7 +1636,8 @@ class wf_crm_admin_form {
             $component['value'] = $val;
             webform_component_update($component);
           }
-          elseif (substr($key, -11) === '_createmode') {
+
+          if (substr($key, -11) === '_createmode') {
             // Update webform's settings with 'Create mode' value for custom group.
             $this->settings['data']['config']['create_mode'][$key] = $val;
           }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -5,6 +5,8 @@
  * Webform CiviCRM module's admin form.
  */
 
+module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_webform_base');
+
 class wf_crm_admin_form {
   private $form;
   private $form_state;
@@ -321,6 +323,28 @@ class wf_crm_admin_form {
             $fieldset[$fid] = $this->addItem($fid, $field);
           }
         }
+
+        // Add 'Create mode' select field to custom group fieldset.
+        if (substr($sid, 0, 2) == 'cg') {
+          $createModeKey = 'civicrm_' . $n . '_contact_' . $i . '_' . $sid . '_createmode';
+
+          $createModeValue = isset($this->settings['data']['config']['create_mode'][$createModeKey]) ? $this->settings['data']['config']['create_mode'][$createModeKey] : NULL;
+
+          $multivalueFieldsetCreateMode = array(
+            '#type' => 'select',
+            '#default_value' => $createModeValue,
+            '#prefix' => '<div class="multivalue-fieldset-create-mode">',
+            '#suffix' => '</div>',
+            '#options' => array(
+              wf_crm_webform_base::MULTIVALUE_FIELDSET_MODE_CREATE_OR_EDIT => t('Create/ Edit'),
+              wf_crm_webform_base::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY => t('Create Only')
+            ),
+            '#title' => t('Create mode'),
+          );
+          $this->help($multivalueFieldsetCreateMode, 'multivalue_fieldset_create_mode', t('Multivalue fieldset create mode'));
+          $fieldset[$createModeKey] = $multivalueFieldsetCreateMode;
+        }
+
         if (isset($set['max_instances'])) {
           $pos[$n . $sid . '_wrapper'][$n . $sid . $i . '_fieldset'] = $fieldset;
         }
@@ -1612,6 +1636,10 @@ class wf_crm_admin_form {
             $component['value'] = $val;
             webform_component_update($component);
           }
+          elseif (substr($key, -11) === '_createmode') {
+            // Update webform's settings with 'Create mode' value for custom group.
+            $this->settings['data']['config']['create_mode'][$key] = $val;
+          }
         }
         // add empty fieldsets for custom civicrm sets with no fields, if "add dynamically" is checked
         elseif (strpos($key, 'settings_dynamic_custom') && $val == 1) {
@@ -1631,6 +1659,7 @@ class wf_crm_admin_form {
           }
         }
       }
+
       if (count($created) == 1) {
         drupal_set_message(t('Added field: %name', array('%name' => $created[0])));
       }
@@ -1655,6 +1684,7 @@ class wf_crm_admin_form {
         }
       }
     }
+
     // Make sure the updates are visible to anonymous users.
     cache_clear_all();
 
@@ -1726,6 +1756,9 @@ class wf_crm_admin_form {
       $val = (array) wf_crm_aval($this->settings, $key);
       if (((in_array('create_civicrm_webform_element', $val, TRUE)) && $this->settings['nid'])
         || strpos($key, 'fieldset') !== FALSE) {
+        unset($fields[$key]);
+      }
+      elseif (substr($key, -11) === '_createmode') {
         unset($fields[$key]);
       }
       else {

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -425,6 +425,14 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function multivalue_fieldset_create_mode() {
+      print '<p>' .
+        t('Create/ Edit Mode (Default): Pre-populate the existing entry (if any) in order to allow user modifying it. If there isn\'t any existing entry, any value entered into the fieldset will be created as a new entry.') .
+        '<br><br>' .
+        t('Create Only Mode: Any value entered into the fieldset will be created as a new entry without overwriting any existing record.') .
+        '</p>';
+  }
+
   /**
    * Get help for a custom field
    */

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -427,9 +427,9 @@ class wf_crm_admin_help {
 
   public static function multivalue_fieldset_create_mode() {
       print '<p>' .
-        t('Create/ Edit Mode (Default): Pre-populate the existing entry (if any) in order to allow user modifying it. If there isn\'t any existing entry, any value entered into the fieldset will be created as a new entry.') .
+        t("Create/ Edit Mode (Default): Pre-populate the existing entry (if any) in order to allow user modifying it. If there isn't any existing entry, any value entered into the fieldset will be created as a new entry.") .
         '<br><br>' .
-        t('Create Only Mode: Any value entered into the fieldset will be created as a new entry without overwriting any existing record.') .
+        t("Create Only Mode: Any value entered into the fieldset will be created as a new entry without overwriting any existing record.") .
         '</p>';
   }
 

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -32,6 +32,10 @@ abstract class wf_crm_webform_base {
   // tax integration
   private $_tax_rate;
 
+  const
+    MULTIVALUE_FIELDSET_MODE_CREATE_OR_EDIT = 0,
+    MULTIVALUE_FIELDSET_MODE_CREATE_ONLY = 1;
+
   /**
    * Magic method to retrieve otherwise inaccessible properties
    * @param $name
@@ -691,10 +695,14 @@ abstract class wf_crm_webform_base {
    * @param $known
    *   Is this a known record (as opposed to a contact matched via dedupe rules)?
    *   We only allow saving blank fields for known contacts.
+   * @param $contact_index
+   *   Contact's index
    */
-  protected function saveCustomData($entity, $entity_id, $entity_type, $known = TRUE) {
+  protected function saveCustomData($entity, $entity_id, $entity_type, $known = TRUE, $contact_index = 1) {
     $existing = FALSE;
     $params = array('entityID' => $entity_id);
+    $createMultiValues = array();
+
     foreach ($entity as $table => $values) {
       if (substr($table, 0, 2) == 'cg' && is_array($values)) {
         if ($existing === FALSE) {
@@ -702,7 +710,8 @@ abstract class wf_crm_webform_base {
         }
         $existing += array($table => array());
         $insert = 0;
-        foreach ($values as $custom) {
+
+        foreach ($values as $valuesIndex => $custom) {
           // Match to id of existing record (id will be 0 for non-multi-value custom sets, which is fine)
           if ($id = each($existing[$table])) {
             $suf = $id['key'];
@@ -711,28 +720,73 @@ abstract class wf_crm_webform_base {
           else {
             $suf = --$insert;
           }
+
+          $multivaluesCreateMode = NULL;
+
+          // Handle 'Create mode' for multivalues custom fields of Contact entity.
+          if ($entity_type === 'Contact') {
+            $createModeKey = 'civicrm_' . $contact_index . '_contact_' . $valuesIndex . '_' . $table . '_createmode';
+            $multivaluesCreateMode = isset($this->data['config']['create_mode'][$createModeKey]) ? (int) $this->data['config']['create_mode'][$createModeKey] : NULL;
+          }
+          $multiValueSuffix = '_' . $suf;
+
+          if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
+            // Using 'Create only' mode we don't need custom value's suffix
+            // so the value can be added as new instead of updated.
+            $multiValueSuffix = '';
+          }
+
+          $customGroupParams = array();
+
           foreach ($custom as $k => $v) {
             // Only save if this is not blank or data already exists and record is known
             if ($v !== '' || ($suf >= 0 && $known)) {
-              $params[$k . '_' . $suf] = $v;
+              $customGroupParams[$k . $multiValueSuffix] = $v;
             }
+          }
+
+          if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
+            $createMultiValues[] = $customGroupParams;
+          }
+          else {
+            $params = array_merge($params, $customGroupParams);
           }
         }
       }
     }
+
     if (count($params) > 1) {
-      $result = CRM_Core_BAO_CustomValueTable::setValues($params);
-      // Prevent wholesale failure by saving each param individually if there was an error while trying to save them all at once
-      if (!empty($result['is_error'])) {
-        $bt = debug_backtrace();
-        array_shift($params);
-        foreach ($params as $k => $v) {
-          $single_param = array('entityID' => $entity_id, $k => $v);
-          $result = CRM_Core_BAO_CustomValueTable::setValues($single_param);
-          if (!empty($result['is_error'])) {
-            $file = explode('/', $bt[0]['file']);
-            watchdog('webform_civicrm', 'The CiviCRM "CustomValueTable::setValues" function returned the error: "%msg" when called by line !line of !file with the following parameters: "!params"', array('%msg' => $result['error_message'], '!line' => $bt[0]['line'], '!file' => array_pop($file), '!params' => print_r($single_param, TRUE)), WATCHDOG_ERROR);
-          }
+      // Update existing values.
+      $this->saveCustomValues($entity_id, $params);
+    }
+
+    if (!empty($createMultiValues)) {
+      // Add new values.
+      foreach ($createMultiValues as $multiValuesSet) {
+        $this->saveCustomValues($entity_id, array_merge($multiValuesSet, array('entityID' => $entity_id)));
+      }
+    }
+  }
+
+  /**
+   * Saves a set of custom values for specific entity Id.
+   *
+   * @param int $entity_id
+   * @param array $params
+   */
+  protected function saveCustomValues($entity_id, array $params) {
+    $result = CRM_Core_BAO_CustomValueTable::setValues($params);
+
+    // Prevent wholesale failure by saving each param individually if there was an error while trying to save them all at once
+    if (!empty($result['is_error'])) {
+      $bt = debug_backtrace();
+      array_shift($params);
+      foreach ($params as $k => $v) {
+        $single_param = array('entityID' => $entity_id, $k => $v);
+        $result = CRM_Core_BAO_CustomValueTable::setValues($single_param);
+        if (!empty($result['is_error'])) {
+          $file = explode('/', $bt[0]['file']);
+          watchdog('webform_civicrm', 'The CiviCRM "CustomValueTable::setValues" function returned the error: "%msg" when called by line !line of !file with the following parameters: "!params"', array('%msg' => $result['error_message'], '!line' => $bt[0]['line'], '!file' => array_pop($file), '!params' => print_r($single_param, TRUE)), WATCHDOG_ERROR);
         }
       }
     }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -763,7 +763,7 @@ abstract class wf_crm_webform_base {
     if (!empty($createMultiValues)) {
       // Add new values.
       foreach ($createMultiValues as $multiValuesSet) {
-        $this->saveCustomValues($entity_id, array_merge($multiValuesSet, array('entityID' => $entity_id)));
+        $this->saveCustomValues($entity_id, array_merge($multiValuesSet, array('entityID' => $entity_id)), TRUE);
       }
     }
   }
@@ -773,8 +773,15 @@ abstract class wf_crm_webform_base {
    *
    * @param int $entity_id
    * @param array $params
+   * @param bool $skipEmpty
    */
-  protected function saveCustomValues($entity_id, array $params) {
+  protected function saveCustomValues($entity_id, array $params, $skipEmpty = FALSE) {
+    if ($skipEmpty) {
+      // Remove empty values from $params array. Useful to not save empty values
+      // with 'Create only' mode.
+      $params = array_filter($params);
+    }
+
     $result = CRM_Core_BAO_CustomValueTable::setValues($params);
 
     // Prevent wholesale failure by saving each param individually if there was an error while trying to save them all at once

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -779,7 +779,12 @@ abstract class wf_crm_webform_base {
     if ($skipEmpty) {
       // Remove empty values from $params array. Useful to not save empty values
       // with 'Create only' mode.
-      $params = array_filter($params);
+      foreach ($params as $key => $value) {
+        $checkValue = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $value);
+        if (empty($checkValue)) {
+          unset($params[$key]);
+        }
+      }
     }
 
     $result = CRM_Core_BAO_CustomValueTable::setValues($params);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -171,7 +171,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
       $this->saveCurrentEmployer($contact, $cid);
 
-      $this->saveCustomData($contact, $cid, 'Contact', !empty($this->existing_contacts[$c]));
+      $this->saveCustomData($contact, $cid, 'Contact', !empty($this->existing_contacts[$c]), $c);
 
       $this->fillHiddenContactFields($cid, $c);
 

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -471,6 +471,16 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           if (isset($this->info[$ent][$c][$table][$n][$name])
             && !(isset($component['cid']) && isset($submitted[$component['cid']]))) {
             $val = $this->info[$ent][$c][$table][$n][$name];
+
+            if ($ent === 'contact') {
+              $createModeKey = 'civicrm_' . $c . '_contact_' . $n . '_' . $table . '_createmode';
+              $multivaluesCreateMode = isset($this->data['config']['create_mode'][$createModeKey]) ? (int) $this->data['config']['create_mode'][$createModeKey] : NULL;
+
+              // Set empty value for field with 'Create only' mode.
+              if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
+                $val = '';
+              }
+            }
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
               $val = wf_crm_explode_multivalue_str($val);
             }


### PR DESCRIPTION
Implementation of 'Create mode' select field for any Custom Group of Contact entity.

'Create mode' select field appears at each Custom Group fieldset of Contact entity (in CIVICRM tab of Webform configuration).
![cgp-904](https://user-images.githubusercontent.com/8986209/32292992-1563bc80-bf42-11e7-9180-aa8cd6cc3002.png)

There are two available values of 'Create mode' field:

0 - "Create/ Edit" - default mode, works with original behavior.
1 - "Create only" - with this mode, when editing a webform submission, the civicrm custom values of the custom group are added (created) as new values set instead of being updated. It only affects civicrm custom values. Drupal webform's values are still updated as originally.
It allows to create infinite sets of civicrm custom group's values using webform submission.


Sample flow using new create modes:

1. We have a custom group with two original values in civicrm:
![cgp-904-step1-civicrm-custom-group](https://user-images.githubusercontent.com/8986209/32327333-6dc101e6-bfd6-11e7-940a-40ef15c8a1b6.png)

2. Here is how it looks on our sample webform: (the civicrm custom values are prepopulated)
![cgp-904-step2-open-webform](https://user-images.githubusercontent.com/8986209/32327353-7f945332-bfd6-11e7-96c5-4e643dad43b8.png)

3. Here is our webform configuration: (including both 'create mode' values)
![cgp-904-step3-webform-configuration](https://user-images.githubusercontent.com/8986209/32327388-a7727e10-bfd6-11e7-976d-11381b78909e.png)

4. We open the webform and fill with the values below:
![cgp-904-step4-save-webform](https://user-images.githubusercontent.com/8986209/32327421-bce4ae30-bfd6-11e7-85b9-cd4f388f02c7.png)

5. Here is how contact's custom values look like after saving the webform:
![cgp-904-step5-civicrm-custom-group-after-webform-submit](https://user-images.githubusercontent.com/8986209/32327444-d309e838-bfd6-11e7-8b2c-1666572aa4d9.png)
