### PR TITLE
Add description to the params sent to the processor

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1930,7 +1930,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
 
     $params['source'] = $this->settings['new_contact_source'];
-    $params['item_name'] = t('Webform Payment: @title', array('@title' => $this->node->title));
+    $params['item_name'] = $params['description'] = t('Webform Payment: @title', array('@title' => $this->node->title));
 
     if (method_exists($paymentProcessor, 'setSuccessUrl')) {
       $paymentProcessor->setSuccessUrl($this->getIpnRedirectUrl('success'));


### PR DESCRIPTION
Overview
----------------------------------------
Add `description` to the param sent to the payment processor.

Before
----------------------------------------
Exception thrown by GoCardless processor for missing required params.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Either this can be fixed in the GoCordless extension or here, but I see `description` param is set in different functions in the same file and also in core civicrm. It was missing in `submitIPNPayment()` function which is now added in this PR.

Details - https://chat.civicrm.org/civicrm/pl/d11tnxs4wfyhjkbibqy8czowac
