### PR TITLE
Avoid warning from 'createmode' when filling data from submission

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2155,8 +2155,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // If value is null then it was hidden by a webform conditional rule - skip it
       if ($val !== NULL && $val !== array(NULL)) {
         list( , $c, $ent, $n, $table, $name) = explode('_', $field_key, 6);
-        // Fieldsets and existing contact fields are not strictly CiviCRM fields, so ignore
-        if ($name === 'existing' || $name === 'fieldset') {
+        // The following are not strictly CiviCRM fields, so ignore
+        if (in_array($name, array('existing', 'fieldset', 'createmode'))) {
           continue;
         }
         // Check to see if configured to ignore hidden field value(s)


### PR DESCRIPTION
## Overview

When filling a webform with some linked custom data with `create_mode` set to 1 it is possible to see an warning about missing indices.

## Before

If you had a form with `create_mode` set to 1 (create only) then `wf_crm_webform_postprocess::fillDataFromSubmission` would produce a warning. This warning would only result if you had a field with `fid` of 1 (which matches the create mode) and this field had a non-null value set.

```php
    /**
    * $field_key will be 'cg<custom_group_id>_createmode', $fid will be 1
    * this is not really a $fid, but the value for createmode
    */
    foreach ($this->enabled as $field_key => $fid) {
      // $val is actually the value for $fid 1
      $val = $this->submissionValue($fid);
      if ($val !== NULL && $val !== array(NULL)) {
        // the inner conditional will be executed like a normal field with $fid of 1
```

This produces a warning later when it tries to fetch field info for the `createmode` field, which doesn't exist

```php
list( , $c, $ent, $n, $table, $name) = explode('_', $field_key, 6);
$field = $this->all_fields[$table . '_' . $name];
```

Which will display this error (one line for each createmode)

![image](https://user-images.githubusercontent.com/6374064/37961562-8eff6f9a-31b0-11e8-9d49-18ec4e225e02.png)

## After

`createmode` is added to the ignore list, along with fieldset and existing contact. Even if a value is set for the field with fid 1, the processing to fetch the value is not executed and no warning is produced.