### PR TITLE
Add filter on is_public event field

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -206,7 +206,7 @@ function wf_crm_get_events($reg_options, $context) {
   if ($event_types) {
     $sql .= ' AND event_type_id IN ( ' . implode(", ", $event_types) . ' ) ';
   }
-  if (is_numeric($reg_options['show_public_events'])) {
+  if (is_numeric(wf_crm_aval($reg_options, 'show_public_events'))) {
     $sql .= ' AND is_public = ' . $reg_options['show_public_events'];
   }
   $sql .= ' ORDER BY start_date ' . ($context == 'config_form' ? 'DESC' : '');

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -206,6 +206,9 @@ function wf_crm_get_events($reg_options, $context) {
   if ($event_types) {
     $sql .= ' AND event_type_id IN ( ' . implode(", ", $event_types) . ' ) ';
   }
+  if (is_numeric($reg_options['show_public_events'])) {
+    $sql .= ' AND is_public = ' . $reg_options['show_public_events'];
+  }
   $sql .= ' ORDER BY start_date ' . ($context == 'config_form' ? 'DESC' : '');
   $dao = CRM_Core_DAO::executeQuery($sql);
   while ($dao->fetch()) {

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -786,6 +786,20 @@ class wf_crm_admin_form {
       ),
     );
     $this->help($this->form['participant']['show_future_events'], 'reg_options_show_future_events');
+    $this->form['participant']['show_public_events'] = array(
+      '#type' => 'select',
+      '#title' => t('Show Public Events'),
+      '#default_value' => wf_crm_aval($this->data, 'reg_options:show_public_events', 'title'),
+      '#suffix' => '</div>',
+      '#parents' => array('reg_options', 'show_public_events'),
+      '#tree' => TRUE,
+      '#options' => array(
+        'all' => t('Public and Private'),
+        '1' => t('Public'),
+        '0' => t('Private'),
+      ),
+    );
+    $this->help($this->form['participant']['show_public_events'], 'reg_options_show_public_events');
     $this->form['participant']['title_display'] = array(
       '#type' => 'select',
       '#title' => t('Title Display'),
@@ -859,6 +873,7 @@ class wf_crm_admin_form {
     $this->addAjaxItem('participant', 'event_type', 'participants');
     $this->addAjaxItem('participant', 'show_past_events', 'participants');
     $this->addAjaxItem('participant', 'show_future_events', 'participants');
+    $this->addAjaxItem('participant', 'show_public_events', 'participants');
     $this->addAjaxItem('participant', 'title_display', 'participants');
 
     for ($n = 1; $reg_type && (($n <= count($this->data['contact']) && $reg_type != 'all') || $n == 1); ++$n) {

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -270,6 +270,12 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function reg_options_show_public_events() {
+    print '<p>' .
+      t('Choose whether to display events marked as Public, Private or all.') .
+      '</p>';
+  }
+
   public static function reg_options_title_display() {
     print '<p>' .
       t('Controls how events are displayed. Date formats can be further configured in <a !link>CiviCRM Date Settings</a>',


### PR DESCRIPTION
Overview
----------------------------------------
Allow users to filter the list of events by whether the event is marked as 'Public'

Before
----------------------------------------
Events are shown regardless of the 'Public' setting, so non-public events are still displayed.

After
----------------------------------------
On the Event Registration tab there is a new dropdown for 'Show Public Events' that allows the selection of 'Private and Public', 'Private' or 'Public'.  The default is 'Private and Public' to match the current behaviour.


