### PR TITLE
CEW-191: Changing validateBillingFields() method to get email value as string.

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1631,7 +1631,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Email
     for ($i = 1; $i <= $this->data['contact'][1]['number_of_email']; ++$i) {
       if (!empty($this->crmValues["civicrm_1_contact_{$i}_email_email"])) {
-        $params['email'] = $this->crmValues["civicrm_1_contact_{$i}_email_email"];
+        // Force email value to contain a string.
+        // For saved draft $this->form_state['storage']['submitted'] contains
+        // a form values wrapped with array and this causes a payment error
+        // (because email appears as array($email_value) instead of $email_value).
+        $emailArray = (array) $this->crmValues["civicrm_1_contact_{$i}_email_email"];
+        $params['email'] = array_shift($emailArray);
         break;
       }
     }


### PR DESCRIPTION
When using a multiple page webform integrated with CiviCRM there is an issue causing a payment error.

It occurs when using draft webform. 

There is difference of storing saved form values for draft webform comparing to non-draft.
Form values are stored in $form_state reference (https://github.com/colemanw/webform_civicrm/blob/7.x-4.x/includes/wf_crm_webform_postprocess.inc#L71).

When walking through webform steps (without using draft or reloading middle step pages) the webform values are stored correctly and contain particular fields values as strings. For example:
civicrm_1_contact_1_email_email = 'someemail@somedomain.com'

However using a draft (or reloading any mid-step page) causes $form_state webform values to be wrapped with arrays. For example:

civicrm_1_contact_1_email_email = array('someemail@somedomain.com')

This causes an error when passing this email value into Contribute payment (using Stripe payment processor in my case).