### PR TITLE
Remove clearfix additions to remove gaps on admin settings form.

### DIFF
--- a/css/webform_civicrm_admin.css
+++ b/css/webform_civicrm_admin.css
@@ -29,11 +29,6 @@ form .web-civi-checkbox-set .auto-width .form-item {
   padding-top: 0;
 }
 
-.web-civi-checkbox-set + div,
-.civicrm-ajax-wrapper {
-  clear:both;
-}
-
 form .hidden,
 .js #no-js-button-wrapper {
   display:none;

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -272,9 +272,6 @@ class wf_crm_admin_form {
       );
     }
 
-    $this->form['contact_' . $n]['contact_subtype_wrapper']['clear'] = array(
-      '#markup' => '<div class="clearfix"> </div>',
-    );
     foreach ($this->sets as $sid => $set) {
       if ($set['entity_type'] != 'contact') {
         continue;


### PR DESCRIPTION
Overview
----------------------------------------
The settings form for Webform CiviCRM on a webform has huge gaps. This is due to the various clearfixes, somehow.

Before
----------------------------------------
`@todo`

After
----------------------------------------
`@todo`

Technical Details
----------------------------------------
Fixes the UI

Comments
----------------------------------------

It's easily testable on a Contact tab -> after the type select there's a large gap for the next fieldset. Same with configuring a membership
