### PR TITLE
Calculate line_items when using installments.

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1780,12 +1780,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
       $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($installments - 1);
       $salesTaxFirstAmount = $contributionParams['tax_amount'] - floor(($contributionParams['tax_amount'] / $installments) * 100) / 100 * ($installments - 1);
-    }
-    // Calculate the line_items for the contributionFirst:
-    foreach ($this->line_items as $key => $k) {
-      $this->line_items[$key]['unit_price'] = $k['unit_price'] / $installments;
-      $this->line_items[$key]['line_total'] = $k['line_total'] / $installments;
-      $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $installments;
+
+      // Calculate the line_items for the contributionFirst:
+      foreach ($this->line_items as $key => $k) {
+        $this->line_items[$key]['unit_price'] = $k['unit_price'] / $installments;
+        $this->line_items[$key]['line_total'] = $k['line_total'] / $installments;
+        $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $installments;
+      }
     }
 
     // Create Params for Creating the Recurring Contribution Series and Create it

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1779,6 +1779,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
       $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
       $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($installments - 1);
+      $salesTaxFirstAmount = $contributionParams['tax_amount'] - floor(($contributionParams['tax_amount'] / $installments) * 100) / 100 * ($installments - 1);
+    }
+    // Calculate the line_items for the contributionFirst:
+    foreach ($this->line_items as $key => $k) {
+      $this->line_items[$key]['unit_price'] = $k['unit_price'] / $installments;
+      $this->line_items[$key]['line_total'] = $k['line_total'] / $installments;
+      $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $installments;
     }
 
     // Create Params for Creating the Recurring Contribution Series and Create it
@@ -1803,6 +1810,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     // Run the Transaction - and Create the Contribution Record - relay Recurring Series information in addition to the already existing Params [and re-key where needed]; at times two keys are required
     $contributionParams['total_amount'] = $contributionFirstAmount;
+    $contributionParams['tax_amount'] = $salesTaxFirstAmount;
     $additionalParams = array(
       'contribution_recur_id' => $resultRecur['id'],
       'contributionRecurID' => $resultRecur['id'],


### PR DESCRIPTION
Before
----------------------------------------
Currently when enabling the functionality to pay the amount due in installments -> the first Contribution is processed properly, the Recurring Series is set up properly - but the line_items of first Contribution are not correct (they are still the line_items for the total obligation rather than for one single installment); 

After
----------------------------------------
Fixed - the view Contribution looks good at line_item level:
![image](https://user-images.githubusercontent.com/5340555/40663825-cc14e918-6316-11e8-9984-f294894d2608.png)

Comments
----------------------------------------
The obligation shows on the webform_civicrm checkout page:
![image](https://user-images.githubusercontent.com/5340555/40663978-1e45b8d4-6317-11e8-868e-da31b8c822c1.png)

An HTML markup element can be used to generate any text like:
![image](https://user-images.githubusercontent.com/5340555/40664064-548a422a-6317-11e8-8b59-54940485bc46.png)

Note that submission:values:installment_amount is a webform_calculator field - this token does not currently work yet - but since this allows any form builder to select the language appropriate for their Membership/Event Fee/Donation form - tokens are the way forward here. 


