### PR TITLE
Fix Editing of Custom Groups Used By Webforms

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -427,6 +427,11 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_group($dao) {
           . "AND form_key LIKE '%cg{$customGroupId}_fieldset'");
   $fieldsets = $dbResource->fetchAll(PDO::FETCH_ASSOC);
 
+  // check if dao fields have been fetched
+  if (!$dao->title) {
+    $dao->find(TRUE);
+  }
+
   // run only if the title of the custom group has changed in civicrm
   if ($fieldsets[0]['name'] != $dao->title) {
     foreach ($fieldsets as $field_info) {


### PR DESCRIPTION
## Overview

When editing a custom group used by a webform an error is thrown.

## Before

After creating a custom group (id 18), enabling CiviCRM processing and adding that custom group to a webform this call:

```
civicrm_api3('CustomGroup', 'create', array(
  'id' => 18,
  'weight' => 12,
));
```

will result in 

```
{

    "is_error": 1,
    "error_message": "SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'name' cannot be null"
}
```

Because the properties are not loaded in the `$dao` object we are updating, meaning it tries to set `name` to null.

## After

If the `$dao` title is not loaded we load it from the database. The call will successfully update the Custom Group. 