### PR TITLE
try getfields for address fields rather than hardcoding them and add …

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1665,16 +1665,34 @@ function wf_crm_location_fields() {
  * @return array
  */
 function wf_crm_address_fields() {
-  return array(
-    'street_address',
-    'street_name',
-    'street_number',
-    'street_unit',
-    'city',
-    'state_province_id',
-    'country_id',
-    'postal_code'
-  );
+  if ( ! $addrfields = &drupal_static('wf_crm_address_fields') ) {
+    try{
+      $result = civicrm_api3('Address', 'getfields', array(
+        'api_action' => "",
+      ));
+    }
+    catch (CiviCRM_API3_Exception $e) {
+      // Handle error here.
+      $addrfields = array(
+        'street_address',
+        'street_name',
+        'street_number',
+        'street_unit',
+        'city',
+        'state_province_id',
+        'country_id',
+        'postal_code'
+      );
+    }
+    if ( empty($result['is_error']) && ! empty($result['count'] ) ) {
+      foreach ($result['values'] as $param => $value ) {
+        $addrfields[] = $param;
+      }
+    }
+    unset($addrfields['location_type_id']);
+    unset($addrfields['id']);
+  }
+  return $addrfields;
 }
 
 /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2407,12 +2407,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $reorderedArray[$index]['location_type_id'] = $existingLocationTypeId;
       }
 
-      if (!empty($eValue[$entity])) {
+      if (isset($eValue[$entity])) {
         $reorderedArray[$index][$entity] = $eValue[$entity];
       }
 
       // address field contain many sub fields and should be handled differently
-      if ($entity != 'address')  {
+      if ($entity != 'address' )  {
         $submittedLocationValues = self::unsetEmptyValueIndexes($submittedLocationValues, $entity);
         $reorderedArray[$index][$entity] = wf_crm_aval($eValue, $entity);
       }
@@ -2441,20 +2441,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
           // address field contain many sub fields and should be handled differently
           if ($entity != 'address')  {
-            $reorderedArray[$index][$entity] = $sValue[$entity];
+            foreach($sValue as $sValueKey => $sValueValue ) {
+              $reorderedArray[$index][$entity] = $sValue[$entity];
+              if ( !array_key_exists($sValueKey, $reorderedArray[$index]) ) {
+                $reorderedArray[$index][$sValueKey] = $sValueValue;
+              }
+            }
           }
           else {
             foreach (wf_crm_address_fields() as $field)  {
               if (isset($sValue[$field]))  {
                 $reorderedArray[$index][$field] = $sValue[$field];
+              } else {
+                // the value has not been submitted so we do not want to include it.
+                unset($reorderedArray[$index][$field]);
               }
-            }
-            // handle supplemental addresses
-            $subAddressIndex = 1;
-            $subAddField = 'supplemental_address_' . $subAddressIndex;
-            while(isset($sValue[$subAddField]))  {
-              $reorderedArray[$index][$subAddField] = $sValue[$subAddField];
-              $subAddField = 'supplemental_address_' . ++$subAddressIndex;
             }
           }
            unset($submittedLocationValues[$key]);


### PR DESCRIPTION
The hard coded fields in wf_crm_address_fields does not account for address custom fields. If we change that function to try and use the api getfields method first, list of all address subfields can be obtained, including the supplemental fields.  If the getfields call fails, then revert to the default hardcoded fields. Whatever the fields turn out to be, using drupal_static ensures that the api call to getfields is only called once per request.

When updating a phone with an extension, if we clear out, or change the extension, it is not submitted for update. The module does a good job with adding the correct field parameter to the submitted values so changing the loop to add all of the submitted values allows for other location entity custom fields and the phone extension to be updated.