### PR TITLE
Save credit card type and last 4 digits

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2018,6 +2018,23 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $params['payment_processor'] = wf_crm_aval($params, 'payment_processor_id');
     }
 
+    // Record additional parameters if we're processing a credit card after version 4.7.17 (CRM-20158)
+    if (version_compare($this->civicrm_version, '4.7.17', '>=')) {
+      if (!empty($params['credit_card_number'])) {
+        if (!empty($params['credit_card_type'])) {
+          $result = wf_civicrm_api('OptionValue', 'get', array(
+            'return' => ['value'],
+            'option_group_id.name' => 'accept_creditcard',
+            'name' => ucfirst($params['credit_card_type']),
+          ));
+          if (!empty($result['id'])) {
+            $params['card_type_id'] = $result['values'][$result['id']]['value'];
+          }
+        }
+        $params['pan_truncation'] = substr($params['credit_card_number'],-4);
+      }
+    }
+
     // Save this stuff for later
     unset($params['soft'], $params['honor_contact_id'], $params['honor_type_id']);
     return $params;


### PR DESCRIPTION
Overview
----------------------------------------
Save additional parameters about credit cards (type and last 4 digits) when processing a credit card after version 4.7.17 (this was implemented in https://issues.civicrm.org/jira/browse/CRM-20158)

I don't know if checking for credit card numbers is required, but better safe than sorry (I have never tried to use webform_civicrm with direct debit, so I don't know what it would do.)

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/2336581/43972997-6a33111e-9c93-11e8-93ef-e353cc74a452.png)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/2336581/43973021-79436ca8-9c93-11e8-9219-45f9a9234f7f.png)
