### PR TITLE
Issue #2948459: address fields don't update...

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -808,7 +808,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               continue;
             }
             // Reset calculated values when updating an address
-            $params['master_id'] = $params['geo_code_1'] = $params['geo_code_2'] = 'null';
+            $params['master_id'] = $params['geo_code_1'] = $params['geo_code_2'] = NULL;
           }
           $params['contact_id'] = $cid;
           if (!empty($existing[$i])) {


### PR DESCRIPTION
This fixes the issue of address fields that won't update with CiviCRM 4.7.28. Maybe some other changes are still required regarding this module's usage of null values. 

However, it seems that core is set to also accept `'null'` strings soon along with `NULL` values... 

* https://www.drupal.org/project/webform_civicrm/issues/2948459
* https://issues.civicrm.org/jira/browse/CRM-21474
* https://github.com/civicrm/civicrm-core/pull/11324