### PR TITLE
Fixed 2948459

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -813,7 +813,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               continue;
             }
             // Reset calculated values when updating an address
-            $params['master_id'] = $params['geo_code_1'] = $params['geo_code_2'] = 'null';
+            $params['geo_code_1'] = $params['geo_code_2'] = 'null';
+            unset($params['master_id']); // we have to unset the master_id as 'null' does not always work (in a couple of civicrm versions).
           }
           $params['contact_id'] = $cid;
           if (!empty($existing[$i])) {


### PR DESCRIPTION
Overview
----------------------------------------
Bug fix of a bug which occured in certain versions of civicrm in combination with a certain version of webform_civicrm module. 

* CiviCRM version 4.7.29
* Webform_civicrm version 7.x-4.20

Before
----------------------------------------
When one adds a webform with address details on it (for example a webform where a new person is registered into civicrm) the address creation will fail. The contact will be created, email address will be created but no address on the contact record,
The failure could be found in the Drupal Log and the address submitted as well.

After
----------------------------------------
When one adds a webform with address details on it (for example a webform where a new person is registered into civicrm) the address creation will **succeed**. The contact will be created, email address will be created **and an address record is created**

Technical Details
----------------------------------------

This was caused by the fact that master_id was set to 'null' and that did not work in address create api. Unsetting the master_id parameter fixed it.
