### PR TITLE
Ensure the civicrm_financial_item records get created correctly

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2123,8 +2123,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
       $lineItemRecord = json_decode(json_encode($item), FALSE);
       // Add financial_item and entity_financial_trxn
-      $taxTrxnID = !empty($lineItemRecord->tax_amount);
-      CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult, $taxTrxnID);
+      // hence that we call CRM_Financial_BAO_FinancialItem::add() twice,
+      // once to create the line item 'total amount' financial_item record and the 2nd
+      // one to create the line item 'tax amount' financial_item  record.
+      CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult);
+      if (!empty($lineItemRecord->tax_amount)) {
+        CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult, TRUE);
+      }
+      
       // Create participant/membership payment records
       if (isset($item['membership_id']) || isset($item['participant_id'])) {
         $type = isset($item['participant_id']) ? 'participant' : 'membership';


### PR DESCRIPTION
Before
----------------------------------------
For line items with tax amounts, two civicrm_financial_item records should be created, one for the line item total_amount and the other for the tax amount. Currently only one record for the tax amount get created.



After
----------------------------------------
IF a line item has a tax amount, then now two civicrm_financial_item records get created one for the total_amount and the other for the tax amount.

Example
----------------------------------------
If for example we configured the webform to create two memberships for contact 1, where one membership has tax on it where the other not, here is how currently it will look like in line items view page : 

<img width="802" alt="2018-04-27 12_42_17-pp test _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39359241-241fb4d6-4a11-11e8-93f6-a36da04787f9.png">

which is correct.

After submitting the webform, the following two line items will get created : 

<img width="650" alt="2018-04-27 13_48_01-_ untitled dmaster8ci_ovi8l buildkit_2 - query - navicat premium" src="https://user-images.githubusercontent.com/6275540/39359263-3a1a0bd8-4a11-11e8-912a-07ba97393e8c.png">

which is also correct.

But if we look at civicrm_financial_item table then this is the only created records : 

<img width="812" alt="2018-04-27 13_48_24-_ untitled dmaster8ci_ovi8l buildkit_2 - query - navicat premium" src="https://user-images.githubusercontent.com/6275540/39359273-4dc89d02-4a11-11e8-8813-1a9da91c7289.png">


as you can see only two civicrm_financial_item records are created, but 3 records should be created instead.


Here is how things looks like after applying this patch : 

<img width="572" alt="2018-04-27 13_53_28-_ untitled dmaster8ci_ovi8l buildkit_2 - query - navicat premium" src="https://user-images.githubusercontent.com/6275540/39359390-b1885d8c-4a11-11e8-8435-03185268f9e2.png">


<img width="855" alt="2018-04-27 13_53_41-_ untitled dmaster8ci_ovi8l buildkit_2 - query - navicat premium" src="https://user-images.githubusercontent.com/6275540/39359394-b464ba8c-4a11-11e8-874b-15d7904ee7e5.png">


as u can see, the line items are still the same which is correct, but now 3 civicrm_financial_item  records will be created.



Technical Details
----------------------------------------
This regressions was introucded in this PR : https://github.com/colemanw/webform_civicrm/pull/105 , in this line https://github.com/colemanw/webform_civicrm/pull/105/files#diff-59be2e079a691088e15ab3a80e0640a0L2054

this code : 

```php
$result = CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult);
if (!is_null($this->tax_rate)) {
  $result = CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult, TRUE);
}
```

was replaced by this one : 

```php
$taxTrxnID = !empty($lineItemRecord->tax_amount);
CRM_Financial_BAO_FinancialItem::add($lineItemRecord, $contributionResult, $taxTrxnID);
```

which means if the line item has a tax amount, true will be passed as a 3rd parameter to CRM_Financial_BAO_FinancialItem::add() method which means only the tax civicrm_financial_item record will be created. I reverted the code to how it was before where there are two calls to CRM_Financial_BAO_FinancialItem::add()  method, one to create the civicrm_financial_item  record for the total_amount and the other for the tax amount.
