### PR TITLE
Only create fieldsets for custom fields on contact entity

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1901,7 +1901,8 @@ class wf_crm_admin_form {
    */
   public static function addFieldset($c, &$field, &$enabled, $settings, $ent = 'contact', $allow_create = FALSE) {
     $type = in_array($ent, self::$fieldset_entities) ? $ent : 'contact';
-    if (strpos($field['form_key'], '_custom_')) {
+    // Custom fields are placed in fieldsets by group (for contact fields only)
+    if (strpos($field['form_key'], '_custom_') && $type == 'contact') {
       $sid = explode('_custom', $field['form_key']);
       $sid = $sid[0] . '_fieldset';
       $customGroupKey = explode('_', $field['form_key'])[4];


### PR DESCRIPTION
Overview
----------------------------------------
I noticed a bug where extra fieldsets were being created around custom fields. This fixes it.

Before
----------------------------------------
- Create a custom activity field.
- Create a webform with all the defaults.
- Add one activity to the form, and select the custom field, along with the activity subject
- The two activity fields will be in different fieldsets. This was never intended and makes the module a little confused about how to handle new fields being added later.

After
----------------------------------------
Fields will be placed in the same fieldset.
