### PR TITLE
Fix issue #3005653 - Do not translate the groupContact "method" string.

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -891,7 +891,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     switch ($data_type) {
       case 'group':
         $api = 'group_contact';
-        $params['method'] = t('Webform');
+        $params['method'] = 'Webform';
         break;
       case 'tag':
         $api = 'entity_tag';


### PR DESCRIPTION
Overview
----------------------------------------
This string is not meant to be translated and was causing field-length db errors.

See bug report in https://www.drupal.org/project/webform_civicrm/issues/3005653