### PR TITLE
Make sure billing parameters are formatted correctly when submitting via a redirect payment processor

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1915,6 +1915,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['source'] = $this->settings['new_contact_source'];
     $params['item_name'] = $params['description'] = t('Webform Payment: @title', array('@title' => $this->node->title));
 
+    // We need the submitted billing params from the request (Eg. billing_country_id-5)
+    //  because that's how payment processors expect to find them.
+    foreach ($this->form_state['input'] as $formKey => $formValue) {
+      if (substr($formKey, 0, 8) === 'billing_') {
+        $params[$formKey] = $formValue;
+      }
+    }
+
     if (method_exists($paymentProcessor, 'setSuccessUrl')) {
       $paymentProcessor->setSuccessUrl($this->getIpnRedirectUrl('success'));
       $paymentProcessor->setCancelUrl($this->getIpnRedirectUrl('cancel'));


### PR DESCRIPTION
Overview
----------------------------------------
All built-in CiviCRM forms that take payment pass billing params through in the format (eg) billing_state_province-5 rather than just state_province before submitting to a (redirect) payment processor.  Webform_civicrm does not, and this causes problems if the payment processor expects the address to be in the format eg `billing_state_province-5` instead of `state_province`.

This was found while integrating Omnipay Sagepay with webform_civicrm.

Before
----------------------------------------
Cannot submit payment via a "redirect" payment processor that has been written to expect billing address parameters to be in the "standard" format.

After
----------------------------------------
Can submit payment via a "redirect" payment processor such as Omnipay Sagepay.  For any processors that are clever enough to look for address fields with different keys there will be no change.

Technical Details
----------------------------------------
Merge $params with $_REQUEST which contains the required parameters in the expected format.

Comments
----------------------------------------
@eileenmcnaughton @pradnayak