### PR TITLE
Fix notice error on custom group create/update

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -433,7 +433,7 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_group($dao) {
   }
 
   // run only if the title of the custom group has changed in civicrm
-  if ($fieldsets[0]['name'] != $dao->title) {
+  if (!empty($fieldsets[0]) && $fieldsets[0]['name'] != $dao->title) {
     foreach ($fieldsets as $field_info) {
       $component = array();
       $component['name'] = $dao->title;


### PR DESCRIPTION
Overview
----------------------------------------
Notice fix after custom group is created/edited.

Before
----------------------------------------
Following notice error is displayed when a custom group in civicrm is edited/updated.

![image](https://user-images.githubusercontent.com/5929648/40413081-95efc408-5e92-11e8-8a23-55c31c5e0276.png)

After
----------------------------------------
Fixed.