### PR TITLE
Element contains ignored property weight

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1696,7 +1696,8 @@ class wf_crm_admin_form {
                 $field += array(
                   // 'nid' => $nid,
                   'form_key' => $key,
-                  'weight' => $i,
+                  // @note: specifying the weight gets it rejected by the Webform UI.
+                  // 'weight' => $i,
                 );
                 // Cannot use isNewFieldset effectively.
                 $previous_data = $handler_configuration['settings'];


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://www.drupal.org/project/webform_civicrm/issues/3003926

Technical Details
----------------------------------------
This removes the legacy property being set: weight. Apparently, we cannot define these when building the CiviCRM elements.