### PR TITLE
CGP-904: Use the default value for create-only fields if it exists

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -478,7 +478,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
 
               // Set empty value for field with 'Create only' mode.
               if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
-                $val = '';
+                $defaultVal = CRM_Utils_Array::value('#default_value', $element);
+                $val = $defaultVal ? $defaultVal : '';
               }
             }
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -478,8 +478,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
 
               // Set empty value for field with 'Create only' mode.
               if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
-                $defaultVal = CRM_Utils_Array::value('#default_value', $element);
-                $val = $defaultVal ? $defaultVal : '';
+                $val = wf_crm_aval($element, '#default_value', '');
               }
             }
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {


### PR DESCRIPTION
## Overview

When using "Create Only" mode the element's default value was never used. This PR fixes that by using the default value if it exists.

## Before 

Default values were ignored with "Create Only" mode.

## After

The form pre-processing will set the value to the default, if it exists.

## Notes

I discovered this because we have a webform with a required hidden field that has a default value. Without the default value set I could not progress beyond this point in the webform because the browser will try to focus on the required element, but since it's hidden it will show an error in the console

```
An invalid form control with name='submitted[civicrm_1_contact_1_cg99999_fieldset][civicrm_1_contact_1_cg99999_custom_100012]' is not focusable.
```