### PR TITLE
Making Expense Claim Submissions possible

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1846,17 +1846,17 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // @see webform_civicrm_civicrm_alterPaymentProcessorParams
     $params['webform_redirect_cancel'] = $this->getIpnRedirectUrl('cancel');
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
-    
+
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
       // doTransferCheckout is deprecated but some processors might still implement it.
-      // Somewhere around 4.6 it was replaced by doPayment as the method of choice, 
+      // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');
     }
     else {
       $paymentProcessor->doPayment($params);
-    }    
-    
+    }
+
   }
 
   /**
@@ -1970,7 +1970,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (!empty($contribution['soft'])) {
       // Get total amount from total amount after line item calculation
       $amount = $this->totalContribution;
-      
+
       // Get Default softcredit type
       $default_soft_credit_type = wf_civicrm_api('OptionValue', 'getsingle', array(
         'return' => "value",
@@ -2197,8 +2197,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               $sum += $v;
             }
           }
-          // We don't allow negative payments
-          $val = $sum < 0 ? 0 : $sum;
+          // Do not constrain to only allow positive amounts [note this will only work if the admin specifically removes the 0 minimum value for the contribution_amount field; which is essentially a setting]
+          $val = $sum;
         }
         else {
           $val = isset($val[0]) ? $val[0] : '';

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2197,7 +2197,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               $sum += $v;
             }
           }
-          // Do not constrain to only allow positive amounts [note this will only work if the admin specifically removes the 0 minimum value for the contribution_amount field; which is essentially a setting]
+          // Do not constrain to only allow positive amounts [note fields like contribution_amount come with a minimum 0 value - so admin must be specific/ok this]
           $val = $sum;
         }
         else {


### PR DESCRIPTION
Use case: allow volunteers/accredited Leaders for an org to make Submit Expense Claims using Webform CiviCRM module

1. Upload a number of receipts - with $amount values:

![image](https://user-images.githubusercontent.com/5340555/32733997-ff691834-c84d-11e7-8a17-1737d5b30d24.png)

2. (webform_calculator-7.x-2.x-dev) module -> allows me to change the contribution_amount field of type formula -> a sum of all receipt amounts multiplied by -1

3. this PR is required to push this negative amount to CiviCRM [previously webform civicrm only allowed positive numbers to be pushed to CiviCRM] -> For Expense Claim submissions I've configured this webform civicrm form to push it as a negative amount with Status Pending (Pay Later)

![image](https://user-images.githubusercontent.com/5340555/32734261-bc2e2c3e-c84e-11e7-9bc8-f239fdecf8c7.png)

4. After admin has issued a chq for the reimbursement payment -> admin Edits the Contribution -> status = Completed; and enters chq/notes information.

5. Does this require an 'allow negative amounts setting'? I've been debating that for a while - and decided no - probably not; Out of the box fields like contribution_amount and membership_fee are of type = Number -> and have a minimum = 0 setting; admin will have to edit these form elements in order to allow negative amounts; Alternatively - admin will have to change the field type for contribution_amount to a formula field; So it's going to be very difficult to accidentally get negative numbers - is what I'm trying to say;

PS - PHPStorm decided to remove some trailing spaces as well

