### PR TITLE
Making Financial Types for Membership configurable.

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -84,6 +84,10 @@ function wf_crm_field_options($field, $context, $data) {
       if ($table == 'contribution' && strpos($name, 'frequency_') === 0) {
         $table = 'contribution_recur';
       }
+      // Use the Contribution table to pull up financial type id-s
+      if ($table == 'membership' && $name == 'financial_type_id') {
+        $table = 'contribution';
+      }
       // Custom fields - use main entity
       if (substr($table, 0, 2) == 'cg') {
         $table = $ent;
@@ -1138,6 +1142,13 @@ function wf_crm_get_fields($var = 'fields') {
         'type' => 'select',
         'expose_list' => TRUE,
         'extra' => array('civicrm_live_options' => 1),
+      );
+      $fields['membership_financial_type_id'] = array(
+        'name' => t('Membership Financial Type'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
       $fields['membership_status_id'] = array(
         'name' => t('Override Status'),

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1547,11 +1547,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               }
             }
 
+            $membership_financialtype = $this->getMembershipTypeField($type, 'financial_type_id');
+            if (isset($item['financial_type_id']) && $item['financial_type_id'] !=0 ) {
+              $membership_financialtype = $item['financial_type_id'];
+            };
+
             if ($price) {
               $this->line_items[] = array(
                 'qty' => $item['num_terms'],
                 'unit_price' => $price,
-                'financial_type_id' => $this->getMembershipTypeField($type, 'financial_type_id'),
+                'financial_type_id' => $membership_financialtype,
                 'label' => $this->getMembershipTypeField($type, 'name') . ": " . wf_crm_display_name($this->existing_contacts[$c]),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',


### PR DESCRIPTION
Overview
----------------------------------------
This PR makes it possible for admin to configure Financial Type for Membership on the Webform. It emulates how one can do that natively in CiviCRM with Pricesets. 

Before
----------------------------------------
Financial Type was always taken directly from the Membership Type Configuration in CiviCRM: 
`$membership_financialtype = $this->getMembershipTypeField($type, 'financial_type_id');`

After
----------------------------------------
Now that Membership Financial Type is configurable - the Webform can be configured to automatically add the Financial Type that has the correct Sales Tax (GST) associated with it - based on the Province the Member lives in - using native Webform conditionals. [Note: could not get the conditionals to work with AJAX select so edited the widget to select options]

![image](https://user-images.githubusercontent.com/5340555/44951392-37041100-ae20-11e8-93ce-858b5fa50aac.png)

![image](https://user-images.githubusercontent.com/5340555/44951394-42573c80-ae20-11e8-9f19-c29e823a216e.png)

Technical Details
----------------------------------------
Modeled after participant status (with - Automatic - option as default)
Default behaviour (if no Membership Financial Type on the form) is to take Financial Type directly from the Membership Type Configuration in CiviCRM.

Comment
----------------------------------------
Will be testing this live on one of our projects this week. 
 
