### PR TITLE
Tally line items with javascript

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -446,6 +446,11 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           if (!empty($field['data_type'])) {
             $dt = $element['#civicrm_data_type'] = $field['data_type'];
           }
+          $element['#attributes']['data-civicrm-field-key'] = $eid;
+          // For contribution line-items
+          if ($table == 'contribution' && in_array($name, array('line_total', 'total_amount'))) {
+            $element['#attributes']['class'][] = 'contribution-line-item';
+          }
           // Provide live options from the Civi DB
           if (!empty($component['extra']['civicrm_live_options']) && isset($element['#options'])) {
             $params = array('extra' => wf_crm_aval($field, 'extra', array())) + $component;

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -3,7 +3,6 @@ cj(function($) {
   'use strict';
   var
     setting = Drupal.settings.webform_civicrm,
-    $contributionAmount = $('.civicrm-enabled[name*="[civicrm_1_contribution_1_contribution_total_amount]"]'),
     $processorFields = $('.civicrm-enabled[name$="civicrm_1_contribution_1_contribution_payment_processor_id]"]');
 
   function getPaymentProcessor() {
@@ -97,19 +96,21 @@ cj(function($) {
     return total < 0 ? 0 : total;
   }
 
-  function calculateContributionAmount() {
-    var amount = getFieldAmount('civicrm_1_contribution_1_contribution_total_amount');
-    var label = $contributionAmount.closest('div.webform-component').find('label').html() || Drupal.t('Contribution');
-    updateLineItem('civicrm_1_contribution_1', amount, label);
+  function calculateLineItemAmount() {
+    var fieldKey = $(this).data('civicrmFieldKey'),
+      amount = getFieldAmount(fieldKey),
+      label = $(this).closest('div.webform-component').find('label').text() || Drupal.t('Contribution'),
+      lineKey = fieldKey.split('_').slice(0, 4).join('_');
+    updateLineItem(lineKey, amount, label);
   }
 
-  if ($contributionAmount.length) {
-    calculateContributionAmount();
-    $contributionAmount.on('change keyup', calculateContributionAmount);
-    // Also use Drupal's jQuery to listen to this event, for compatibility with other modules
-    jQuery($contributionAmount[0]).change(calculateContributionAmount);
-  }
-  else {
-    tally();
-  }
+  $('.civicrm-enabled.contribution-line-item')
+    .each(calculateLineItemAmount)
+    .on('change keyup', calculateLineItemAmount)
+    .each(function() {
+      // Also use Drupal's jQuery to listen to this event, for compatibility with other modules
+      jQuery(this).change(calculateLineItemAmount);
+    });
+
+  tally();
 });


### PR DESCRIPTION
Overview
----------------------------------------
Follow up on #159 - tallies line items on-the-fly without requiring a page break.

Before
----------------------------------------
Line items were only tallied properly if they were not on the last page of the webform.

After
----------------------------------------
Line items tallied on any page.