### PR TITLE
Fix Case ID in tokens

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -948,8 +948,7 @@ function _webform_civicrm_replaceCaseIdTokens($tokens, $webformSubmissionData) {
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
     if (!empty($webformSubmissionData->civicrm['case'][$entityID]['id'])) {
-      $caseId = $webformSubmissionData->civicrm['case'][$entityID]['id'];
-      $tokenNewValue = $caseID;
+      $tokenNewValue = $webformSubmissionData->civicrm['case'][$entityID]['id'];
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Case ID does not get set because there is a typo.

Before
----------------------------------------
Case ID is not set in tokens (eg [submission:case-id:1])

After
----------------------------------------
Case ID is set in tokens (eg [submission:case-id:1])

Technical Details
----------------------------------------
Typo `$caseId` != `$caseID`
