### PR TITLE
Add defaults to resetFields call when creating new contact

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -12,7 +12,7 @@ var wfCivi = (function ($, D) {
 
   pub.existingSelect = function (num, nid, path, toHide, hideOrDisable, showEmpty, cid, fetch, defaults) {
     if (cid.charAt(0) === '-') {
-      resetFields(num, nid, true, 'show', toHide, hideOrDisable, showEmpty, 500);
+      resetFields(num, nid, true, 'show', toHide, hideOrDisable, showEmpty, 500, defaults);
       // Fill name fields with name typed
       if (cid.length > 1) {
         var names = {first: '', last: ''};


### PR DESCRIPTION
…in webform_civicrm_forms.js, solving the bug of missing CiviCRM defaults.

Overview
----------------------------------------
When creating a new contact in a webform, defaults for Civi fields are not preserved, while defaults for non-Civi fields remain. This change preserves the defaults for Civi fields as well.

Before
----------------------------------------
This is our Test Defaults webform:
![webform_civicrm_defaults_01select](https://user-images.githubusercontent.com/32659959/43377193-c5da79ce-9402-11e8-9fd3-8dc58bc9947a.png)
Here is what happens when selecting an existing Contact (all defaults are preserved, fields with saved data are updated):
![webform_civicrm_defaults_02existing](https://user-images.githubusercontent.com/32659959/43377203-d4b65774-9402-11e8-9239-c70b1e54f2e1.png)
Here is what happens when creating a new contact (Civi defaults are not preserved):
![webform_civicrm_defaults_03create](https://user-images.githubusercontent.com/32659959/43377243-07ea193c-9403-11e8-81c5-0d09aa520d7a.png)


After
----------------------------------------
Now all defaults are preserved when creating a new Contact:
![webform_civicrm_defaults_04createwithdefaults](https://user-images.githubusercontent.com/32659959/43377253-1b604c98-9403-11e8-80ca-ba1ce379aefc.png)


Technical Details
----------------------------------------
The _defaults_ parameter of the _resetFields_ function seems to be relatively new. It looks like it can be used when creating a new Contact, and adding it here doesn't appear to break anything else (but maybe there's a use case I'm not considering).
