### PR TITLE
Adding auto-renewal support when buying memberships

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,6 +77,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'auto_renew') {
+      $ret = array(1 => t('Yes'), 0 => t('No'));
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = array('field' => $name, 'context' => 'create');
@@ -1151,6 +1154,12 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_end_date'] = array(
         'name' => t('End Date'),
         'type' => 'date',
+      );
+      $fields['membership_auto_renew'] = array(
+        'name' => t('Auto-renew Membership?'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
       );
     }
     // Add campaign fields

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1896,6 +1896,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if ($autoRenewMembership) {
         $params['installments'] = 'null';
         $params['auto_renew'] = 1;
+
+        if (empty($params['frequency_unit']) || empty($params['frequency_interval'])) {
+          $minimumFrequencyData =  $this->calculateMinimumFrequencyUnitAndInterval();
+          $params['frequency_unit'] = $minimumFrequencyData['unit'];
+          $params['frequency_interval'] = $minimumFrequencyData['interval'];
+        }
+
         $createRecurringContribution = TRUE;
       }
 
@@ -1913,6 +1920,52 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $this->ent['contribution'][1]['id'] = $result['id'];
+  }
+
+  /**
+   * If the membership is paid using PriceSet
+   * that allows the creation of more than
+   * one membership to be associated with
+   * the same recurring contribution, Then
+   * we use this method to determine the membership
+   * with the type that has the minimum frequency
+   * unit and interval so we can use it to set
+   * the recurring contribution unit and interval.
+   *
+   * @return array
+   *   With two keys, 'unit' and 'interval'
+   */
+  private function calculateMinimumFrequencyUnitAndInterval() {
+    $frequencyUnitOrderMap = [
+      'day'   => 1,
+      'week'  => 2,
+      'month' => 3,
+      'year'  => 4,
+    ];
+    $frequencyUnitsList= [];
+    $frequencyIntervalsList= [];
+
+    $allMembershipTypeDetails = civicrm_api3('MembershipType', 'get', array(
+      'return' => array('duration_unit', 'duration_interval'),
+      'options' => array('limit' => 0),
+    ))['values'];
+
+    $membershipsToBeCreatedTypes = [];
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if ($membership['auto_renew']) {
+          $membershipsToBeCreatedTypes[] = $membership['membership_type_id'];
+        }
+      }
+    }
+
+    foreach($membershipsToBeCreatedTypes as $membershipTypeID) {
+      $unitName = $allMembershipTypeDetails[$membershipTypeID]['duration_unit'];
+      $frequencyUnitsList[] = $frequencyUnitOrderMap[$unitName];
+      $frequencyIntervalsList[] = $allMembershipTypeDetails[$membershipTypeID]['duration_interval'];
+    }
+    array_multisort($frequencyUnitsList, $frequencyIntervalsList);
+    return ['unit' => array_search($frequencyUnitsList[0], $frequencyUnitOrderMap), 'interval' => $frequencyIntervalsList[0]];
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1184,6 +1184,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
+      // if the membership is to be auto-renewed, we set its related recurring contribution ID
+      if ($params['auto_renew']) {
+        $contributionID = $this->ent['contribution'][1]['id'];
+        $contribution = wf_civicrm_api('Contribution', 'get', array(
+            'sequential' => 1,
+            'id' => $contributionID,
+            'return' => array('contribution_recur_id'),
+          )
+        );
+        if (!empty($contribution['values'][0]['contribution_recur_id'])) {
+          $params['contribution_recur_id'] = $contribution['values'][0]['contribution_recur_id'];
+        }
+      }
+      unset($params['auto_renew']);
+
       $result = wf_civicrm_api('membership', 'create', $params);
 
       if (!empty($result['id'])) {
@@ -1774,6 +1789,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    */
   private function contributionRecur($contributionParams, $paymentType = 'live') {
     $installments = $contributionParams['installments'];
+    $contributionRecurAmount = $contributionParams['total_amount'];
+    $contributionFirstAmount = $contributionParams['total_amount'];
     if ($installments != 0) {
       // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
       $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
@@ -1792,6 +1809,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'currency' => $contributionParams['currency'],
       'payment_processor_id' =>  $contributionParams['payment_processor_id'],
       'financial_type_id' =>  $contributionParams['financial_type_id'],
+      'auto_renew' =>  !empty($contributionParams['auto_renew']) ? 1 : 0,
     );
 
     if(empty($contributionParams['payment_processor_id'])) {
@@ -1863,9 +1881,31 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
 
-    $numInstallments = wf_crm_aval($params, 'installments', 1, TRUE);
-    $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments > 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    $autoRenewMembership = FALSE;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if ($membership['auto_renew']) {
+          $autoRenewMembership = TRUE;
+        }
+      }
+    }
+
+    $installmentsCount = wf_crm_aval($params, 'installments', 1, TRUE);
+    $createRecurringContribution = FALSE;
+    if ($this->contributionIsPayLater) {
+      if ($autoRenewMembership) {
+        $params['installments'] = 'null';
+        $params['auto_renew'] = 1;
+        $createRecurringContribution = TRUE;
+      }
+
+      if ($installmentsCount > 1) {
+        $params['installments'] = $installmentsCount;
+        $createRecurringContribution = TRUE;
+      }
+    }
+
+    if ($createRecurringContribution) {
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {


### PR DESCRIPTION
Before
----------------------------------------
This module currently does not provide a way to auto-renew memberships.

After
----------------------------------------
The ability to set a membership to be auto-renewed is now available, you can either set the membership to be auto-renewed automatically, or not to be auto-renewed (which is the default option), or to allow the user to selected whither to set the membership to be auto renewed or not as u can see below : 

<img width="600" alt="2018-04-27 13_59_31-pp test _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39359592-81f5362a-4a12-11e8-8972-80229af5adbb.png">


If the membership is set to be auto-renewed automatically, or if the end user selected the membership to be auto-renewed then a recurring contribution record will be created with auto_renew field set to TRUE, and the created memberships will have their contribution_recur_id field refer to the newly created recurring contribution ID.

Here is an example with one/no installments : 

![111111](https://user-images.githubusercontent.com/6275540/39359777-4c085f96-4a13-11e8-9e7e-9d4d83e1cbae.gif)


![2222222222222](https://user-images.githubusercontent.com/6275540/39359784-4ec6132c-4a13-11e8-8d98-71687733f03a.gif)



And here is another one with 3 installments : 

![3333333333](https://user-images.githubusercontent.com/6275540/39359868-a8a7b8e6-4a13-11e8-8340-769db4a3f081.gif)

![44444444](https://user-images.githubusercontent.com/6275540/39359874-abbacfd2-4a13-11e8-89a1-351514cc9c15.gif)


