### PR TITLE
 Adding support for overridden memebership until specific date

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1330,7 +1330,9 @@ function wf_crm_get_fields($var = 'fields') {
             'andor' => 'or',
             'action' => 'show',
             'rules' => array(
-              'contact_contact_sub_type' => $sets[$set]['sub_types'],
+              'contact_contact_sub_type' => array(
+                'values' => $sets[$set]['sub_types'],
+              ),
             ),
           );
         }

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1117,6 +1117,16 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_status_override_end_date'] = array(
         'name' => t('Status Override Until Date'),
         'type' => 'date',
+        'civicrm_condition' => array(
+          'andor' => 'or',
+          'action' => 'show',
+          'rules' => array(
+            'membership_status_id' => array(
+              'values' => '0',
+              'operator' => 'not_equal',
+            ),
+          ),
+        ),
       );
       $fields['membership_num_terms'] = array(
         'name' => t('Number of Terms'),

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1114,6 +1114,10 @@ function wf_crm_get_fields($var = 'fields') {
         'value' => 0,
         'exposed_empty_option' => '- ' . t('No') . ' -',
       );
+      $fields['membership_status_override_end_date'] = array(
+        'name' => t('Status Override Until Date'),
+        'type' => 'date',
+      );
       $fields['membership_num_terms'] = array(
         'name' => t('Number of Terms'),
         'type' => 'select',

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1108,11 +1108,11 @@ function wf_crm_get_fields($var = 'fields') {
         'extra' => array('civicrm_live_options' => 1),
       );
       $fields['membership_status_id'] = array(
-        'name' => t('Membership Status'),
+        'name' => t('Override Status'),
         'type' => 'select',
         'expose_list' => TRUE,
         'value' => 0,
-        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
+        'exposed_empty_option' => '- ' . t('No') . ' -',
       );
       $fields['membership_num_terms'] = array(
         'name' => t('Number of Terms'),

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1714,22 +1714,27 @@ class wf_crm_admin_form {
       'nid' => $this->node->nid,
       'rgid' => $rgid,
       'weight' => $weight,
-      'target' => $enabled[$field['form_key']],
-      'target_type' => 'component',
+      'actions' => array(
+        array(
+          'target' => $enabled[$field['form_key']],
+          'target_type' => 'component',
+          'action' => $field['civicrm_condition']['action'],
+        ),
+      ),
     );
     $rule_group['rules'] = array();
-    foreach ($field['civicrm_condition']['rules'] as $source => $conditions) {
+    foreach ($field['civicrm_condition']['rules'] as $source => $condition) {
       $source_key = "civicrm_{$c}_{$ent}_{$n}_{$source}";
       $source_id = wf_crm_aval($enabled, $source_key);
       if ($source_id) {
         $options = wf_crm_field_options(array('form_key' => $source_key), '', $this->settings['data']);
-        foreach ($conditions as $condition) {
-          if (isset($options[$condition])) {
+        foreach ((array) $condition['values'] as $value) {
+          if (isset($options[$value])) {
             $rule_group['rules'][] = array(
               'source_type' => 'component',
               'source' => $source_id,
-              'operator' => 'equal',
-              'value' => $condition,
+              'operator' => wf_crm_aval($condition, 'operator', 'equal'),
+              'value' => $value,
             );
           }
         }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1122,6 +1122,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (empty($params['membership_type_id'])) {
         continue;
       }
+
+      if (empty($params['status_id'])) {
+        $params['status_override_end_date'] = '';
+      }
+
       // Search for existing membership to renew - must belong to same domain and organization
       // But not necessarily the same membership type to allow for upsell
       if (!empty($params['num_terms'])) {

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -504,6 +504,14 @@ var wfCiviAdmin = (function ($, D) {
           $dateWrappers.hide().find('input').prop('checked', false);
         }
       }).trigger('change', 'init');
+      $('select[name$=_membership_status_id]', context).once('crm-mem-date').change(function(e) {
+        $target = $(this).parent().siblings('[class$="membership-status-override-end-date"]');
+        if ($(this).val() == '0') {
+          $target.hide().find('input').prop('checked', false);
+        } else {
+          $target.show();
+        }
+      }).change();
 
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -493,7 +493,7 @@ var wfCiviAdmin = (function ($, D) {
 
       // Membership constraints
       $('select[name$=_membership_num_terms]', context).once('crm-mem-date').change(function(e, type) {
-        var $dateWrappers = $(this).parent().siblings('[class$="-date"]');
+        var $dateWrappers = $(this).parent().siblings('[class$="-date"]').not('[class$="-status-override-end-date"]');
         if ($(this).val() == '0') {
           $dateWrappers.show();
           if (type !== 'init') {


### PR DESCRIPTION
Following the changes in this PR : https://github.com/civicrm/civicrm-core/pull/11622, I made here these changes to this module : 

1- relabeling the "Membership Status" field to  "Override Status". and relabeling the option "- Automatic -" to  "No".

![1](https://user-images.githubusercontent.com/6275540/36666191-c117aa32-1ae1-11e8-8040-5b1448b2873b.png)

![2](https://user-images.githubusercontent.com/6275540/36666193-c38d774c-1ae1-11e8-9d89-6584641a6c63.png)



2- A new checkbox to memebership tab is added 
called "Status Override Until Date" When checked, a date field will be added to the webform to allow admin/ user to select the date that the status override will expire. This field:

A- does not take any effect if "Override Status" field is set to "No" in the configuration or on the form
B- the selected date will  be saved into "status_override_end_date" field if a status is selected in the "Override Status" field in the configuration or on the form.


here are the test cases : 

![full_test](https://user-images.githubusercontent.com/6275540/36666210-ce4a3b20-1ae1-11e8-9380-de9a4695b2dd.gif)
