### PR TITLE
CATL-1017: Support For Using Custom Contact Ref Fields To Autofill Contact In Webforms

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -41,6 +41,7 @@ function _webform_defaults_civicrm_contact() {
       'default_contact_id' => '',
       'default_relationship' => '',
       'default_relationship_to' => '1',
+      'default_custom_ref' => '',
       'allow_url_autofill' => TRUE,
       'dupes_allowed' => FALSE,
       'filters' => array(
@@ -238,6 +239,15 @@ function _webform_edit_civicrm_contact($component) {
       '#parents' => array('extra', 'default_relationship'),
     );
   }
+  $form['defaults']['default']['#options']['custom_ref'] = t('Custom reference field');
+  $form['defaults']['default_custom_ref'] = array(
+    '#type' => 'select',
+    '#title' => t('Specify Custom Field'),
+    '#options' => wf_crm_get_custom_ref_options(),
+    '#required' => TRUE,
+    '#default_value' => $component['extra']['default_custom_ref'],
+    '#parents' => array('extra', 'default_custom_ref'),
+  );
   $form['defaults']['default']['#options']['auto'] = t('Auto - From Filters');
   $form['defaults']['default_contact_id'] = array(
     '#type' => 'textfield',
@@ -898,6 +908,44 @@ function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
     $dao->free();
   }
   return $found;
+}
+
+/**
+ * Returns a list of all custom CiviCRM fields of type "ContactReference"
+ *
+ * @return array
+ */
+function wf_crm_get_custom_ref_options() {
+  $filters = array(
+    'sequential' => 1,
+    'return' => ["id", "label"],
+    'data_type' => "ContactReference",
+  );
+  $result = wf_civicrm_api('CustomField', 'get', $filters);
+  $options = array();
+  foreach ($result['values'] as $val) {
+    $options[$val['id']] = $val['label'];
+  }
+  return $options;
+}
+
+/**
+ * Returns ids of all contacts who have reference to given contact via given custom field id
+ *
+ * @param $cid
+ * @param $customFieldID
+ * @return array
+ */
+function wf_crm_find_custom_refs($cid, $customFieldID) {
+  $filters = array(
+    'return' => ['custom_'.$customFieldID],
+    'id' => $cid,
+  );
+  $result = wf_civicrm_api('Contact', 'get', $filters);
+  if (isset($result['values'][$cid]['custom_'.$customFieldID])) {
+    return array($result['values'][$cid]['custom_'.$customFieldID] => $result['values'][$cid]['custom_'.$customFieldID]);
+  }
+  return array();
 }
 
 /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -274,6 +274,12 @@ abstract class wf_crm_webform_base {
             $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['extra']['default_relationship']);
           }
           break;
+        case 'custom_ref':
+          $to = $component['extra']['default_relationship_to'];
+          if (!empty($this->ent['contact'][$to]['id'])) {
+            $found = wf_crm_find_custom_refs($this->ent['contact'][$to]['id'], $component['extra']['default_custom_ref']);
+          }
+          break;
         case 'auto':
           $component['extra']['allow_create'] = FALSE;
           $found = array_keys(wf_crm_contact_search($this->node, $component, $filters, wf_crm_aval($this->ent, 'contact', array())));

--- a/js/contact_component.js
+++ b/js/contact_component.js
@@ -44,8 +44,11 @@ var wfCiviContact = (function ($, D) {
             $(this).css('display', 'none');
             $(':checkbox', this).prop('disabled', true);
           }
+          if (val == 'custom-ref' && $(this).is('[class*=form-item-extra-default-relationship-to]')) {
+            $(this).removeAttr('style');
+          }
         });
-        if (val === 'auto' || val === 'relationship') {
+        if (val === 'auto' || val === 'relationship' || val == 'custom-ref') {
           $('.form-item-extra-randomize, .form-item-extra-dupes-allowed')
             .removeAttr('style')
             .find(':checkbox')


### PR DESCRIPTION

Overview
----------------------------------------
This ticket is targeted at improving the data loading capabilities of the ‘Existing Contact’ field of the Webform CiviCRM through the default contact setting
With this new setting - we will be able to preload the existing contact field with values derived from a particular custom field on the contact on the webform

Before
----------------------------------------
Currently we have the ability to load the existing contact fields of a contact on the webform with the following options:
Set default contact from:
Relationship to - Specify Contact - Specify Relationship

After
----------------------------------------
We have a new option in the default value options of the existing contact field on the webform.
![sample](https://user-images.githubusercontent.com/36624620/45292573-3c91e300-b513-11e8-8630-6bac7251e3ad.jpg)
