### PR TITLE
Ensure that line item amounts are computed correctly when  paying with installments

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1496,11 +1496,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (isset($this->enabled[$fid]) || $this->getData($fid) > 0) {
       $totalAmount = $this->getData($fid);
-
       $unitPrice = $this->calculateSingleInstallmentAmount($totalAmount);
 
-      $installmentPercentage = $this->calculateSingleInstallmentPercentage($unitPrice, $totalAmount);
-      $label = wf_crm_aval($this->node->webform['components'], $this->enabled[$fid] . ':name', t('Contribution')) . ' ' . $installmentPercentage;
+      $label = wf_crm_aval($this->node->webform['components'], $this->enabled[$fid] . ':name', t('Contribution'));
 
       $this->line_items[] = array(
         'qty' => 1,
@@ -1531,8 +1529,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             if ($price) {
               $unitPrice = $this->calculateSingleInstallmentAmount($price);
 
-              $installmentPercentage = $this->calculateSingleInstallmentPercentage($unitPrice, $price);
-              $label = $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]) . ' ' . $installmentPercentage;
+              $label = $this->getMembershipTypeField($type, 'name') . ': ' . wf_crm_display_name($this->existing_contacts[$c]);
 
               $this->line_items[] = array(
                 'qty' => $item['num_terms'],
@@ -1583,15 +1580,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     return $installmentAmount;
-  }
-
-  private function calculateSingleInstallmentPercentage($installmentAmount, $totalAmount) {
-    if ($installmentAmount == $totalAmount) {
-      return '';
-    }
-
-    $percentage = '(' . round(($installmentAmount / $totalAmount) * 100, 1, PHP_ROUND_HALF_DOWN) . '%)';
-    return $percentage;
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1495,11 +1495,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Contribution
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (isset($this->enabled[$fid]) || $this->getData($fid) > 0) {
+      $totalAmount = $this->getData($fid);
+
+      $unitPrice = $this->calculateSingleInstallmentAmount($totalAmount);
+
+      $installmentPercentage = $this->calculateSingleInstallmentPercentage($unitPrice, $totalAmount);
+      $label = wf_crm_aval($this->node->webform['components'], $this->enabled[$fid] . ':name', t('Contribution')) . ' ' . $installmentPercentage;
+
       $this->line_items[] = array(
         'qty' => 1,
-        'unit_price' => $this->getData($fid),
+        'unit_price' => $unitPrice,
         'financial_type_id' => $this->contribution_page['financial_type_id'],
-        'label' => wf_crm_aval($this->node->webform['components'], $this->enabled[$fid] . ':name', t('Contribution')),
+        'label' => $label,
         'element' => 'civicrm_1_contribution_1',
         'entity_table' => 'civicrm_contribution',
       );
@@ -1522,11 +1529,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             }
 
             if ($price) {
+              $unitPrice = $this->calculateSingleInstallmentAmount($price);
+
+              $installmentPercentage = $this->calculateSingleInstallmentPercentage($unitPrice, $price);
+              $label = $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]) . ' ' . $installmentPercentage;
+
               $this->line_items[] = array(
                 'qty' => $item['num_terms'],
-                'unit_price' => $price,
+                'unit_price' => $unitPrice,
                 'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
-                'label' => $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]),
+                'label' => $label,
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
               );
@@ -1558,6 +1570,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
     return round($this->totalContribution, 2);
+  }
+
+
+  private function calculateSingleInstallmentAmount($totalAmount) {
+    $installmentAmount = $totalAmount;
+
+    $installmentsFieldID = 'civicrm_1_contribution_1_contribution_installments';
+    if (isset($this->enabled[$installmentsFieldID]) && $this->getData($installmentsFieldID) > 1) {
+      $installmentsCount = $this->getData($installmentsFieldID);
+      $installmentAmount = floor(($totalAmount / $installmentsCount) * 100) / 100;
+    }
+
+    return $installmentAmount;
+  }
+
+  private function calculateSingleInstallmentPercentage($installmentAmount, $totalAmount) {
+    if ($installmentAmount == $totalAmount) {
+      return '';
+    }
+
+    $percentage = '(' . round(($installmentAmount / $totalAmount) * 100, 1, PHP_ROUND_HALF_DOWN) . '%)';
+    return $percentage;
   }
 
   /**
@@ -1773,21 +1807,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Generate recurring contribution and transact the first one
    */
   private function contributionRecur($contributionParams, $paymentType = 'live') {
-    $installments = $contributionParams['installments'];
-    if ($installments != 0) {
-      // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
-      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($installments - 1);
-    }
-
     // Create Params for Creating the Recurring Contribution Series and Create it
     $contributionRecurParams = array(
       'sequential' => 1,
       'contact_id' => $contributionParams['contact_id'],
       'frequency_interval' => wf_crm_aval($contributionParams, 'frequency_interval', 1),
       'frequency_unit' => wf_crm_aval($contributionParams, 'frequency_unit', 'month'),
-      'installments' => $installments,
-      'amount' => $contributionRecurAmount,
+      'installments' => $contributionParams['installments'],
+      'amount' => $contributionParams['total_amount'],
       'contribution_status_id' => 5,
       'currency' => $contributionParams['currency'],
       'payment_processor_id' =>  $contributionParams['payment_processor_id'],
@@ -1801,7 +1828,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $resultRecur = wf_civicrm_api('ContributionRecur', 'create', $contributionRecurParams);
 
     // Run the Transaction - and Create the Contribution Record - relay Recurring Series information in addition to the already existing Params [and re-key where needed]; at times two keys are required
-    $contributionParams['total_amount'] = $contributionFirstAmount;
     $additionalParams = array(
       'contribution_recur_id' => $resultRecur['id'],
       'contributionRecurID' => $resultRecur['id'],

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -214,6 +214,14 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       else {
         $js_vars['paymentProcessor'] = $this->getData($fid);
       }
+
+      $installmentsFieldID = 'civicrm_1_contribution_1_contribution_installments';
+      if (!empty($this->enabled[$installmentsFieldID])) {
+        $js_vars['installmentsCount'] = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsFieldID]);
+      }
+      else {
+        $js_vars['installmentsCount'] = $this->getData($installmentsFieldID);
+      }
     }
     if ($js_vars) {
       $this->form['#attached']['js'][] = array(
@@ -600,6 +608,9 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       'id' => 'wf-crm-billing-total',
       'data-amount' => $total,
     );
+
+    $this->generateInstallmentsSummaryRow($rows);
+
     return theme('table', array(
       'sticky' => FALSE,
       'caption' => $this->contribution_page['title'],
@@ -607,6 +618,40 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       'rows' => $rows,
       'attributes' => array('id' => "wf-crm-billing-items"),
     ));
+  }
+
+  private function generateInstallmentsSummaryRow(&$rows) {
+    $installmentsFieldID = 'civicrm_1_contribution_1_contribution_installments';
+    if (!empty($this->enabled[$installmentsFieldID])) {
+      $installmentsCount = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsFieldID]);
+    }
+    else {
+      $installmentsCount = $this->getData($installmentsFieldID);
+    }
+
+    if ($installmentsCount > 1) {
+      $installmentsIntervalFieldID = 'civicrm_1_contribution_1_contribution_frequency_interval';
+      if (!empty($this->enabled[$installmentsIntervalFieldID])) {
+        $installmentsInterval = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsIntervalFieldID]);
+      }
+      else {
+        $installmentsInterval = $this->getData($installmentsIntervalFieldID);
+      }
+
+      $installmentsUnitFieldID = 'civicrm_1_contribution_1_contribution_frequency_unit';
+      if (!empty($this->enabled[$installmentsUnitFieldID])) {
+        $installmentsUnit = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsUnitFieldID]);
+      }
+      else {
+        $installmentsUnit = $this->getData($installmentsUnitFieldID);
+      }
+
+      $rows[] = array(
+        'data' => array(t("The above amount will be collected every {$installmentsInterval} {$installmentsUnit}(s) for {$installmentsCount} {$installmentsUnit}(s)"), ''),
+        'id' => 'wf-crm-billing-installments-message',
+        'data-amount' => '',
+      );
+    }
   }
 
   /**

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -609,8 +609,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       'data-amount' => $total,
     );
 
-    $this->generateInstallmentsSummaryRow($rows);
-
     return theme('table', array(
       'sticky' => FALSE,
       'caption' => $this->contribution_page['title'],
@@ -618,40 +616,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       'rows' => $rows,
       'attributes' => array('id' => "wf-crm-billing-items"),
     ));
-  }
-
-  private function generateInstallmentsSummaryRow(&$rows) {
-    $installmentsFieldID = 'civicrm_1_contribution_1_contribution_installments';
-    if (!empty($this->enabled[$installmentsFieldID])) {
-      $installmentsCount = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsFieldID]);
-    }
-    else {
-      $installmentsCount = $this->getData($installmentsFieldID);
-    }
-
-    if ($installmentsCount > 1) {
-      $installmentsIntervalFieldID = 'civicrm_1_contribution_1_contribution_frequency_interval';
-      if (!empty($this->enabled[$installmentsIntervalFieldID])) {
-        $installmentsInterval = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsIntervalFieldID]);
-      }
-      else {
-        $installmentsInterval = $this->getData($installmentsIntervalFieldID);
-      }
-
-      $installmentsUnitFieldID = 'civicrm_1_contribution_1_contribution_frequency_unit';
-      if (!empty($this->enabled[$installmentsUnitFieldID])) {
-        $installmentsUnit = wf_crm_aval($this->form_state, 'storage:submitted:' . $this->enabled[$installmentsUnitFieldID]);
-      }
-      else {
-        $installmentsUnit = $this->getData($installmentsUnitFieldID);
-      }
-
-      $rows[] = array(
-        'data' => array(t("The above amount will be collected every {$installmentsInterval} {$installmentsUnit}(s) for {$installmentsCount} {$installmentsUnit}(s)"), ''),
-        'id' => 'wf-crm-billing-installments-message',
-        'data-amount' => '',
-      );
-    }
   }
 
   /**

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -77,7 +77,6 @@ cj(function($) {
         taxPara = 1 + (tax / 100);
       }
 
-      $('td', $lineItem).html(label);
       $('td+td', $lineItem).html(CRM.formatMoney(amount * taxPara));
       $lineItem.data('amount', amount * taxPara);
     }
@@ -102,9 +101,8 @@ cj(function($) {
   function calculateContributionAmount() {
     var totalAmount = getFieldAmount('civicrm_1_contribution_1_contribution_total_amount');
     var listedAmount = calculateSingleInstallmentAmount(totalAmount);
-    var amountPercentage = calculateSingleInstallmentPercentage(listedAmount, totalAmount);
 
-    var label = $contributionAmount.closest('div.webform-component').find('label').html() + ' ' + amountPercentage || Drupal.t('Contribution') + ' ' + amountPercentage;
+    var label = $contributionAmount.closest('div.webform-component').find('label').html() || Drupal.t('Contribution');
     updateLineItem('civicrm_1_contribution_1', listedAmount, label);
   }
 
@@ -116,14 +114,6 @@ cj(function($) {
     }
 
     return amount;
-  }
-
-  function calculateSingleInstallmentPercentage(installmentAmount, totalAmount) {
-    if (installmentAmount == totalAmount) {
-      return '';
-    }
-
-    return '(' + ((installmentAmount / totalAmount) * 100).toFixed(1) + '%)';
   }
 
   if ($contributionAmount.length) {

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -76,6 +76,8 @@ cj(function($) {
       if (tax && tax !== '0') {
         taxPara = 1 + (tax / 100);
       }
+
+      $('td', $lineItem).html(label);
       $('td+td', $lineItem).html(CRM.formatMoney(amount * taxPara));
       $lineItem.data('amount', amount * taxPara);
     }
@@ -98,9 +100,30 @@ cj(function($) {
   }
 
   function calculateContributionAmount() {
-    var amount = getFieldAmount('civicrm_1_contribution_1_contribution_total_amount');
-    var label = $contributionAmount.closest('div.webform-component').find('label').html() || Drupal.t('Contribution');
-    updateLineItem('civicrm_1_contribution_1', amount, label);
+    var totalAmount = getFieldAmount('civicrm_1_contribution_1_contribution_total_amount');
+    var listedAmount = calculateSingleInstallmentAmount(totalAmount);
+    var amountPercentage = calculateSingleInstallmentPercentage(listedAmount, totalAmount);
+
+    var label = $contributionAmount.closest('div.webform-component').find('label').html() + ' ' + amountPercentage || Drupal.t('Contribution') + ' ' + amountPercentage;
+    updateLineItem('civicrm_1_contribution_1', listedAmount, label);
+  }
+
+  function calculateSingleInstallmentAmount(totalAmount) {
+    var amount = totalAmount;
+
+    if (setting.installmentsCount > 1) {
+      amount = totalAmount / setting.installmentsCount;
+    }
+
+    return amount;
+  }
+
+  function calculateSingleInstallmentPercentage(installmentAmount, totalAmount) {
+    if (installmentAmount == totalAmount) {
+      return '';
+    }
+
+    return '(' + ((installmentAmount / totalAmount) * 100).toFixed(1) + '%)';
   }
 
   if ($contributionAmount.length) {


### PR DESCRIPTION
Currently and for example when you do a payment for a $120 worth membership and a $60 add-on in 12 installments. The line items generated will look like: 


<img width="775" alt="2018-04-09 01_50_33-pp test _ dmaster8" src="https://user-images.githubusercontent.com/6275540/38473458-0771b25c-3b99-11e8-97d9-e612b8f28aaa.png">

<img width="707" alt="2018-04-09 01_56_59-t119 aa com t119 aa com _ dmaster8" src="https://user-images.githubusercontent.com/6275540/38473487-6102d7d8-3b99-11e8-9e6e-22be4ee3feae.png">

Though the contribution and the recurring contribution records will be  : 

<img width="757" alt="2018-04-09 01_56_47-t119 aa com t119 aa com _ dmaster8" src="https://user-images.githubusercontent.com/6275540/38473492-73210af2-3b99-11e8-84cc-6ac4197af9e0.png">

So as you can see, the line items amounts are not correct.


This PR ensure that the line items amounts get generated correctly as you can see below : 

<img width="785" alt="2018-04-09 02_02_42-pp test _ dmaster8" src="https://user-images.githubusercontent.com/6275540/38473538-28b9d196-3b9a-11e8-835f-dbf769ce7bd6.png">

<img width="666" alt="2018-04-09 02_03_48-io91 a com io91 a com _ dmaster8" src="https://user-images.githubusercontent.com/6275540/38473546-4953b2d2-3b9a-11e8-8d98-217aa7f0eac3.png">


as you can also see, we add the percentage of the amount to the line item label too.




------------ 

Update : The percentage calculation that you see in the images above and added to each line item label is not longer happen.