### PR TITLE
Support permissioned relationships for multiple contacts

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -699,9 +699,54 @@ function wf_crm_contact_access($component, $filters, $cid) {
       }
     }
   }
+
+  // Check if the logged in contact has permission via a relationship
+  $filters = wf_crm_contact_access_relationship($filters);
+
   // Fetch contact name with filters applied
   $result = wf_civicrm_api('contact', 'get', $filters);
   return wf_crm_format_contact(wf_crm_aval($result, "values:$cid"), $component['extra']['results_display']);
+}
+
+/**
+ * Check if the logged in contact has permission via a relationship to view another contact
+ *
+ * @param $filters
+ *
+ * @return array
+ * @throws \CiviCRM_API3_Exception
+ */
+function wf_crm_contact_access_relationship($filters) {
+  if (empty($filters['check_permissions'])) {
+    // Don't do anything if we are not checking permissions
+    return $filters;
+  }
+
+  $loggedInContactId = wf_crm_user_cid();
+  if (empty($loggedInContactId)) {
+    // Not logged in
+    return $filters;
+  }
+
+  $contactRelationships = civicrm_api3('Relationship', 'get', [
+    'contact_id' => $loggedInContactId,
+    'return' => ['rtype', 'is_permission_a_b', 'is_permission_b_a']
+  ]);
+  if (empty($contactRelationships['count'])) {
+    // Logged in contact has no relationships
+    return $filters;
+  }
+
+  // Logged in contact has relationships, see if any match the requested contact ID,
+  //  and if they have permission to view(2), view/edit(1) them.
+  foreach ($contactRelationships['values'] as $relationship) {
+    if (($relationship['cid'] == $filters['id'])
+      && ($relationship['is_permission_' . $relationship['rtype']] > 0))
+    {
+      $filters['check_permissions'] = FALSE;
+    }
+  }
+  return $filters;
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
If you are logged in as contact 1, allow access to other contacts that they have a permissioned relationship with.

Create a webform with two contacts, both should have "Existing Contact" field enabled.

For example, user is logged in as contact ID 1.
Contact ID 1 has a permissioned relationship with Contact ID 2:
- Contact ID 1 is Parent Of Contact ID 2
- Contact ID 1 has permission to View/Edit Contact ID 2

Before
----------------------------------------
Cannot load details for Contact ID 2.  Contact ID 2 details are blank.

After
----------------------------------------
Can load details for Contact ID 2 (eg. on URL: cid2=2). Contact ID 2 details are filled in.

Technical Details
----------------------------------------
Previously, webform_civicrm did not check for any permissioned relationships between contacts.  Now it does.
