### PR TITLE
Fix default selection of multi-select element

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1346,6 +1346,9 @@ class wf_crm_admin_form {
         $options = array_keys($options);
         $item['#default_value'] = $options[1];
       }
+      elseif (!empty($this->data[$ent][$c][$table][$n]) && empty($this->data[$ent][$c][$table][$n][$name]) && $item['#default_value'] == 0) {
+        $item['#default_value'] = NULL;
+      }
       if (!empty($field['extra']['multiple'])) {
         $item['#default_value'] = (array) $item['#default_value'];
         if (isset($this->settings[$fid]) && !is_array($this->settings[$fid])


### PR DESCRIPTION
Overview
----------------------------------------
Multi-select option does not stick on the form when we re-edit.

Before
----------------------------------------
To reproduce -

1. Create a webform -> Click on Activities tab.
2. Toggle the multi-select field `Assign Activity to` to single select and save `none` option for the input field.

![image](https://user-images.githubusercontent.com/5929648/46947648-1d015380-d099-11e8-946d-679f7b8d68c7.png)


2. Save the form and try to edit again. The field selection remains the default one and the setting saved in the above step is lost. 

![image](https://user-images.githubusercontent.com/5929648/46947668-31dde700-d099-11e8-8331-f87d8768cd2a.png)


After
----------------------------------------
The value `none` is saved and retrieved correctly on editing the webform.

