### PR TITLE
Use the payment processor payment method instead of the default configured one 

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1911,13 +1911,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params = $this->contributionParams();
     $params['contribution_status_id'] = 'Pending';
     $params['is_pay_later'] = $this->contributionIsPayLater;
-    //Fix IPN payments marked as paid by cheque
-    if (empty($params['payment_instrument_id'])) {
-      if (!empty($params['payment_processor_id']) && $this->contribution_page['is_monetary']) {
-        $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
-        $params['payment_instrument_id'] = key($defaultPaymentInstrument);
-      }
-    }
 
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
@@ -2105,6 +2098,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         'is_test' => 1,
         'domain_id' => $domain,
       ));
+    }
+
+    if (empty($params['payment_instrument_id'])) {
+      $params['payment_instrument_id'] = $this->getPaymentInstrument($params['payment_processor_id']);
     }
 
     // doPayment requries payment_processor and payment_processor_mode fields.
@@ -2625,5 +2622,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     return $values;
+  }
+
+  private function getPaymentInstrument($paymentProcessorId) {
+    $processor = \Civi\Payment\System::singleton()->getById($paymentProcessorId);
+    return $processor->getPaymentInstrumentID();
   }
 }


### PR DESCRIPTION
Before
----------------------------------------
If you have a payment processor with the payment method  configured to be for example Cash or EFT or whatever, then generated contribution after submitting the webform will always use the default payment method instead of the payment processor payment method.

For example we have here a payment processor that is using **manual payment** class and configured to use "EFT" payment method : 

<img width="723" alt="2018-04-27 17_33_19-" src="https://user-images.githubusercontent.com/6275540/39368277-110212de-4a31-11e8-8bd8-f29d64333c4d.png">


and the site default payment method is set "Check" : 

<img width="778" alt="2018-04-27 17_37_35-payment methods options _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39368317-251e24a6-4a31-11e8-9b65-995f7bdfdc4e.png">

After submitting a webform payment using this payment processor, here is generated contribution : 

<img width="696" alt="2018-04-27 17_32_49-tt122121 aa com tt122121 aa com _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39368350-3ab7d0fa-4a31-11e8-892b-90f52a0ce2dd.png">


As u can see, it used the default site payment method instead of the payment processor payment method.



After
----------------------------------------

I changed the code to use the payment processor payment method instead  : 

<img width="730" alt="2018-04-27 17_34_01-" src="https://user-images.githubusercontent.com/6275540/39368389-5800f1f0-4a31-11e8-895d-623cc47f962e.png">



Know issue
----------------------------------------
What is fixed in the PR above will only work for payment processors that are configured to use "Payment_Manual" class, in which payments will be considered as an offline payment. The reason for live payments, we are using the Contribution API **transact** action which will change the instrument method based on the payment processor payment_type field.

The code in this line shows that https://github.com/civicrm/civicrm-core/blob/master/api/v3/Contribution.php#L437

And as you can see, if the payment type of the payment processor is a "credit" then the API will change the payment method to "Credit Card", and if the payment type "debit" then it will change the payment method to "Debit Card" 

This isssue is fixed in this Core PR : https://github.com/civicrm/civicrm-core/pull/13073

