### PR TITLE
When generating case-link token use the first array index for contact_id instead of hardcoded index 1

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -916,14 +916,13 @@ function _webform_civicrm_getCaseContactID($caseID) {
   civicrm_initialize();
 
   $caseEntity = civicrm_api3('Case', 'get', array(
-    'sequential' => 1,
     'return' => array('contact_id'),
     'id' => $caseID,
   ));
 
   $caseContactID = WEBFORM_CIVICRM_DEFAULT_CONTACT_ID;
-  if (!empty($caseEntity['values'][0]['contact_id'][1])) {
-    $caseContactID = $caseEntity['values'][0]['contact_id'][1];
+  if ((count($caseEntity['values'][$caseID]['contact_id']) > 0) && !empty(reset($caseEntity['values'][$caseID]['contact_id']))) {
+    $caseContactID = reset($caseEntity['values'][$caseID]['contact_id']);
   }
 
   return $caseContactID;


### PR DESCRIPTION
For historical reasons the Case API returns a 1-based array for contact_id/client_id.  This is the only bit of code in webform_civicrm that relies on the first index being 1 instead of just using the first element in the array.

This PR removes that hardcoding without any functional changes but means that the code would continue working if the array indexing changed as we only care about the first element of the array, not what (meaningless) index it has.