### PR TITLE
 Avoid overwrite only first field with last value

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2511,6 +2511,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           // address field contain many sub fields and should be handled differently
           if ($entity != 'address')  {
             $reorderedArray[$index][$entity] = $sValue[$entity];
+            unset($submittedLocationValues[$key]);
+            break;
           }
           else {
             foreach (wf_crm_address_fields() as $field)  {


### PR DESCRIPTION
Overview
----------------------------------------
Webforms with multiple emails values are not being saved correctly. The last submitted value is written to the first email field. Other emails are not being updated.

Before
----------------------------------------
1. Data before submission
![image](https://user-images.githubusercontent.com/3916979/42423357-8901cb6a-82be-11e8-9f86-78b79e039f5d.png)

2. Example configuration of the webform
![image](https://user-images.githubusercontent.com/3916979/42423359-8e547efa-82be-11e8-947a-b467b056601a.png)

3. Data when visiting the webform
![image](https://user-images.githubusercontent.com/3916979/42423367-a24b8d18-82be-11e8-8b4a-0f1a183e9459.png)

4. Filling the webform with a second email
![image](https://user-images.githubusercontent.com/3916979/42423370-a7b84b42-82be-11e8-9862-81b010feec5d.png)

5. Visiting the webform again we can see that first email was overwritten with last email
![image](https://user-images.githubusercontent.com/3916979/42423373-ad120d12-82be-11e8-8d89-a76c2d70fbf9.png)

6. From the Admin UI it confirms what the webform was showing: first email overwritten with last email.
![image](https://user-images.githubusercontent.com/3916979/42423375-b2dea9c6-82be-11e8-9d54-96b4ff2c9af2.png)


After
----------------------------------------
1. Repeat steps 1 to 4 from "Before" for initial data, filling the webform and saving.

2.  Data was stored correctly.
![image](https://user-images.githubusercontent.com/3916979/42423592-4475a77e-82c2-11e8-8edc-652a4be23a69.png)


Technical Details
----------------------------------------

- Attaching exported webform with node export:
[webform-multiple-emails.txt](https://github.com/colemanw/webform_civicrm/files/2174088/webform-multiple-emails.txt)

- Site created for testing with civibuild using this command
`civibuild create civi12 --type drupal-demo --civi-ver 4.7.27 --url http://civi12 --web-root /home/beto/buildkit/build/civi12`

- CiviCRM currently uses civicrm_webform 7.20, however this module was replaced with the last version found here https://github.com/colemanw/webform_civicrm

Comments
----------------------------------------
Base on the modifed code (shown below) this is probably not only applicable to emails but for fields which are not addresses.
![image](https://user-images.githubusercontent.com/3916979/42423678-ea5e5ec8-82c3-11e8-9fe7-8fe4365f1077.png)

