### PR TITLE
Prefer case relationship if case id is present in the URL

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -881,7 +881,7 @@ function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
     if ($type_ids) {
       $typeClause = "AND relationship_type_id IN ($type_ids)";
     }
-    $sql = "SELECT relationship_type_id, contact_id_a, contact_id_b
+    $sql = "SELECT relationship_type_id, contact_id_a, contact_id_b, case_id
       FROM civicrm_relationship
       WHERE (contact_id_a = $cid OR contact_id_b = $cid) $typeClause";
     if ($current) {
@@ -893,6 +893,10 @@ function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
       if (!$allowed || in_array($dao->relationship_type_id . '_' . $a_b, $allowed)) {
         $c = $dao->{"contact_id_$a_b"};
         $found[$c] = $c;
+        if ($type_ids && !empty($dao->case_id) && !empty($_GET["case1"]) && $_GET["case1"] == $dao->case_id) {
+          //Make this contact as a first value in the array.
+          $found = array_merge([$c => $c], $found);
+        }
       }
     }
     $dao->free();


### PR DESCRIPTION
Overview
----------------------------------------
Prefer case relationship to load on a contact if caseid is present in the URL. 

Before
----------------------------------------
Eg - 

- A has multiple "Referring Officer" relationship with contact B and C.

- The relationship of Contact C is attached to case id 1.

- webform contact input field has a default value set as below -

![image](https://user-images.githubusercontent.com/5929648/47213386-75e22c00-d3b8-11e8-999c-6d545bc2cf05.png)

- Now, if a webform is loaded with `case1=1` param in the URL, it loads the contact which is related to contact A, but do not actually prefer the case related contact, which might make more sense to load as a default one?

After
----------------------------------------
If there are multiple relationship with a contact - load the case related contact if there is a case id in the URL.

Comments
----------------------------------------
If this doesn't seem to be a safe fix, should we just add a setting on the component page? eg `Load case related contact if case id is present in the URL`.