### PR TITLE
Allow filtering existing contacts by relationship

### DIFF
--- a/css/webform_civicrm_admin.css
+++ b/css/webform_civicrm_admin.css
@@ -193,10 +193,13 @@ form .civi-icon.case {
 
 /* Contact component form */
 #webform-component-edit-form div.form-item-extra-default,
-#webform-component-edit-form div.form-item-extra-default-relationship-to {
+#webform-component-edit-form div.form-item-extra-default-relationship-to,
+#webform-component-edit-form div.form-item-extra-filters-relationship-contact,
+#webform-component-edit-form div.form-item-extra-filters-relationship-type {
   display: inline-block;
 }
 
+#webform-component-edit-form div.form-item-extra-filters-relationship-type label,
 #webform-component-edit-form div.form-item-extra-default-relationship-to label {
   display:none;
 }

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -47,6 +47,7 @@ function _webform_defaults_civicrm_contact() {
         'contact_sub_type' => 0,
         'group' => array(),
         'tag' => array(),
+        'relationship' => array(),
         'check_permissions' => 1,
       ),
     ),
@@ -236,19 +237,6 @@ function _webform_edit_civicrm_contact($component) {
       '#default_value' => $component['extra']['default_relationship'],
       '#parents' => array('extra', 'default_relationship'),
     );
-    $all_relationship_types = array_fill(1, $c - 1, array());
-    for ($i = 1; $i < $c; ++$i) {
-      $form['defaults']['default_relationship_to']['#options'][$i] = wf_crm_contact_label($i, $data, 'plain');
-      $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
-      foreach ($rtypes as $k => $v) {
-        $all_relationship_types[$i][] = array('key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain'));
-        $form['defaults']['default_relationship']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
-      }
-      if (!$rtypes) {
-        $all_relationship_types[$i][] = array('key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']])) . ' -');
-      }
-    }
-    $form['defaults']['default_relationship_to']['#attributes']['data-types'] = json_encode($all_relationship_types);
   }
   $form['defaults']['default']['#options']['auto'] = t('Auto - From Filters');
   $form['defaults']['default_contact_id'] = array(
@@ -323,6 +311,35 @@ function _webform_edit_civicrm_contact($component) {
     '#default_value' => $component['extra']['filters']['tag'],
     '#description' => t('Listed contacts must be have at least one of the selected tags (leave blank to not filter by tag).'),
   );
+  if ($c > 1) {
+    $form['filters']['relationship']['contact'] = array(
+      '#type' => 'select',
+      '#title' => t('Relationships to'),
+      '#options' => array('' => '- ' . t('None') . ' -'),
+      '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:contact'),
+    );
+    $form['filters']['relationship']['type'] = array(
+      '#type' => 'select',
+      '#multiple' => TRUE,
+      '#title' => t('Specify Relationship(s)'),
+      '#options' => array('' => '- ' . t('Any relation') . ' -'),
+      '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:type'),
+    );
+    // Fill relationship data for defaults and filters
+    $all_relationship_types = array_fill(1, $c - 1, array());
+    for ($i = 1; $i < $c; ++$i) {
+      $form['defaults']['default_relationship_to']['#options'][$i] = $form['filters']['relationship']['contact']['#options'][$i] = wf_crm_contact_label($i, $data, 'plain');
+      $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
+      foreach ($rtypes as $k => $v) {
+        $all_relationship_types[$i][] = array('key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain'));
+        $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['type']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
+      }
+      if (!$rtypes) {
+        $all_relationship_types[$i][] = array('key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']])) . ' -');
+      }
+    }
+    $form['#attributes']['data-reltypes'] = json_encode($all_relationship_types);
+  }
   $form['filters']['check_permissions'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enforce Permissions'),
@@ -399,29 +416,19 @@ function _webform_render_civicrm_contact($component, $value = NULL, $filter = TR
         $element['#attached']['js'][] = wf_crm_tokeninput_path();
         $element['#attached']['css'][] = drupal_get_path('module', 'webform_civicrm') . '/css/token-input.css';
         $settings = '{
-          queryParam: "str",
           hintText: ' . json_encode(filter_xss($component['extra']['search_prompt'])) . ',
           noResultsText: ' . json_encode(filter_xss($component['extra']['none_prompt'])) . ',
-          searchingText: ' . json_encode(t('Searching...')) . ',
-          tokenLimit: 1,
-          prePopulate: prep
+          searchingText: ' . json_encode(t('Searching...')) . '
         }';
-        $js = "var prep = wfCivi.existingInit(field, $c, {$node->nid}, $callback_path, toHide);
-                field.tokenInput($callback_path, $settings);
-                $onChange";
+        $js = "wfCivi.existingInit(field, $c, {$node->nid}, $callback_path, toHide, $settings);$onChange";
       }
       break;
 
     case 'select':
+      // Options will be set by wf_crm_fill_contact_value.
       $element['#options'] = array();
       if ($node && isset($node->webform_civicrm)) {
-        $filters = wf_crm_search_filters($node, $component);
-        $element['#options'] = wf_crm_contact_search($node, $component, $filters);
         $js = "$onChange wfCivi.existingInit(field, $c, {$node->nid}, $callback_path, toHide);";
-      }
-      // Display empty option unless there are no results
-      if (!$component['extra']['allow_create'] || count($element['#options']) > 1) {
-        $element['#empty_option'] = filter_xss($component['extra'][$element['#options'] ? 'search_prompt' : 'none_prompt']);
       }
       break;
 
@@ -485,16 +492,21 @@ function _webform_render_civicrm_contact($component, $value = NULL, $filter = TR
 
 /**
  * Lookup contact name from ID, verify permissions, and attach as html data.
- * Used when rendering or altering a CiviCRM contact field
  *
- * @param $node
+ * Used when rendering or altering a CiviCRM contact field.
+ *
+ * Also sets options for select lists.
+ *
+ * @param stdClass $node
  *   Node object
- * @param $component
+ * @param array $component
  *   Webform component
- * @param $element
+ * @param array $element
  *   FAPI form element (reference)
+ * @param array $ids
+ *   Known entity ids
  */
-function wf_crm_fill_contact_value($node, $component, &$element) {
+function wf_crm_fill_contact_value($node, $component, &$element, $ids = NULL) {
   $cid = wf_crm_aval($element, '#default_value', '');
   if ($element['#type'] == 'hidden') {
     // User may not change this value for hidden fields
@@ -519,6 +531,15 @@ function wf_crm_fill_contact_value($node, $component, &$element) {
   }
   if (empty($cid) && $element['#type'] == 'hidden' && $component['extra']['none_prompt']) {
     $element['#attributes']['data-civicrm-name'] = filter_xss($component['extra']['none_prompt']);
+  }
+  // Set options list for select elements. We do this here so we have access to entity ids.
+  if (is_array($ids) && $element['#type'] == 'select') {
+    $filters = wf_crm_search_filters($node, $component);
+    $element['#options'] = wf_crm_contact_search($node, $component, $filters, wf_crm_aval($ids, 'contact', array()));
+    // Display empty option unless there are no results
+    if (!$component['extra']['allow_create'] || count($element['#options']) > 1) {
+      $element['#empty_option'] = filter_xss($component['extra'][$element['#options'] ? 'search_prompt' : 'none_prompt']);
+    }
   }
 }
 
@@ -588,18 +609,20 @@ function _webform_csv_data_civicrm_contact($component, $export_options, $value) 
 /**
  * Returns a list of contacts based on component settings.
  *
- * @param $node
+ * @param stdClass $node
  *   Node object
- * @param $component
+ * @param array $component
  *   Webform component
- * @param $params
+ * @param array $params
  *   Contact get params (filters)
- * @param $str
+ * @param array $contacts
+ *   Existing contact data
+ * @param string $str
  *   Search string (used during autocomplete)
  *
  * @return array
  */
-function wf_crm_contact_search($node, $component, $params, $str = NULL) {
+function wf_crm_contact_search($node, $component, $params, $contacts, $str = NULL) {
   if (empty($node->webform_civicrm)) {
     return array();
   }
@@ -617,6 +640,18 @@ function wf_crm_contact_search($node, $component, $params, $str = NULL) {
     'sort' => $sort_field,
     'return' => $display_fields,
   );
+  if (!empty($params['relationship']['contact'])) {
+    $c = $params['relationship']['contact'];
+    $relations = NULL;
+    if (!empty($contacts[$c]['id'])) {
+      $relations = wf_crm_find_relations($contacts[$c]['id'], wf_crm_aval($params['relationship'], 'type'));
+      $params['id'] = array('IN' => $relations);
+    }
+    if (!$relations) {
+      return $ret;
+    }
+  }
+  unset($params['relationship']);
   if ($str) {
     $str = str_replace(' ', '%', CRM_Utils_Type::escape($str, 'String'));
     // The contact api takes a quirky format for display_name and sort_name
@@ -802,16 +837,16 @@ function wf_crm_update_existing_component(&$component, $enabled, $data) {
 /**
  * Get a contact's relations of certain types
  *
- * @param cid
+ * @param int cid
  *   Contact id
- * @param types
+ * @param array types
  *   Array of relationship_type_ids
- * @param $current
+ * @param bool $current
  *   Limit to current & enabled relations?
  *
  * @return array
  */
-function wf_crm_find_relations($cid, $types, $current = TRUE) {
+function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
   $found = $allowed = array();
   $cid = (int) $cid;
   static $employer_type = 0;
@@ -828,8 +863,9 @@ function wf_crm_find_relations($cid, $types, $current = TRUE) {
         FROM civicrm_contact
         WHERE id = $cid OR employer_id = $cid";
         $dao = CRM_Core_DAO::executeQuery($sql);
+        $employer = $dao->id == $cid ? $dao->employer_id : $dao->id;
         while ($dao->fetch()) {
-          $found[] = $dao->id == $cid ? $dao->employer_id : $dao->id;
+          $found[$employer] = $employer;
         }
         $dao->free();
       }
@@ -841,23 +877,25 @@ function wf_crm_find_relations($cid, $types, $current = TRUE) {
         $allowed[] = $type . '_b';
       }
     }
+    $typeClause = '';
     if ($type_ids) {
-      $sql = "SELECT relationship_type_id, contact_id_a, contact_id_b
-        FROM civicrm_relationship
-        WHERE relationship_type_id IN ($type_ids) AND (contact_id_a = $cid OR contact_id_b = $cid)";
-      if ($current) {
-        $sql .= " AND is_active = 1 AND (end_date > CURDATE() OR end_date IS NULL)";
-      }
-      $dao = CRM_Core_DAO::executeQuery($sql);
-      while ($dao->fetch()) {
-        $a_b = $dao->contact_id_a == $cid ? 'b' : 'a';
-        if (in_array($dao->relationship_type_id . '_' . $a_b, $allowed)) {
-          $c = $dao->{"contact_id_$a_b"};
-          $found[$c] = $c;
-        }
-      }
-      $dao->free();
+      $typeClause = "AND relationship_type_id IN ($type_ids)";
     }
+    $sql = "SELECT relationship_type_id, contact_id_a, contact_id_b
+      FROM civicrm_relationship
+      WHERE (contact_id_a = $cid OR contact_id_b = $cid) $typeClause";
+    if ($current) {
+      $sql .= " AND is_active = 1 AND (end_date > CURDATE() OR end_date IS NULL)";
+    }
+    $dao = CRM_Core_DAO::executeQuery($sql);
+    while ($dao->fetch()) {
+      $a_b = $dao->contact_id_a == $cid ? 'b' : 'a';
+      if (!$allowed || in_array($dao->relationship_type_id . '_' . $a_b, $allowed)) {
+        $c = $dao->{"contact_id_$a_b"};
+        $found[$c] = $c;
+      }
+    }
+    $dao->free();
   }
   return $found;
 }

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -60,6 +60,13 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
     $this->data = $this->node->webform_civicrm['data'];
     $component = $this->node->webform['components'][$fid];
     $filters = wf_crm_search_filters($this->node, $component);
+    // Populate other contact ids for related data
+    $this->ent += array('contact' => array());
+    foreach ($_GET as $k => $v) {
+      if (substr($k, 0, 3) == 'cid' && $v && is_numeric($v)) {
+        $this->ent['contact'][substr($k, 3)]['id'] = (int) $v;
+      }
+    }
     // Bypass filters when choosing contact on component edit form
     if (!empty($_GET['admin']) && wf_crm_admin_access($this->node)) {
       $filters = array('check_permissions' => 1, 'is_deleted' => 0, 'contact_type' => $filters['contact_type']);
@@ -68,7 +75,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
     // Autocomplete contact names
     if (!empty($_GET['str'])) {
       if ($str = trim($_GET['str'])) {
-        drupal_json_output(wf_crm_contact_search($this->node, $component, $filters, $str));
+        drupal_json_output(wf_crm_contact_search($this->node, $component, $filters, $this->ent['contact'], $str));
       }
       exit();
     }
@@ -89,13 +96,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
         $sp = CRM_Core_DAO::VALUE_SEPARATOR;
         $this->enabled = wf_crm_enabled_fields($this->node);
         list(, $c, ) = explode('_', $component['form_key'], 3);
-        // Populate other contact ids for related data
-        foreach ($_GET as $k => $v) {
-          if (substr($k, 0, 3) == 'cid' && $v && is_numeric($v)) {
-            $this->ent['contact'][substr($k, 3)]['id'] = (int) $v;
-          }
-          $this->ent['contact'][$c]['id'] = (int) $_GET['cid'];
-        }
+        $this->ent['contact'][$c]['id'] = (int) $_GET['cid'];
         // Redact fields if they are to be hidden unconditionally, otherwise they are needed on the client side
         $to_hide = (wf_crm_aval($component['extra'], 'hide_method', 'hide') == 'hide' && !wf_crm_aval($component['extra'], 'no_hide_blank')) ? $component['extra']['hide_fields'] : array();
         $contact = $this->loadContact($c, $to_hide);

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -270,13 +270,13 @@ abstract class wf_crm_webform_base {
           break;
         case 'relationship':
           $to = $component['extra']['default_relationship_to'];
-          if (!empty($this->ent['contact'][$to]['id'])) {
+          if (!empty($this->ent['contact'][$to]['id']) && !empty($component['extra']['default_relationship'])) {
             $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['extra']['default_relationship']);
           }
           break;
         case 'auto':
           $component['extra']['allow_create'] = FALSE;
-          $found = array_keys(wf_crm_contact_search($this->node, $component, $filters));
+          $found = array_keys(wf_crm_contact_search($this->node, $component, $filters, wf_crm_aval($this->ent, 'contact', array())));
           break;
       }
       if ($component['extra']['randomize']) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -522,7 +522,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             }
           }
           if ($name == 'existing') {
-            wf_crm_fill_contact_value($this->node, $component, $element);
+            wf_crm_fill_contact_value($this->node, $component, $element, $this->ent);
           }
           if ($name == 'contribution_page_id') {
             $element['#prefix'] = $this->displayLineItems();

--- a/js/contact_component.js
+++ b/js/contact_component.js
@@ -51,19 +51,30 @@ var wfCiviContact = (function ($, D) {
             .find(':checkbox')
             .prop('disabled', false);
         }
-        changeRelationTo();
+        $('#edit-extra-default-relationship-to', context).each(changeDefaultRelationTo);
       }
-      function changeRelationTo() {
-        var c = $('#edit-extra-default-relationship-to').val(),
-          types = $('#edit-extra-default-relationship-to').data('types')[c];
-        CRM.utils.setOptions('#edit-extra-default-relationship', types);
+      function changeDefaultRelationTo() {
+        var c = $(this).val(),
+          types = $(this).closest('form').data('reltypes')[c],
+          placeholder = types.length ? false : '- ' + Drupal.ts('No relationship types available for these contact types') + ' -';
+        CRM.utils.setOptions('#edit-extra-default-relationship', types, placeholder);
         // Provide default to circumvent "required" validation error
-        if ($('#edit-extra-default').val() !== 'relationship' && types.length === 1 && types[0].key === '') {
+        if ($('#edit-extra-default').val() !== 'relationship' && !types.length && types[0].key === '') {
           CRM.utils.setOptions('#edit-extra-default-relationship', {key: '-', value: '-'});
+          $('#edit-extra-default-relationship').val('-');
+        }
+      }
+      function changeFiltersRelationTo() {
+        var c = $(this).val(),
+          types = $(this).closest('form').data('reltypes')[c];
+        $('.form-item-extra-filters-relationship-type', context).toggle(!!c);
+        if (c) {
+          CRM.utils.setOptions('#edit-extra-filters-relationship-type', types);
         }
       }
       $('#edit-extra-default', context).once('wf-civi').change(changeDefault).each(changeDefault);
-      $('#edit-extra-default-relationship-to', context).once('wf-civi').change(changeRelationTo);
+      $('#edit-extra-default-relationship-to', context).once('wf-civi').change(changeDefaultRelationTo);
+      $('#edit-extra-filters-relationship-contact', context).once('wf-civi').change(changeFiltersRelationTo).each(changeFiltersRelationTo);
       $('#edit-extra-widget', context).once('wf-civi').change(function() {
         if ($(this).val() == 'hidden') {
           $('.form-item-extra-search-prompt', context).css('display', 'none');

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -47,11 +47,16 @@ var wfCivi = (function ($, D) {
     }
   };
 
-  pub.existingInit = function ($field, num, nid, path, toHide) {
+  pub.existingInit = function ($field, num, nid, path, toHide, tokenInputSettings) {
     var cid = $field.val(),
-      ret = null,
+      prep = null,
       hideOrDisable = $field.attr('data-hide-method'),
       showEmpty = $field.attr('data-no-hide-blank') == '1';
+
+    function getCallbackPath() {
+      return path + (path.indexOf('?') < 0 ? '?' : '&') + $.param(getCids(nid));
+    }
+
     if ($field.length) {
       if ($field.is('[type=hidden]') && !cid) {
         return;
@@ -61,9 +66,9 @@ var wfCivi = (function ($, D) {
       }
       if (cid) {
         if (cid == $field.attr('data-civicrm-id')) {
-          ret = [{id: cid, name: $field.attr('data-civicrm-name')}];
+          prep = [{id: cid, name: $field.attr('data-civicrm-name')}];
         }
-        else if ($field.is(':text')) {
+        else if (tokenInputSettings) {
           // If for some reason the data is not embedded, fetch it from the server
           $.ajax({
             url: path,
@@ -72,14 +77,19 @@ var wfCivi = (function ($, D) {
             async: false,
             success: function(data) {
               if (data) {
-                ret = [{id: cid, name: data}];
+                prep = [{id: cid, name: data}];
               }
             }
           });
         }
       }
+      if (tokenInputSettings) {
+        tokenInputSettings.queryParam = 'str';
+        tokenInputSettings.tokenLimit = 1;
+        tokenInputSettings.prePopulate = prep;
+        $field.tokenInput(getCallbackPath, tokenInputSettings);
+      }
     }
-    return ret;
   };
 
   pub.initFileField = function(field, info) {


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new filter option:

![screenshot from 2018-08-27 14-42-59](https://user-images.githubusercontent.com/2874912/44678921-92409880-aa07-11e8-91bc-adb29a90217a.png)

Notes
-----
This filter should work with just about every webform configuration, including autocomplete lists, and multipage forms. Demo:

1. Create a new webform with 3 contacts.
2. Add an "Existing contact" field for all 3.
3. Edit the Contact 2 "Existing contact" field: set widget to "Select" and set a relationship filter to Contact 1.
4. Edit the Contact 2 "Existing contact" field: set widget to "Autocomplete" and set a relationship filter to Contact 2.
5. Try the form. You'll see that contact 2 has a dropdown populated by relations to the current logged in user. Changing that selection will update the autocomplete results for contact 3 in real-time.

Limitations
------
The one thing it won't do is update a `Select` list on-the-fly. E.g. if the Contact 3 widget was `Select` in the above scenario it wouldn't update the Contact 3 list in realtime. Workaround is to put a page break between contacts 2 and 3, or use autocomplete widget.