### PR TITLE
If installments=0 we create an open-ended recurring contribution but we still need an amount

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1748,8 +1748,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   private function submitLivePayment() {
     $contributionParams = $this->contributionParams();
 
-    // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 in CiviCRM Core means open ended commitment;
-    $numInstallments = wf_crm_aval($contributionParams, 'installments', 1, TRUE);
+    // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
+    $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($contributionParams, 'frequency_unit');
     if ($numInstallments != 1 && !empty($frequencyInterval)) {
       $result = $this->contributionRecur($contributionParams);
@@ -1771,33 +1771,37 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   }
 
   /**
+   *
    * Generate recurring contribution and transact the first one
    */
   private function contributionRecur($contributionParams, $paymentType = 'live') {
-    $installments = $contributionParams['installments'];
-    if ($installments != 0) {
+    $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
+    // if ($installments === 0) or $installments is not defined we treat as an open-ended recur
+    $contributionFirstAmount = $contributionRecurAmount = $contributionParams['total_amount'];
+    $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);;
+    if ($numInstallments > 0) {
       // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $installments) * 100) / 100;
-      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($installments - 1);
-      $salesTaxFirstAmount = $contributionParams['tax_amount'] - floor(($contributionParams['tax_amount'] / $installments) * 100) / 100 * ($installments - 1);
+      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $numInstallments) * 100) / 100;
+      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($numInstallments - 1);
+      $salesTaxFirstAmount = $salesTaxFirstAmount - floor(($salesTaxFirstAmount / $numInstallments) * 100) / 100 * ($numInstallments - 1);
 
-      // Calculate the line_items for the contributionFirst:
+      // Calculate the line_items for the first contribution:
+      // At this point line_items are set to the full (non-installment) amounts.
       foreach ($this->line_items as $key => $k) {
-        $this->line_items[$key]['unit_price'] = $k['unit_price'] / $installments;
-        $this->line_items[$key]['line_total'] = $k['line_total'] / $installments;
-        $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $installments;
+        $this->line_items[$key]['unit_price'] = $k['unit_price'] / $numInstallments;
+        $this->line_items[$key]['line_total'] = $k['line_total'] / $numInstallments;
+        $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $numInstallments;
       }
     }
 
     // Create Params for Creating the Recurring Contribution Series and Create it
     $contributionRecurParams = array(
-      'sequential' => 1,
       'contact_id' => $contributionParams['contact_id'],
       'frequency_interval' => wf_crm_aval($contributionParams, 'frequency_interval', 1),
       'frequency_unit' => wf_crm_aval($contributionParams, 'frequency_unit', 'month'),
-      'installments' => $installments,
+      'installments' => $numInstallments,
       'amount' => $contributionRecurAmount,
-      'contribution_status_id' => 5,
+      'contribution_status_id' => 'In Progress',
       'currency' => $contributionParams['currency'],
       'payment_processor_id' =>  $contributionParams['payment_processor_id'],
       'financial_type_id' =>  $contributionParams['financial_type_id'],
@@ -1873,9 +1877,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
 
-    $numInstallments = wf_crm_aval($params, 'installments', 1, TRUE);
+    $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments > 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    if ($numInstallments != 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -607,7 +607,7 @@ function webform_civicrm_civicrm_alterPaymentProcessorParams($paymentObj, $rawPa
  * @param mixed $default
  *   Value to return if given array key does not exist
  * @param bool $strict
- *   Should we use empty or isset to determine if array key exists?
+ *   Should we use empty or isset to determine if array key exists? If TRUE, use isset
  *
  * @return mixed
  *   found value or default


### PR DESCRIPTION
Overview
----------------------------------------
If we configure the webform_civicrm with installments=0, frequency=weekly (or any other frequency) then we should create an open-ended recurring contribution.

Before
----------------------------------------
Create recurring contribution/contribution fails because amount is not set.  You have to specify `installments=0` to create an open-ended recur.

After
----------------------------------------
Create recurring contribution/contribution succeeds because amount is set.  You don't have to specify `installments` at all to create an open-ended recur.

Technical Notes
----------------------------------------
1. The code makes assumptions that tax_amount will be set - it is optional (ie. you may not have tax and invoicing enabled in Civi).  The current webform_civicrm code will throw PHP notices if it is not set.
2. On the CiviCRM side, "installments" is very much an optional parameter and is treated differently by different processors - it doesn't actually do what it should in many cases.  webform_civicrm is doing something sensible - however, it is assuming that it will always be defined, which is not what CiviCRM expects.  This PR updates the webform_civicrm handling to allow either `installments = 0` or `!isset(installments)` to mean an open-ended recurring contribution if frequency unit/frequency interval is set.  This mimics the behaviour in CiviCRM.
3. This PR makes sure that variables are always defined before being used (`$salesTaxFirstAmount` and 
`$contributionFirstAmount` were not being set if `installments = 0` previously leading to undefined behaviour - an API exception).
4. I'm not able to test the changes in `createDeferredPayment()` as I don't know how to get there.  However, they are inline with changes in the other functions.