### PR TITLE
Change help text for create new relationship

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1123,7 +1123,7 @@ class wf_crm_admin_form {
       '#type' => 'checkbox',
       '#title' => t('Create New Relationship'),
       '#default_value' => !empty($this->settings['create_new_relationship']),
-      '#description' => t('Create new relationship if duplicate record exists and is expired or inactive.'),
+      '#description' => t('If enabled, only Active relationships will load on the form, and will be updated on Submit. If there are no Active relationships then a new one will be created.'),
     );
     $this->form['options']['new_contact_source'] = array(
       '#type' => 'textfield',


### PR DESCRIPTION
Changing the description of this setting due to its multiple usages apart from only creating new relationship -

- It avoids the loading of expired or inactive relationship. eg https://www.drupal.org/project/webform_civicrm/issues/2945709
- If an active version of a relationship is present, it will be loaded and updated on webform submission.
- If no active relationship is present, a new relationship is created.