### PR TITLE
Fix getCreditCardCSSNames() call which is deleted from core civi

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -867,8 +867,18 @@ abstract class wf_crm_webform_base {
    * @return int|null
    */
   function addPaymentJs() {
-    CRM_Core_Resources::singleton()->addCoreResources();
-    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    $currentVer = CRM_Core_BAO_Domain::version();
+    if (version_compare($currentVer, '5.8') <= 0 && method_exists('CRM_Core_Payment_Form', 'getCreditCardCSSNames')) {
+      $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
+      CRM_Core_Resources::singleton()
+        ->addCoreResources()
+        ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
+        ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    }
+    else {
+      CRM_Core_Resources::singleton()->addCoreResources();
+      CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    }
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -867,11 +867,8 @@ abstract class wf_crm_webform_base {
    * @return int|null
    */
   function addPaymentJs() {
-    $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
-    CRM_Core_Resources::singleton()
-      ->addCoreResources()
-      ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    CRM_Core_Resources::singleton()->addCoreResources();
+    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on the webform

Before
----------------------------------------
`getCreditCardCSSNames()` function is deleted from core civi in the PR merged yesterday https://github.com/civicrm/civicrm-core/pull/12615. The core civi PR defines two `protected` function in order to set the js in core. Webform civi still uses the old function call which leads to a fatal error in viewing any of the webform.

After
----------------------------------------
Replaced the deleted function with the one used in core. The fatal error is fixed.

