### PR TITLE
Fatal error: Can't use function return value in write context

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -390,7 +390,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $lastName = CRM_Utils_Array::value('last_name', $participants);
 
       $participantName = "{$firstName} {$lastName}";
-      if (empty(trim($participantName))) {
+      if (empty($participantName)) {
         $participantName = CRM_Utils_Array::value('webform_label', $participants);
         if (!empty($this->existing_contacts[$c])) {
           $participantName = CRM_Contact_BAO_Contact::displayName($this->existing_contacts[$c]);


### PR DESCRIPTION
Fixes this error.

Fatal error: Can't use function return value in write context in /public_html/sites/all/modules/contrib/webform_civicrm/includes/wf_crm_webform_postprocess.inc on line 393

Overview
----------------------------------------
_A brief description of the pull request. Try to keep it non-technical._

Before
----------------------------------------
_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

After
----------------------------------------
_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
