### PR TITLE
Load default location type for address/phone/email configured in civi

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -778,13 +778,14 @@ function wf_crm_get_fields($var = 'fields') {
       'type' => 'select',
       'expose_list' => TRUE,
     );
+    $defaultLocType = CRM_Core_BAO_LocationType::getDefault();
     foreach (array('address' => t('Address # Location'), 'phone' => t('Phone # Location'), 'email' => t('Email # Location'), 'im' => t('IM # Location')) as $key => $label) {
       if (isset($sets[$key])) {
         $fields[$key . '_location_type_id'] = array(
           'name' => $label,
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => '1',
+          'value' => $defaultLocType->id,
         );
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Load default location type for address/phone/email as per civi configuration.

Before
----------------------------------------
On webform - default location type is loaded as `Home` even if `Main` is selected as default in `civicrm/admin/locationType?reset=1`

![image](https://user-images.githubusercontent.com/5929648/47082056-19510680-d22a-11e8-88c9-13358cc9609e.png)


After
----------------------------------------
Default loc type is loaded according to the default configured in civi.
