### PR TITLE
Allow multiple values with same location without swapping primary keys

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -780,12 +780,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $uid = wf_crm_user_cid($cid, 'contact');
             if ($uid) {
               $user = user_load($uid);
-              if ($params['email'] != $user->mail) {
-                // Verify this email is unique before saving it to user
-                $args = array(':mail' => $params['email']);
-                if (!(db_query("SELECT count(uid) FROM {users} WHERE mail = :mail", $args)->fetchField())) {
-                  user_save($user, array('mail' => $params['email']));
-                }
+              // Verify this email is different from current user email
+              // and unique between Drupal users before updating it
+              if ($params['email'] != $user->mail && !user_load_by_mail($params['email']) ) {
+                user_save($user, array('mail' => $params['email']));
               }
             }
           }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -761,7 +761,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $existing = array_merge(array(array()), $result['values']);
         }
         // Check which location_type_id is to be set as is_primary=1;
-        $is_primary_location_type = isset($contact[$location]) ? $contact[$location][1]['location_type_id'] : null;
+        $is_primary_location_type = isset($contact[$location][1]['location_type_id']) ? $contact[$location][1]['location_type_id'] : null;
 
         foreach ($contact[$location] as $i => $params) {
           // Translate state/prov abbr to id

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -795,6 +795,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             foreach ($params as $param => $val) {
               if ($val != (string) wf_crm_aval($existing[$i], $param, '')) {
                 $same = FALSE;
+                break;
               }
             }
             if ($same) {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -747,10 +747,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * @param int $c
    */
   private function saveContactLocation($contact, $cid, $c) {
-    // Check which location_type_id is to be set as is_primary=1;
-    $is_primary_address_location_type = wf_crm_aval($contact, 'address:1:location_type_id');
-    $is_primary_email_location_type = wf_crm_aval($contact, 'email:1:location_type_id');
-
     foreach (wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
         $existing = array();
@@ -764,6 +760,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           // start array index at 1
           $existing = array_merge(array(array()), $result['values']);
         }
+        // Check which location_type_id is to be set as is_primary=1;
+        $is_primary_location_type = isset($contact[$location]) ? $contact[$location][1]['location_type_id'] : null;
+
         foreach ($contact[$location] as $i => $params) {
           // Translate state/prov abbr to id
           if (!empty($params['state_province_id'])) {
@@ -828,17 +827,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             continue;
           }
           if ($location != 'website') {
-            if (empty($params['location_type_id'])) {
-              $params['location_type_id'] = wf_crm_aval($existing, "$i:location_type_id", 1);
-            }
-            $params['is_primary'] = $i == 1 ? 1 : 0;
-            // Override that just in cases we know
-            if ($location == 'address' && $params['location_type_id'] == $is_primary_address_location_type) {
-              $params['is_primary'] = 1;
-            }
-            if ($location == 'email' && $params['location_type_id'] == $is_primary_email_location_type) {
-              $params['is_primary'] = 1;
-            }
+            $params['location_type_id'] = empty($params['location_type_id']) ? wf_crm_aval($existing, "$i:location_type_id", 1) : $params['location_type_id'];
+            // Modify is_primary parameter if location type of the current field is the same
+            // type of the first field, assuring only first field to be set as primary
+            $params['is_primary'] = (int) ($params['location_type_id'] == $is_primary_location_type && $i == 1);
           }
           wf_civicrm_api($location, 'create', $params);
         }


### PR DESCRIPTION
Overview
----------------------------------------
Webform CiviCRM does not support multiple fields with same location type, for example: 3 emails of location type personal.

This lack of support for multiple fields also creates related issues as the swapping of primary keys on save, and even data corruption (only if webform is configured with multiple fields with same location)

The objective of this task is to enhance webform_civicrm capabilities to allow multiple fields with any location types (repeated or not) work as expected in the same webform, without swapping primary keys unexpectedly between the configured fields and saving all values in a predictable way.

Before
----------------------------------------
When saving multiple fields with the same location type the last value that changes will be saved as the primary field.

All fields are same location type. Notice the order of values before and after submit.

![peek 2018-07-16 16-34](https://user-images.githubusercontent.com/3916979/42784901-3bbb4148-8916-11e8-8f4c-fdb2fc8936ff.gif)


After
----------------------------------------
When saving multiple fields with the same location type the first value will remain as the primary field, no matter if it changes or not.

All fields are same location type. Notice the order of values before and after submit.

![peek 2018-07-16 16-37](https://user-images.githubusercontent.com/3916979/42785022-8a0e29aa-8916-11e8-867b-29c87590efc7.gif)
