### PR TITLE
Add street_name, street_number, and street_unit to processed fields in utils.inc

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1667,6 +1667,9 @@ function wf_crm_location_fields() {
 function wf_crm_address_fields() {
   return array(
     'street_address',
+    'street_name',
+    'street_number',
+    'street_unit',
     'city',
     'state_province_id',
     'country_id',

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -683,7 +683,7 @@ function wf_crm_get_fields($var = 'fields') {
       'name' => t('Email'),
       'type' => 'email',
     );
-    foreach (array('street_address' => t('Street Address'), 'supplemental_address_1' => t('Street Address # Line 2'), 'supplemental_address_2' => t('Street Address # Line 3'), 'city' => t('City')) as $key => $value) {
+    foreach (array('street_address' => t('Street Address'), 'street_name' => t('Street Name'), 'street_number' => t('Street Number'), 'street_unit' => t('Street Number Suffix'), 'supplemental_address_1' => t('Street Address # Line 2'), 'supplemental_address_2' => t('Street Address # Line 3'), 'city' => t('City')) as $key => $value) {
       $fields['address_' . $key] = array(
         'name' => $value,
         'type' => 'textfield',

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -115,11 +115,20 @@ class wf_crm_admin_form {
     $this->rebuildData();
     // Hack for nicer UX: pre-check phone, email, etc when user increments them
     if (!empty($_POST['_triggering_element_name'])) {
-      foreach (array('phone' => 'phone', 'email' => 'email', 'website' => 'url', 'im' => 'name') as $ent => $field) {
+      $defaults = array(
+        'phone' => 'phone',
+        'email' => 'email',
+        'website' => 'url',
+        'im' => 'name',
+        'address' => array('street_address', 'city', 'state_province_id', 'postal_code'),
+      );
+      foreach ($defaults as $ent => $fields) {
         if (strpos($_POST['_triggering_element_name'], "_number_of_$ent")) {
           list(, $c) = explode('_', $_POST['_triggering_element_name']);
           for ($n = 1; $n <= $this->data['contact'][$c]["number_of_$ent"]; ++$n) {
-            $this->settings["civicrm_{$c}_contact_{$n}_{$ent}_{$field}"] = 1;
+            foreach ((array) $fields as $field) {
+              $this->settings["civicrm_{$c}_contact_{$n}_{$ent}_{$field}"] = 1;
+            }
           }
         }
       }

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -88,6 +88,30 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function address_street_address() {
+    print '<p>' .
+      t('Single field for whole address line: Street Name, Number and Number Suffix. Don\'t use together with the separate fields.') .
+      '</p>';
+  }
+
+  public static function address_street_name() {
+    print '<p>' .
+      t('Use together with Street Number and Street Number Suffix as an alternative for Street Address.') .
+      '</p>';
+  }
+
+  public static function address_street_number() {
+    print '<p>' .
+      t('Use together with Street Name and Street Number Suffix as an alternative for Street Address.') .
+      '</p>';
+  }
+
+  public static function address_street_unit() {
+    print '<p>' .
+      t('Use together with Street Name and Street Number as an alternative for Street Address.') .
+      '</p>';
+  }
+
   public static function address_master_id() {
     print '<p>' .
       t('When selected, will hide fields for this address and use those of the other contact.') .


### PR DESCRIPTION
Needed for integration with postal code database.

This way it the street name, number and unit can be auto-filled when the address already is set,
and the street name and city can be autofilled (with external script) when the user fills in postal code and street number.
