### PR TITLE
Allow token to be a default value for contribution amount

### DIFF
--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -691,7 +691,11 @@ function wf_crm_cs_validate($form, &$form_state) {
 function wf_crm_money_validate($form, &$form_state) {
   $vals = $form_state['values'];
   if (!empty($vals['value']) && !is_numeric($vals['value']) && $vals['type'] != 'formula') {
-    form_error($form['value'], t('This is a CiviCRM currency field. @field must be a number.', array('@field' => $form['value']['#title'])));
+    //Check if default value is a token string.
+    $isTokenString = token_replace($vals['value'], array(), array('clear' => true));
+    if (!empty($isTokenString)) {
+      form_error($form['value'], t('This is a CiviCRM currency field. @field must be a number.', array('@field' => $form['value']['#title'])));
+    }
   }
   foreach (array('items', 'options') as $field) {
     if (!empty($vals['extra'][$field])) {


### PR DESCRIPTION
Overview
----------------------------------------
Allow token string to be a default value for contribution amount input field.

Before
----------------------------------------
Error when token string is passed to the default value of contribution amount.

![image](https://user-images.githubusercontent.com/5929648/39463772-5e60bd56-4d37-11e8-835f-245e9d4eb684.png)


After
----------------------------------------
Fixed. 

Technical Details
----------------------------------------
Validation function is modified to not error for token string using `token_replace` function.

Tested string value

  - `abc` - errors
 - `[current-page:query:civicrm_1_contribution_1_contribution_total_amount]` - works fine.

