### PR TITLE
Adding membership Auto-renewal support

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -77,6 +77,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'auto_renew') {
+      $ret = array(1 => t('Yes'), 0 => t('No'));
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = array('field' => $name, 'context' => 'create');
@@ -1226,6 +1229,12 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_end_date'] = array(
         'name' => t('End Date'),
         'type' => 'date',
+      );
+      $fields['membership_auto_renew'] = array(
+        'name' => t('Auto-renew Membership?'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
       );
     }
     // Add campaign fields

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1198,6 +1198,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $params['contribution_recur_id'] = $this->ent['contribution_recur'][1]['id'];
       }
 
+      // if the membership is to be auto-renewed, we set its related recurring contribution ID
+      if (!empty($params['auto_renew'])) {
+        $contributionID = $this->ent['contribution'][1]['id'];
+        $contribution = wf_civicrm_api('Contribution', 'get', array(
+            'sequential' => 1,
+            'id' => $contributionID,
+            'return' => array('contribution_recur_id'),
+          )
+        );
+
+        if (!empty($contribution['values'][0]['contribution_recur_id'])) {
+          $params['contribution_recur_id'] = $contribution['values'][0]['contribution_recur_id'];
+        }
+      }
+      unset($params['auto_renew']);
+
       $result = wf_civicrm_api('membership', 'create', $params);
 
       if (!empty($result['id'])) {
@@ -1758,11 +1774,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    */
   private function submitLivePayment() {
     $contributionParams = $this->contributionParams();
+    $recurContributionExtraParams = $this->generateRecurringContributionParams($contributionParams);
+    $contributionParams = array_merge($contributionParams, $recurContributionExtraParams);
 
-    // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
-    $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
-    $frequencyInterval = wf_crm_aval($contributionParams, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval)) {
+    if (!empty($recurContributionExtraParams)) {
       $result = $this->contributionRecur($contributionParams);
     }
     else {
@@ -1778,6 +1793,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
       return;
     }
+
     $this->ent['contribution'][1]['id'] = $result['id'];
   }
 
@@ -1816,6 +1832,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'currency' => $contributionParams['currency'],
       'payment_processor_id' =>  $contributionParams['payment_processor_id'],
       'financial_type_id' =>  $contributionParams['financial_type_id'],
+      'auto_renew' =>  !empty($contributionParams['auto_renew']) ? 1 : 0,
     );
 
     if(empty($contributionParams['payment_processor_id'])) {
@@ -1889,9 +1906,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
     }
 
-    $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
-    $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    $recurContributionExtraParams = $this->generateRecurringContributionParams($params);
+    $params = array_merge($params, $recurContributionExtraParams);
+
+    if ($this->contributionIsPayLater && !empty($recurContributionExtraParams)) {
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {
@@ -2596,4 +2614,83 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     return $values;
   }
+
+  /**
+   * This generates a list of recurring contribution parameters
+   * to be appended to the original ones if there is a need to
+   * generated a recurring contribution. If there is no need then
+   * and empty array will be returned.
+   *
+   * Cases in which a recurring contribution need to be created is if there
+   * are memberships (or one membership) to be auto renewed or when there
+   * is a recurring contribution configured by the user on the webform.
+   */
+  private function generateRecurringContributionParams($contributionParams) {
+    $generatedParams = array();
+    $installmentsCount = wf_crm_aval($contributionParams, 'installments', 1, TRUE);
+
+    if ($this->isThereMembershipToBeAutoRenewed()) {
+      $generatedParams['installments'] = 'null';
+      $generatedParams['auto_renew'] = 1;
+      if (empty($contributionParams['frequency_unit']) || empty($contributionParams['frequency_interval'])) {
+        $minimumFrequencyData =  $this->calculateFrequencyUnitAndInterval();
+        $generatedParams['frequency_unit'] = $minimumFrequencyData['unit'];
+        $generatedParams['frequency_interval'] = $minimumFrequencyData['interval'];
+      }
+    }
+
+    if ($installmentsCount > 1) {
+      $generatedParams['installments'] = $installmentsCount;
+    }
+
+    return $generatedParams;
+  }
+
+  /**
+   * Determines if the webform is configured to have
+   * any membership to be autorenwed or not.
+   */
+  private function isThereMembershipToBeAutoRenewed() {
+    $autoRenewMembership = FALSE;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if (!empty($membership['auto_renew'])) {
+          $autoRenewMembership = TRUE;
+        }
+      }
+    }
+
+    return $autoRenewMembership;
+  }
+
+  /**
+   * If the user did not configure a recurring contribution
+   * or did not configure the frequency unit or Interval for it,
+   * this method will take care of that and generate both
+   * based on the frequency unit and duration of the membership.
+   */
+  private function calculateFrequencyUnitAndInterval() {
+    $membershipsTypeId = NULL;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      if (!empty($membershipsTypeId)) {
+        break;
+      }
+
+      foreach($contactMemberships['membership'] as $membership) {
+        if ($membership['auto_renew']) {
+          $membershipsTypeId = $membership['membership_type_id'];
+          break;
+        }
+      }
+    }
+
+    $membershipTypeDetails = civicrm_api3('MembershipType', 'get', array(
+      'id' => $membershipsTypeId,
+      'sequential' => 1,
+      'return' => array('duration_unit', 'duration_interval'),
+    ))['values'][0];
+
+    return ['unit' => $membershipTypeDetails['duration_unit'], 'interval' => $membershipTypeDetails['duration_interval']];
+  }
+
 }

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -513,6 +513,29 @@ var wfCiviAdmin = (function ($, D) {
         }
       }).change();
 
+      var autorenewMembershipsTracker = {};
+      var $membershipPageSelect = $('.form-item-membership-1-number-of-membership');
+      $('select[name$=_membership_auto_renew]').change(function(e, type) {
+        var fieldName = $(this).attr('name');
+        autorenewMembershipsTracker[fieldName] = $(this).val();
+
+        autorenew_counter = 0;
+        for(var key in autorenewMembershipsTracker){
+          if (autorenewMembershipsTracker[key] != 0) {
+            autorenew_counter++;
+          }
+        }
+
+        if (autorenew_counter > 1) {
+          if (!$('.wf-crm-membership-autorenew-alert').length) {
+            var msg = Drupal.t("Ensure that the memberships selected to be Auto-Renewed have the same frequency unit and interval or otherwise it might not work well !");
+            $membershipPageSelect.after('<div class="messages error wf-crm-membership-autorenew-alert">' + msg + '</div>');
+          }
+        } else {
+          $('.wf-crm-membership-autorenew-alert').remove();
+        }
+      });
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         // Warning about contribution page with no email


### PR DESCRIPTION
This is an alternative to this PR : https://github.com/colemanw/webform_civicrm/pull/133

Overview
----------------------------------------
Adding Membership Auto-renewal support to webform



Before
----------------------------------------
This module currently does not provide a way to auto-renew memberships.


After
----------------------------------------
The ability to set a membership to be auto-renewed is now available, you can either set the membership to be auto-renewed automatically, or not to be auto-renewed (which is the default option), or to allow the user to selected whither to set the membership to be auto renewed or not as u can see below : 

<img width="600" alt="2018-04-27 13_59_31-pp test _ dmaster8" src="https://user-images.githubusercontent.com/6275540/39359592-81f5362a-4a12-11e8-8972-80229af5adbb.png">


If the membership is set to be auto-renewed automatically, or if the end user selected the membership to be auto-renewed then a recurring contribution record will be created with auto_renew field set to TRUE, and the created memberships will have their contribution_recur_id field refer to the newly created recurring contribution ID.

Here is an example with one/no installments : 

![111111](https://user-images.githubusercontent.com/6275540/39359777-4c085f96-4a13-11e8-9e7e-9d4d83e1cbae.gif)


![2222222222222](https://user-images.githubusercontent.com/6275540/39359784-4ec6132c-4a13-11e8-8d98-71687733f03a.gif)



And here is another one with 3 installments : 

![3333333333](https://user-images.githubusercontent.com/6275540/39359868-a8a7b8e6-4a13-11e8-8340-769db4a3f081.gif)

![44444444](https://user-images.githubusercontent.com/6275540/39359874-abbacfd2-4a13-11e8-89a1-351514cc9c15.gif)



