### PR TITLE
Allow event selection by multiple types

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -202,8 +202,11 @@ function wf_crm_get_events($reg_options, $context) {
     $date_future = date('Y-m-d H:i:s', strtotime($date_future));
     $sql .= " AND (end_date <= '$date_future' OR end_date IS NULL)";
   }
-  if (is_numeric($reg_options['event_type'])) {
-    $sql .= ' AND event_type_id = ' . $reg_options['event_type'];
+  if (is_array($reg_options['event_type'])) {
+    $event_types = array_filter($reg_options['event_type'], "is_numeric");
+    if ($event_types) {
+      $sql .= ' AND event_type_id IN ( ' . implode(", ", $event_types) . ' ) ';
+    }
   }
   $sql .= ' ORDER BY start_date ' . ($context == 'config_form' ? 'DESC' : '');
   $dao = CRM_Core_DAO::executeQuery($sql);

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -202,11 +202,9 @@ function wf_crm_get_events($reg_options, $context) {
     $date_future = date('Y-m-d H:i:s', strtotime($date_future));
     $sql .= " AND (end_date <= '$date_future' OR end_date IS NULL)";
   }
-  if (is_array($reg_options['event_type'])) {
-    $event_types = array_filter($reg_options['event_type'], "is_numeric");
-    if ($event_types) {
-      $sql .= ' AND event_type_id IN ( ' . implode(", ", $event_types) . ' ) ';
-    }
+  $event_types = array_filter((array) $reg_options['event_type'], "is_numeric");
+  if ($event_types) {
+    $sql .= ' AND event_type_id IN ( ' . implode(", ", $event_types) . ' ) ';
   }
   $sql .= ' ORDER BY start_date ' . ($context == 'config_form' ? 'DESC' : '');
   $dao = CRM_Core_DAO::executeQuery($sql);

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -738,12 +738,13 @@ class wf_crm_admin_form {
     $this->help($this->form['participant']['participant_reg_type'], 'participant_reg_type');
     $this->form['participant']['event_type'] = array(
       '#type' => 'select',
-      '#title' => t('Show Events of Type'),
+      '#title' => t('Show Events of Type(s)'),
       '#options' => array('any' => t('- Any Type -')) + wf_crm_apivalues('event', 'getoptions', array('field' => 'event_type_id')),
       '#default_value' => wf_crm_aval($this->data, 'reg_options:event_type', 'any'),
       '#prefix' => '<div id="event-reg-options-wrapper"><div class="web-civi-checkbox-set">',
       '#parents' => array('reg_options', 'event_type'),
       '#tree' => TRUE,
+      '#multiple' => TRUE,
     );
     $this->form['participant']['show_past_events'] = array(
       '#type' => 'select',


### PR DESCRIPTION
Overview
---------------------------------------
Allow events to be filtered by selecting multiple event types

Before
----------------------------------------
On the Event Registration tab there is a dropdown for 'Show Events of Type' that allows the selection of a single type.

After
----------------------------------------
The dropdown is renamed 'Show Events of Type(s)' and allows the selection of multiple types.

