### PR TITLE
issue 2938155

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1848,7 +1848,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
 
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      // doTransferCheckout is deprecated but some processors might still implement it.
+      /* Paypal Express checkout */
+	  if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
+		try {
+		  $params['button'] = 'express';
+		  $params['component'] = 'contribute';
+		  $result = $paymentProcessor->doPreApproval($params);
+		  if (empty($result)) {
+			// This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+			return;
+		  }
+		}
+		catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+		  drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
+		  CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+		}
+		$preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+		$params = array_merge($params, $preApprovalParams);
+		if (!empty($result['redirect_url'])) {
+		  CRM_Utils_System::redirect($result['redirect_url']);
+		}
+	  }
+	  // doTransferCheckout is deprecated but some processors might still implement it.
       // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1848,28 +1848,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
 
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      /* Paypal Express checkout */
-	  if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
-		try {
-		  $params['button'] = 'express';
-		  $params['component'] = 'contribute';
-		  $result = $paymentProcessor->doPreApproval($params);
-		  if (empty($result)) {
-			// This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
-			return;
-		  }
-		}
-		catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-		  drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
-		  CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
-		}
-		$preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
-		$params = array_merge($params, $preApprovalParams);
-		if (!empty($result['redirect_url'])) {
-		  CRM_Utils_System::redirect($result['redirect_url']);
-		}
-	  }
-	  // doTransferCheckout is deprecated but some processors might still implement it.
+      //Paypal Express checkout
+      if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
+        try {
+          $params['button'] = 'express';
+          $params['component'] = 'contribute';
+          $result = $paymentProcessor->doPreApproval($params);
+            if (empty($result)) {
+            // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+            return;
+          }
+        }
+        catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+          drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
+          CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+        }
+        $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+        $params = array_merge($params, $preApprovalParams);
+        if (!empty($result['redirect_url'])) {
+          CRM_Utils_System::redirect($result['redirect_url']);
+        }
+      }
+      // doTransferCheckout is deprecated but some processors might still implement it.
       // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
       // but to be safe still call it if it exists for now.
       $paymentProcessor->doTransferCheckout($params, 'contribute');


### PR DESCRIPTION
This changes will redirect to Pay-pal site.
Token & Payer ID being returned. 

at the moment it is being redirected to node/{nid}/done?token=xx&PayerID=yyy
to complete the payment doExpressCheckout method should be called via doPayment method .

CiviCRM having confirmation page on contribution pages. therefor when make payment button being pressed they are calling doPayment method with token & payerid 

in same way some how doPayment method should be called in webform after the SetExpressCheckout redirection.


https://www.drupal.org/project/webform_civicrm/issues/2938155