### PR TITLE
Improving"pay later" with installments prcoessing

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -264,8 +264,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     // Send confirmation for each generated Contribution.
     foreach ($this->ent['contribution'] as $contributionRow) {
-      $contributionID = $contributionRow['id'];
-      wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $contributionID) + $this->contribution_page);
+      $params = array_merge($this->contribution_page, array('id' => $contributionRow['id']));
+      $params['payment_processor_id'] = $this->data['contribution'][1]['contribution'][1]['payment_processor_id'];
+      wf_civicrm_api('contribution', 'sendconfirmation', $params);
     }
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1498,6 +1498,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $contributionsCount = $installmentsCount;
     }
 
+    $contributionParams = $this->contributionParams();
+    $frequencyUnit = wf_crm_aval($contributionParams, 'frequency_unit');
+
+    $currentDate = (new DateTime())->format('Y-m-d');
+
     foreach (wf_crm_aval($this->data, 'membership', array()) as $c => $memberships) {
       if (isset($this->existing_contacts[$c]) && !empty($memberships['number_of_membership'])) {
         foreach ($memberships['membership'] as $n => $lineItem) {
@@ -1515,16 +1520,24 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             }
 
             if ($price) {
+              $singleInstallmentAmount= $this->calculateSingleInstallmentAmount($price, $contributionsCount);
+
+              $label = $this->getMembershipTypeField($type, 'name');
+              if ($contributionsCount > 1) {
+                $singleInstallmentPercentage = $this->calculateSingleInstallmentPercentage($singleInstallmentAmount, $price);
+                $label .= ' (' . $singleInstallmentPercentage . '%)';
+              }
+
               $lineItemData = array(
                 'qty' => $lineItem['num_terms'],
                 'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
-                'label' => $this->getMembershipTypeField($type, 'name'),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
+                'unit_price' => $singleInstallmentAmount,
               );
 
               for ($i = 1; $i <= $contributionsCount; $i++) {
-                $lineItemData['unit_price'] = $this->calculateSingleInstallmentAmount($price, $contributionsCount);
+                $lineItemData['label'] = $label . CRM_Utils_Date::customFormat($this->calculateInstallmentReceiveDate($i, $frequencyUnit));
                 $this->line_items[] = $lineItemData;
               }
             }
@@ -1547,6 +1560,76 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return round($this->totalContribution, 2);
+  }
+
+
+  /**
+   * Calculate and returns the receive date for
+   * a single installment.
+   *
+   * @param int $contributionNumber
+   * @param string $frequencyUnit
+   *
+   * @return string
+   */
+  private function calculateInstallmentReceiveDate($contributionNumber, $frequencyUnit) {
+    $currentDate = new DateTime();
+    $contributionNumber--;
+    switch ($frequencyUnit) {
+      case 'month':
+        $currentDate = $this->shiftMonth($currentDate, $contributionNumber);
+        break;
+      default:
+        $currentDate->modify('+' . $contributionNumber . ' ' . $frequencyUnit);
+        break;
+    }
+
+    return $currentDate->format('Y-m-d');
+  }
+  /**
+   * Copied from http://php.net/manual/en/datetime.modify.php#120513
+   *
+   * Returns end of months when we shift to a shorter or longer month
+   * workaround for http://php.net/manual/en/datetime.add.php#example-2489.
+   *
+   * Makes the assumption that shifting from the 28th Feb +1 month is 31st March
+   * Makes the assumption that shifting from the 28th Feb -1 month is 31st Jan
+   * Makes the assumption that shifting from the 29,30,31 Jan +1 month is 28th (or 29th) Feb
+   *
+   * @param DateTime $aDate
+   * @param int $months positive or negative
+   *
+   * @return DateTime new instance - original parameter is unchanged
+   */
+  private function shiftMonth(DateTime $aDate, $months) {
+    $dateA = clone($aDate);
+    $dateB = clone($aDate);
+    $plusMonths = clone($dateA->modify($months . ' Month'));
+    // Check whether reversing the month addition gives us the original day back.
+    if ($dateB != $dateA->modify($months * -1 . ' Month')) {
+      $result = $plusMonths->modify('last day of last month');
+    }
+    elseif ($aDate == $dateB->modify('last day of this month')) {
+      $result =  $plusMonths->modify('last day of this month');
+    }
+    else {
+      $result = $plusMonths;
+    }
+    return $result;
+  }
+
+  /**
+   * Calculates and returns the percentage value
+   * of the single installment compared
+   * to the total amount.
+   *
+   * @param float $installmentAmount
+   * @param float $totalAmount
+   *
+   * @return float
+   */
+  private function calculateSingleInstallmentPercentage($installmentAmount, $totalAmount) {
+    return round(($installmentAmount / $totalAmount) * 100, 2, PHP_ROUND_HALF_DOWN);
   }
 
   /**
@@ -1862,9 +1945,15 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $totalAmount = $params['total_amount'];
+    $singleInstallmentAmount = $this->calculateSingleInstallmentAmount($totalAmount, $params['installments']);
+    $params['non_deductible_amount'] = $params['total_amount'] = $singleInstallmentAmount;
     for ($i = 1; $i <= $contributionsCount; $i++) {
-      $params['non_deductible_amount'] = $params['total_amount'] = $this->calculateSingleInstallmentAmount($totalAmount, $params['installments']);
       $params['invoice_id'] = md5(uniqid(rand(), TRUE));
+
+      if (!empty($recurringContribution['values'][0]['frequency_unit'])) {
+        $params['receive_date'] = $this->calculateInstallmentReceiveDate($i, $recurringContribution['values'][0]['frequency_unit']);
+      }
+
       $contribution = wf_civicrm_api('contribution', 'create', $params);
       $this->ent['contribution'][$i]['id'] = $contribution['id'];
     }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -261,8 +261,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $template = CRM_Core_Smarty::singleton();
       $template->assign('is_pay_later', 1);
     }
-    $contribute_id = $this->ent['contribution'][1]['id'];
-    wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $contribute_id) + $this->contribution_page);
+
+    // Send confirmation for each generated Contribution.
+    foreach ($this->ent['contribution'] as $contributionRow) {
+      $contributionID = $contributionRow['id'];
+      wf_civicrm_api('contribution', 'sendconfirmation', array('id' => $contributionID) + $this->contribution_page);
+    }
   }
 
   /**
@@ -1189,7 +1193,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         foreach ($this->line_items as &$item) {
           if ($item['element'] == "civicrm_{$c}_membership_{$n}") {
             $item['membership_id'] = $result['id'];
-            break;
           }
         }
       }
@@ -1476,7 +1479,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Calculate line-items for this webform submission
    */
   private function tallyLineItems() {
-    // Contribution
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (isset($this->enabled[$fid]) || $this->getData($fid) > 0) {
       $this->line_items[] = array(
@@ -1488,37 +1490,49 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         'entity_table' => 'civicrm_contribution',
       );
     }
-    // Membership
+
+    $contributionIsPayLater = empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
+    $installmentsCount = $this->getData('civicrm_1_contribution_1_contribution_installments');
+    $contributionsCount = 1;
+    if ($contributionIsPayLater  && $installmentsCount > 1) {
+      $contributionsCount = $installmentsCount;
+    }
+
     foreach (wf_crm_aval($this->data, 'membership', array()) as $c => $memberships) {
       if (isset($this->existing_contacts[$c]) && !empty($memberships['number_of_membership'])) {
-        foreach ($memberships['membership'] as $n => $item) {
-          if (!empty($item['membership_type_id'])) {
-            $type = $item['membership_type_id'];
+        foreach ($memberships['membership'] as $n => $lineItem) {
+          if (!empty($lineItem['membership_type_id'])) {
+            $type = $lineItem['membership_type_id'];
             $price = $this->getMembershipTypeField($type, 'minimum_fee');
 
             //if number of terms is set, regard membership fee field as price per term
             //if you choose to set dates manually while membership fee field is enabled, take the membership fee as total cost of this membership
-            if (isset($item['fee_amount'])) {
-              $price = $item['fee_amount'];
-              if (empty($item['num_terms'])) {
-                $item['num_terms'] = 1;
+            if (isset($lineItem['fee_amount'])) {
+              $price = $lineItem['fee_amount'];
+              if (empty($lineItem['num_terms'])) {
+                $lineItem['num_terms'] = 1;
               }
             }
 
             if ($price) {
-              $this->line_items[] = array(
-                'qty' => $item['num_terms'],
-                'unit_price' => $price,
+              $lineItemData = array(
+                'qty' => $lineItem['num_terms'],
                 'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
-                'label' => $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]),
+                'label' => $this->getMembershipTypeField($type, 'name'),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
               );
+
+              for ($i = 1; $i <= $contributionsCount; $i++) {
+                $lineItemData['unit_price'] = $this->calculateSingleInstallmentAmount($price, $contributionsCount);
+                $this->line_items[] = $lineItemData;
+              }
             }
           }
         }
       }
     }
+
     // Calculate totals
     $this->totalContribution = 0;
     foreach ($this->line_items as &$item) {
@@ -1533,6 +1547,27 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return round($this->totalContribution, 2);
+  }
+
+  /**
+   * Calculates a single installment amount (price)
+   * if there are more than one installment.
+   *
+   * If there is only one installment then its
+   * amount will be the total amount.
+   *
+   * @param float $totalAmount
+   * @param int $installmentsCount
+   *
+   * @return float
+   */
+  private function calculateSingleInstallmentAmount($totalAmount, $installmentsCount) {
+    $amount =  $totalAmount;
+    if ($installmentsCount > 1) {
+      $amount = floor(($totalAmount / $installmentsCount) * 100) / 100;
+    }
+
+    return $amount;
   }
 
   /**
@@ -1748,33 +1783,30 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Generate recurring contribution and transact the first one
    */
   private function contributionRecur($contributionParams) {
-    $installments = $contributionParams['installments'];
-    if ($installments != 0) {
-      // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
-      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($installments - 1);
-    }
+    $recurringContribution = $this->createRecurringContribution($contributionParams);
 
-    // Create Params for Creating the Recurring Contribution Series and Create it
-    $contributionRecurParams = array(
-      'sequential' => 1,
-      'contact_id' => $contributionParams['contact_id'],
-      'frequency_interval' => wf_crm_aval($contributionParams, 'frequency_interval', 1),
-      'frequency_unit' => wf_crm_aval($contributionParams, 'frequency_unit', 'month'),
-      'installments' => $installments,
-      'amount' => $contributionRecurAmount,
-      'contribution_status_id' => 5,
-      'currency' => $contributionParams['currency'],
-      'payment_processor_id' =>  $contributionParams['payment_processor_id'],
-      'financial_type_id' =>  $contributionParams['financial_type_id'],
-    );
-    $resultRecur = wf_civicrm_api('ContributionRecur', 'create', $contributionRecurParams);
+    return $this->doContributionTransact($contributionParams, $recurringContribution['id']);
+  }
+
+  /**
+   * Makes a Contribution transact for
+   * the specified contribution
+   *
+   * @param array $contributionParams
+   * @param int $recurringContributionId
+   *
+   * @return array
+   */
+  private function doContributionTransact($contributionParams, $recurringContributionId) {
+    if ($contributionParams['installments'] != 0) {
+      $contributionFirstAmount = $this->calculateSingleInstallmentAmount($contributionParams['total_amount'], $contributionParams['installments']);
+    }
 
     // Run the Transaction - and Create the Contribution Record - relay Recurring Series information in addition to the already existing Params [and re-key where needed]; at times two keys are required
     $contributionParams['total_amount'] = $contributionFirstAmount;
     $additionalParams = array(
-      'contribution_recur_id' => $resultRecur['id'],
-      'contributionRecurID' => $resultRecur['id'],
+      'contribution_recur_id' => $recurringContributionId,
+      'contributionRecurID' => $recurringContributionId,
       'is_recur' => 1,
       'contactID' => $contributionParams['contact_id'],
       'frequency_interval' => wf_crm_aval($contributionParams, 'frequency_interval', 1),
@@ -1784,14 +1816,15 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     // If transaction was successful - Update the Recurring Series - currency must be resubmitted or else it will re-default to USD; invoice_id is that of the initiating Contribution
     if (empty($result['error_message'])) {
-      $resultUpdateRecur = wf_civicrm_api('ContributionRecur', 'create', array(
-        'id' => $resultRecur['id'],
+      wf_civicrm_api('ContributionRecur', 'create', array(
+        'id' => $recurringContributionId,
         'currency' => $contributionParams['currency'],
-        'next_sched_contribution_date' => date("Y-m-d H:i:s", strtotime('+' . $contributionRecurParams['frequency_interval'] . ' ' . $contributionRecurParams['frequency_unit'])),
+        'next_sched_contribution_date' => date("Y-m-d H:i:s", strtotime('+' . $additionalParams['frequency_interval'] . ' ' . $additionalParams['frequency_unit'])),
         'invoice_id' => $result['values'][$result['id']]['invoice_id'],
         'payment_instrument_id' => $result['values'][$result['id']]['payment_instrument_id'],
       ));
     }
+
     return $result;
   }
 
@@ -1811,8 +1844,56 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $params['payment_instrument_id'] = key($defaultPaymentInstrument);
       }
     }
-    $result = wf_civicrm_api('contribution', 'create', $params);
-    $this->ent['contribution'][1]['id'] = $result['id'];
+
+    $createRecurringContribution = FALSE;
+    $installmentsCount = wf_crm_aval($params, 'installments', 1, TRUE);
+    $contributionsCount = 1;
+    if ($this->contributionIsPayLater && $installmentsCount > 1) {
+      $contributionsCount = $installmentsCount;
+      $createRecurringContribution = TRUE;
+    }
+
+    // Creating Recurring Contribution if needed.
+    if ($createRecurringContribution) {
+      $recurringContribution = $this->createRecurringContribution($params);
+      if (!empty($recurringContribution['id'])) {
+        $params['contribution_recur_id'] = $recurringContribution['id'];
+      }
+    }
+
+    $totalAmount = $params['total_amount'];
+    for ($i = 1; $i <= $contributionsCount; $i++) {
+      $params['non_deductible_amount'] = $params['total_amount'] = $this->calculateSingleInstallmentAmount($totalAmount, $params['installments']);
+      $params['invoice_id'] = md5(uniqid(rand(), TRUE));
+      $contribution = wf_civicrm_api('contribution', 'create', $params);
+      $this->ent['contribution'][$i]['id'] = $contribution['id'];
+    }
+  }
+
+  /**
+   * Creates Recurring Contribution entry.
+   *
+   * @param array $contributionParams
+   *
+   * @return array
+   */
+  private function createRecurringContribution(array $contributionParams) {
+    $amount = $this->calculateSingleInstallmentAmount($contributionParams['total_amount'], $contributionParams['installments']);
+    $paymentProcessorId = !empty($contributionParams['payment_processor_id']) ? $contributionParams['payment_processor_id'] : NULL;
+    $contributionRecurParams = array(
+      'sequential' => 1,
+      'contact_id' => $contributionParams['contact_id'],
+      'frequency_interval' => wf_crm_aval($contributionParams, 'frequency_interval', 1),
+      'frequency_unit' => wf_crm_aval($contributionParams, 'frequency_unit', 'month'),
+      'installments' => $contributionParams['installments'],
+      'amount' => $amount,
+      'contribution_status_id' => 'In Progress',
+      'currency' => $contributionParams['currency'],
+      'payment_processor_id' => $paymentProcessorId,
+      'financial_type_id' =>  $contributionParams['financial_type_id'],
+    );
+
+    return wf_civicrm_api('ContributionRecur', 'create', $contributionRecurParams);
   }
 
   /**
@@ -1941,7 +2022,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     // Fix bug for testing.
-    if ($params['is_test'] == 1) {
+    if ($params['is_test'] == 1 && $params['payment_processor_id']) {
       $liveProcessorName = wf_civicrm_api('payment_processor', 'getvalue', array(
         'id' => $params['payment_processor_id'],
         'return' => 'name',
@@ -1976,93 +2057,120 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    */
   private function processContribution() {
     $contribution = $this->data['contribution'][1]['contribution'][1];
-    $id = $this->ent['contribution'][1]['id'];
-    // Save custom data
-    $this->saveCustomData($this->data['contribution'][1], $id, 'Contribution', FALSE);
-    // Save soft credits
-    if (!empty($contribution['soft'])) {
-      // Get total amount from total amount after line item calculation
-      $amount = $this->totalContribution;
-
-      // Get Default softcredit type
-      $default_soft_credit_type = wf_civicrm_api('OptionValue', 'getsingle', array(
-        'return' => "value",
-        'option_group_id' => "soft_credit_type",
-        'is_default' => 1,
-      ));
-
-      foreach (array_filter($contribution['soft']) as $cid) {
-        wf_civicrm_api('contribution_soft', 'create', array(
-          'contact_id' => $cid,
-          'contribution_id' => $id,
-          'amount' => $amount,
-          'currency' => $this->contribution_page['currency'],
-          'soft_credit_type_id' => $default_soft_credit_type['value'],
+    foreach ($this->ent['contribution'] as $contributionRow) {
+      $id = $contributionRow['id'];
+      // Save custom data
+      $this->saveCustomData($this->data['contribution'][1], $id, 'Contribution', FALSE);
+      // Save soft credits
+      if (!empty($contribution['soft'])) {
+        foreach (array_filter($contribution['soft']) as $cid) {
+          wf_civicrm_api('contribution_soft', 'create', array(
+            'contact_id' => $cid,
+            'contribution_id' => $id,
+            'amount' => $contribution['total_amount'],
+            'currency' => $this->contribution_page['currency'],
+          ));
+        }
+      }
+      // Save honoree
+      // FIXME: these api params were deprecated in 4.5, should be switched to use soft-credits when we drop support for 4.4
+      if (!empty($contribution['honor_contact_id']) && !empty($contribution['honor_type_id'])) {
+        wf_civicrm_api('contribution', 'create', array(
+          'id' => $id,
+          'total_amount' => $contribution['total_amount'],
+          'honor_contact_id' => $contribution['honor_contact_id'],
+          'honor_type_id' => $contribution['honor_type_id'],
         ));
       }
-    }
-    // Save honoree
-    // FIXME: these api params were deprecated in 4.5, should be switched to use soft-credits when we drop support for 4.4
-    if (!empty($contribution['honor_contact_id']) && !empty($contribution['honor_type_id'])) {
-      wf_civicrm_api('contribution', 'create', array(
-        'id' => $id,
-        'total_amount' => $contribution['total_amount'],
-        'honor_contact_id' => $contribution['honor_contact_id'],
-        'honor_type_id' => $contribution['honor_type_id'],
-      ));
-    }
+      $lineItemIndex = $this->getAvailableLineItemIndex();
+      if ($lineItemIndex === NULL) {
+        continue;
+      }
 
-    $contributionResult = CRM_Contribute_BAO_Contribution::getValues(array('id' => $id), CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
+      $contributionResult = CRM_Contribute_BAO_Contribution::getValues(array('id' => $id), CRM_Core_DAO::$_nullArray, CRM_Core_DAO::$_nullArray);
+      $updatedLineItem = $this->updateContributionLineItem($this->line_items[$lineItemIndex], $contributionResult);
+      $this->createPaymentRecord($id, $updatedLineItem);
+    }
+  }
 
-    // Save line-items
-    foreach ($this->line_items as &$item) {
+  /**
+   * Returns first available line item index.
+   *
+   * @return int|NULL
+   */
+  private function getAvailableLineItemIndex() {
+    foreach ($this->line_items as $index => $item) {
       if (empty($item['line_total'])) {
         continue;
       }
-      if (empty($item['entity_id'])) {
-        $item['entity_id'] = $id;
-      }
-      // tax integration
-      if (empty($item['contribution_id'])) {
-        $item['contribution_id'] = $id;
-      }
-      // Membership
-      if (!empty($item['membership_id'])) {
-        $item['entity_id'] = $item['membership_id'];
-        $lineItemArray = wf_civicrm_api('LineItem', 'get', array(
-          'entity_table' => "civicrm_membership",
-          'entity_id' => $item['entity_id'],
-        ));
-        if ($lineItemArray['count'] != 0) {
-          // We only require first membership (signup) entry to make this work.
-          $firstLineItem = array_shift($lineItemArray['values']);
 
-          // Membership signup line item entry.
-          // Line Item record is already present for membership by this stage.
-          // Just need to upgrade contribution_id column in the record.
-          if (!isset($firstLineItem['contribution_id'])) {
-            $item['id'] = $firstLineItem['id'];
-          }
+      if (empty($item['entity_id'])) {
+        return $index;
+      }
+    }
+
+    return NULL;
+  }
+
+  /**
+   * Updates Line Item with Membership and financial data.
+   *
+   * @param array $lineItem
+   * @param object $contribution
+   *
+   * @return array
+   */
+  private function updateContributionLineItem(&$lineItem, $contribution) {
+    // tax integration
+    if (empty($lineItem['contribution_id'])) {
+      $lineItem['contribution_id'] = $contribution->id;
+    }
+    // Membership
+    if (!empty($lineItem['membership_id'])) {
+      $lineItem['entity_id'] = $lineItem['membership_id'];
+      $lineItemArray = wf_civicrm_api('LineItem', 'get', array(
+        'entity_table' => 'civicrm_membership',
+        'entity_id' => $lineItem['entity_id'],
+        'options' => array(
+          'sort' => 'id DESC',
+          'limit' => 1,
+        ),
+      ));
+      if ($lineItemArray['count'] != 0) {
+        $firstLineItem = array_shift($lineItemArray['values']);
+        // Membership signup line item entry.
+        // Line Item record is already present for membership by this stage.
+        // Just need to upgrade contribution_id column in the record.
+        if (!isset($firstLineItem['contribution_id'])) {
+          $lineItem['id'] = $firstLineItem['id'];
         }
       }
+    }
+    $line_result = wf_civicrm_api('line_item', 'create', $lineItem);
+    $lineItem['id'] = $line_result['id'];
+    $lineItemRecord = json_decode(json_encode($lineItem), FALSE);
+    // Add financial_item and entity_financial_trxn
+    CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contribution);
+    if (!is_null($this->tax_rate)) {
+      CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contribution, TRUE);
+    }
 
-      $line_result = wf_civicrm_api('line_item', 'create', $item);
-      $item['id'] = $line_result['id'];
+    return $lineItem;
+  }
 
-      $lineItemRecord = json_decode(json_encode($item), FALSE);
-      // Add financial_item and entity_financial_trxn
-      $result = CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult);
-      if (!is_null($this->tax_rate)) {
-        $result = CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult, TRUE);
-      }
-      // Create participant/membership payment records
-      if (isset($item['membership_id']) || isset($item['participant_id'])) {
-        $type = isset($item['participant_id']) ? 'participant' : 'membership';
-        wf_civicrm_api("{$type}_payment", 'create', array(
-          "{$type}_id" => $item["{$type}_id"],
-          'contribution_id' => $id,
-        ));
-      }
+  /**
+   * Creates participant/membership payment record.
+   *
+   * @param int $contributionId
+   * @param array $lineItem
+   */
+  private function createPaymentRecord($contributionId, $lineItem) {
+    if (isset($lineItem['membership_id']) || isset($lineItem['participant_id'])) {
+      $type = isset($lineItem['participant_id']) ? 'participant' : 'membership';
+      wf_civicrm_api("{$type}_payment", 'create', array(
+        "{$type}_id" => $lineItem["{$type}_id"],
+        'contribution_id' => $contributionId,
+      ));
     }
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1945,7 +1945,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $totalAmount = $params['total_amount'];
-    $singleInstallmentAmount = $this->calculateSingleInstallmentAmount($totalAmount, $params['installments']);
+    $singleInstallmentAmount = $this->calculateSingleInstallmentAmount($totalAmount, $contributionsCount);
     $params['non_deductible_amount'] = $params['total_amount'] = $singleInstallmentAmount;
     for ($i = 1; $i <= $contributionsCount; $i++) {
       $params['invoice_id'] = md5(uniqid(rand(), TRUE));

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1946,8 +1946,17 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $totalAmount = $params['total_amount'];
+    $nonDeductibleAmount = $params['non_deductible_amount'];
+
     $singleInstallmentAmount = $this->calculateSingleInstallmentAmount($totalAmount, $contributionsCount);
-    $params['non_deductible_amount'] = $params['total_amount'] = $singleInstallmentAmount;
+
+    $params['total_amount'] = $singleInstallmentAmount;
+
+    $params['non_deductible_amount'] = 0;
+    if ($nonDeductibleAmount) {
+      $params['non_deductible_amount'] =  $singleInstallmentAmount;
+    }
+
     for ($i = 1; $i <= $contributionsCount; $i++) {
       $params['invoice_id'] = md5(uniqid(rand(), TRUE));
 


### PR DESCRIPTION
## Before

Currently when enabling installments in the webform contribution configurations : 

<img width="950" alt="2018-02-19 22_41_33-nvidia geforce overlay dt" src="https://user-images.githubusercontent.com/6275540/36399939-d5d12a12-15d6-11e8-8f44-cdd6e96cb5ac.png">

There will be either one of two cases : 

1- Using specific payment processor : 

In this case, webform_civicrm module will create a single '**completed**' contribution with amount that represent part of the total payment, and a recurring contribution record will be also created . If there was a membership configured, it will also be created and be in "**New**" status. Each time another installment time comes, the payment processor (if it supports recurring contribution) will trigger an IPN request to a civicrm callback URL and another contribution will be created until all the installments (the total amount) is paid. so as we can see webform_civicrm handle this case properly.

2- Using 'Pay Later' Option : 

In this case, webform_civicrm creates only a single contribution with the total amount in '**pending**' status, no recurring contribution record will be created and if there is a membership configured then it will be created in '**pending**' status. So basically webform_civicrm module does not handle it properly.


## Example

To Explain the above with an example, let us assume the following webform  configurations : 

1. Create a webform and Enable CiviCRM Processing on the CiviCRM tab section
2. Enable First Name, Last Name and Email for the Contact 1
3. Enable one membership for Contact 1.
4. Enable Membership Fee on the membership tab
5. Select a Contribution Page that has Pay Later option on the Contribution tab
6. Select "month" in "Frequency of Installments". then Enable number of installments and Interval of Installments

Now suppose there is now a user submitted this webform to pay for a membership that worth $120 for a  1 year membership in 12 monthly installments using "pay later" option, this is what will happen : 

1- A single contribution with amount  = 120$ in pending status will be created.
2- No recurring contribution will be created.
3- A membership in pending  statues will created.

![before_pp1](https://user-images.githubusercontent.com/6275540/36400432-7fe64120-15d9-11e8-8386-7c95241918fa.gif)


## After

Since there is no IPN in case of "pay later" option, all the installment contributions should be created in advance in 'pending' status (instead of single one in pending contribution that contain the total amount) and a recurring contribution record should also be created and all the installment contributions should link to it. The admin then can manually change each installment contribution status to paid if it get paid by the user since as we said there is no IPN in this case to do that.

In the example above, 12 contributions should be created, each with amount = 10$, and a recurring contribution record will be created.

![after_pp_1](https://user-images.githubusercontent.com/6275540/36400628-b81f07a6-15da-11e8-8ec2-5b286dd7a0d5.gif)



## Notes

- There are notices appear after submitting the webform (it appear even before my changes), I did a check on them and fixed one of them which is caused by **sendconfirmation** api call by ensuring the correct payment processor get passed to it. The other notices require many modification to civicrm core to get rid of them since they happen due to wrong assumptions + code smells on civicrm side but they should not affect the webform module for now.
 

- Tested on both civi 4.7.31 and 4.6.33.

- This solution is done originally here https://github.com/compucorp/webform_civicrm-1/pull/1 and here https://github.com/compucorp/webform_civicrm-1/pull/2 ,  I just tried to improve it, fix some issues  and did some refactoring and testing.