### PR TITLE
Autofill contact from relationships

### DIFF
--- a/css/webform_civicrm_admin.css
+++ b/css/webform_civicrm_admin.css
@@ -190,3 +190,13 @@ form .civi-icon.grant {
 form .civi-icon.case {
   background-position:-203px 0;
 }
+
+/* Contact component form */
+#webform-component-edit-form div.form-item-extra-default,
+#webform-component-edit-form div.form-item-extra-default-relationship-to {
+  display: inline-block;
+}
+
+#webform-component-edit-form div.form-item-extra-default-relationship-to label {
+  display:none;
+}

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -40,6 +40,7 @@ function _webform_defaults_civicrm_contact() {
       'default' => '',
       'default_contact_id' => '',
       'default_relationship' => '',
+      'default_relationship_to' => '1',
       'allow_url_autofill' => TRUE,
       'dupes_allowed' => FALSE,
       'filters' => array(
@@ -92,6 +93,7 @@ function _webform_edit_civicrm_contact($component) {
   });';
   $form['#attached']['js'][$js] = array('type' => 'inline');
   $form['#attached']['css'][] = drupal_get_path('module', 'webform_civicrm') . '/css/token-input.css';
+  $form['#attached']['css'][] = drupal_get_path('module', 'webform_civicrm') . '/css/webform_civicrm_admin.css';
   $form['#attached']['js'][] = drupal_get_path('module', 'webform_civicrm') . '/js/contact_component.js';
 
   $form['display']['widget'] = array(
@@ -217,22 +219,36 @@ function _webform_edit_civicrm_contact($component) {
     $form['defaults']['default']['#options']['user'] = t('Current User');
   }
   elseif ($c > 1) {
-    $form['defaults']['default']['#options']['relationship'] = t('Relationship to !contact', array('!contact' => wf_crm_contact_label(1, $data)));
+    $form['defaults']['default']['#options']['relationship'] = t('Relationship to...');
+    $to = $component['extra']['default_relationship_to'];
+    $form['defaults']['default_relationship_to'] = array(
+      '#type' => 'select',
+      '#title' => t('Relationship to Contact'),
+      '#default_value' => $to,
+      '#parents' => array('extra', 'default_relationship_to'),
+    );
     $form['defaults']['default_relationship'] = array(
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => t('Specify Relationship(s)'),
-      '#options' => array('' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][1]['contact'][1]['contact_type']])) . ' -'),
+      '#options' => array('-' => '-'),
+      '#required' => TRUE,
       '#default_value' => $component['extra']['default_relationship'],
       '#parents' => array('extra', 'default_relationship'),
     );
-    $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][1]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][1]['contact'][1]['contact_sub_type']);
-    foreach ($rtypes as $k => $v) {
-      $form['defaults']['default_relationship']['#options'][$k] = $v . ' ' . wf_crm_contact_label(1, $data, 'plain');
-      // We do this in the loop so the field is only required if it has some options
-      $form['defaults']['default_relationship']['#required'] = TRUE;
-      unset($form['defaults']['default_relationship']['#options']['']);
+    $all_relationship_types = array_fill(1, $c - 1, array());
+    for ($i = 1; $i < $c; ++$i) {
+      $form['defaults']['default_relationship_to']['#options'][$i] = wf_crm_contact_label($i, $data, 'plain');
+      $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
+      foreach ($rtypes as $k => $v) {
+        $all_relationship_types[$i][] = array('key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain'));
+        $form['defaults']['default_relationship']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
+      }
+      if (!$rtypes) {
+        $all_relationship_types[$i][] = array('key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']])) . ' -');
+      }
     }
+    $form['defaults']['default_relationship_to']['#attributes']['data-types'] = json_encode($all_relationship_types);
   }
   $form['defaults']['default']['#options']['auto'] = t('Auto - From Filters');
   $form['defaults']['default_contact_id'] = array(

--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -542,7 +542,7 @@ class wf_crm_admin_component {
               $row['data'][3]['data'] = t('Auto - From Filters');
             }
             elseif ($component['extra']['default'] == 'relationship' && $component['extra']['default_relationship']) {
-              $row['data'][3]['data'] = t('Relationship to !contact', array('!contact' => wf_crm_contact_label(1, $data)));
+              $row['data'][3]['data'] = t('Relationship to !contact', array('!contact' => wf_crm_contact_label($component['extra']['default_relationship_to'], $data)));
             }
           }
           elseif (isset($component['value']) && strlen($component['value']) && ($field['type'] == 'select' || !empty($field['expose_list']))) {

--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -542,7 +542,14 @@ class wf_crm_admin_component {
               $row['data'][3]['data'] = t('Auto - From Filters');
             }
             elseif ($component['extra']['default'] == 'relationship' && $component['extra']['default_relationship']) {
-              $row['data'][3]['data'] = t('Relationship to !contact', array('!contact' => wf_crm_contact_label($component['extra']['default_relationship_to'], $data)));
+              $relationship_labels = array();
+              $relationship_types = wf_crm_get_relationship_types();
+              foreach ($component['extra']['default_relationship'] as $default_relationship) {
+                list($rid, $rtype) = explode('_', $default_relationship);
+                $label_type = $rtype == 'b' ? 'b_a' : 'a_b';
+                $relationship_labels[] = $relationship_types[$rid]["label_$label_type"] . ' ' . wf_crm_contact_label($component['extra']['default_relationship_to'], $data);
+              }
+              $row['data'][3]['data'] = implode(' ' . ts('or') . ' ', $relationship_labels);
             }
           }
           elseif (isset($component['value']) && strlen($component['value']) && ($field['type'] == 'select' || !empty($field['expose_list']))) {

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -269,8 +269,9 @@ abstract class wf_crm_webform_base {
           }
           break;
         case 'relationship':
-          if (!empty($this->ent['contact'][1]['id'])) {
-            $found = wf_crm_find_relations($this->ent['contact'][1]['id'], $component['extra']['default_relationship']);
+          $to = $component['extra']['default_relationship_to'];
+          if (!empty($this->ent['contact'][$to]['id'])) {
+            $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['extra']['default_relationship']);
           }
           break;
         case 'auto':

--- a/js/contact_component.js
+++ b/js/contact_component.js
@@ -34,24 +34,36 @@ var wfCiviContact = (function ($, D) {
 
   D.behaviors.webform_civicrmContact = {
     attach: function (context) {
-      $('#edit-extra-default', context).once('wf-civi').change(function() {
+      function changeDefault() {
         var val = $(this).val().replace(/_/g, '-');
         $('#edit-defaults > div > .form-item', context).not('.form-item-extra-default, .form-item-extra-allow-url-autofill').each(function() {
-          if ($(this).hasClass('form-item-extra-default-'+val)) {
+          if (val.length && $(this).is('[class*=form-item-extra-default-'+val+']')) {
             $(this).removeAttr('style');
           }
           else {
             $(this).css('display', 'none');
-            $(':checkbox', this).attr('disabled', 'disabled');
+            $(':checkbox', this).prop('disabled', true);
           }
         });
         if (val === 'auto' || val === 'relationship') {
           $('.form-item-extra-randomize, .form-item-extra-dupes-allowed')
             .removeAttr('style')
             .find(':checkbox')
-            .removeAttr('disabled');
+            .prop('disabled', false);
         }
-      }).change();
+        changeRelationTo();
+      }
+      function changeRelationTo() {
+        var c = $('#edit-extra-default-relationship-to').val(),
+          types = $('#edit-extra-default-relationship-to').data('types')[c];
+        CRM.utils.setOptions('#edit-extra-default-relationship', types);
+        // Provide default to circumvent "required" validation error
+        if ($('#edit-extra-default').val() !== 'relationship' && types.length === 1 && types[0].key === '') {
+          CRM.utils.setOptions('#edit-extra-default-relationship', {key: '-', value: '-'});
+        }
+      }
+      $('#edit-extra-default', context).once('wf-civi').change(changeDefault).each(changeDefault);
+      $('#edit-extra-default-relationship-to', context).once('wf-civi').change(changeRelationTo);
       $('#edit-extra-widget', context).once('wf-civi').change(function() {
         if ($(this).val() == 'hidden') {
           $('.form-item-extra-search-prompt', context).css('display', 'none');


### PR DESCRIPTION
Overview
----------------------------------------
Allow existing contact to be autofilled from any relationship, not just to contact 1.

![screenshot from 2018-07-19 14-21-46](https://user-images.githubusercontent.com/2874912/42962340-62ff1716-8b5f-11e8-81d4-4a5f2da0a3f7.png)

Before
----------------------------------------
The default value could only be set "by relationship" to contact 1.

After
----------------------------------------
The default value can be set "by relationship" to any preceeding contact on the webform (e.g. contact 3 can be set from contacts 1 or 2 but not 4 or 5).

Comments
----------------------------------------
This is for *prepopulation* only. Selecting a different contact via autocomplete after the form is already loaded won't do anything.

------
https://www.drupal.org/project/webform_civicrm/issues/2797345