### PR TITLE
Add name to lineitem label

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1497,7 +1497,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'qty' => $item['num_terms'],
                 'unit_price' => $price,
                 'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
-                'label' => $this->getMembershipTypeField($type, 'name'),
+                'label' => $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
               );


### PR DESCRIPTION
If webform is used to buy memberships for two organistions, both just
show membership type.  This adds the org name to the label.