### PR TITLE
Fix possible bug in address handling

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1292,6 +1292,7 @@ function wf_crm_get_fields($var = 'fields') {
     while ($dao->fetch()) {
       if (isset($custom_types[$dao->html_type])) {
         $set = 'cg' . $dao->custom_group_id;
+        // Place these custom fields directly into their entity
         if ($dao->entity_type == 'address' || $dao->entity_type == 'relationship' || $dao->entity_type == 'membership') {
           $set = $dao->entity_type;
         }
@@ -1665,16 +1666,13 @@ function wf_crm_location_fields() {
  * @return array
  */
 function wf_crm_address_fields() {
-  return array(
-    'street_address',
-    'street_name',
-    'street_number',
-    'street_unit',
-    'city',
-    'state_province_id',
-    'country_id',
-    'postal_code'
-  );
+  $fields = array();
+  foreach (array_keys(wf_crm_get_fields()) as $key) {
+    if (strpos($key, 'address') === 0) {
+      $fields[] = substr($key, 8);
+    }
+  }
+  return $fields;
 }
 
 /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2371,7 +2371,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   }
 
   /**
-   * reorder submitted location values according to existing location values
+   * Reorder submitted location values according to existing location values
    *
    * @param array $submittedLocationValues
    * @param array $existingLocationValues
@@ -2406,14 +2406,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
       else {
         foreach (wf_crm_address_fields() as $field)  {
-          $reorderedArray[$index][$field] = isset($eValue[$field]) ? $eValue[$field] : '';
-        }
-        // handle supplemental addresses
-        $subAddressIndex = 1;
-        $subAddField = 'supplemental_address_' . $subAddressIndex;
-        while(isset($eValue[$subAddField]))  {
-          $reorderedArray[$index][$subAddField] = $eValue[$subAddField];
-          $subAddField = 'supplemental_address_' . ++$subAddressIndex;
+          if ($field != 'location_type_id') {
+            $reorderedArray[$index][$field] = isset($eValue[$field]) ? $eValue[$field] : '';
+          }
         }
       }
 
@@ -2433,19 +2428,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
           else {
             foreach (wf_crm_address_fields() as $field)  {
-              if (isset($sValue[$field]))  {
+              if (isset($sValue[$field]) && $field != 'location_type_id')  {
                 $reorderedArray[$index][$field] = $sValue[$field];
               }
             }
-            // handle supplemental addresses
-            $subAddressIndex = 1;
-            $subAddField = 'supplemental_address_' . $subAddressIndex;
-            while(isset($sValue[$subAddField]))  {
-              $reorderedArray[$index][$subAddField] = $sValue[$subAddField];
-              $subAddField = 'supplemental_address_' . ++$subAddressIndex;
-            }
           }
-           unset($submittedLocationValues[$key]);
+          unset($submittedLocationValues[$key]);
         }
       }
       $index++;


### PR DESCRIPTION
When I was recently reading the code it appeared that there was an oversight. A function named `wf_crm_address_fields()` was returning some but not all address fields, it omitted e.g. postal code suffix as well as all custom fields. But according to the discussion in #43 address fields will not save properly without it. I'm not exactly sure how to reproduce the error but want to flag this up with a possible fix.