### PR TITLE
Use payment processor payment method for deferred payment

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1858,8 +1858,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
       if (!empty($params['payment_processor_id']) && $this->contribution_page['is_monetary']) {
-        $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
-        $params['payment_instrument_id'] = key($defaultPaymentInstrument);
+        $paymentInstrumentValue = civicrm_api3('PaymentProcessor', 'getvalue', array(
+          'return' => 'payment_instrument_id',
+          'id' => $params['payment_processor_id'],
+        ));
+        $paymentInstrumentName = CRM_Core_PseudoConstant::getName('CRM_Contribute_BAO_Contribution', 'payment_instrument_id', $paymentInstrumentValue);
+        $params['payment_instrument_id'] = $paymentInstrumentName;
       }
     }
 


### PR DESCRIPTION
Before
----------------------------------------
If you have a payment processor that uses the core **manual payment** class, and if the payment method for this payment processor is configured to be for example Cash or EFT or whatever, then generated contributtion after submitting the webform will always use the default payment method instead of the payment processor payment method.


For example we have here a payment processor that is using **manual payment** class and configured to use "EFT" payment method : 

<img width="723" alt="2018-04-27 17_33_19-" src="https://user-images.githubusercontent.com/6275540/39368277-110212de-4a31-11e8-8bd8-f29d64333c4d.png">


and the site default payment method is set "Check" : 

<img width="778" alt="2018-04-27 17_37_35-payment methods options _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39368317-251e24a6-4a31-11e8-9b65-995f7bdfdc4e.png">

After submitting a webform payment using this payment procrssoer, here is generated contribution : 

<img width="696" alt="2018-04-27 17_32_49-tt122121 aa com tt122121 aa com _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39368350-3ab7d0fa-4a31-11e8-892b-90f52a0ce2dd.png">


As u can see, it used the default site payment method instead of the payment processor payment method.



After
----------------------------------------

I changed the code to use the payment processor payment method instead  : 

<img width="730" alt="2018-04-27 17_34_01-" src="https://user-images.githubusercontent.com/6275540/39368389-5800f1f0-4a31-11e8-895d-623cc47f962e.png">

