### PR TITLE
CATL-1020: Load Default Value For A Contact From Case Relationships

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -41,6 +41,8 @@ function _webform_defaults_civicrm_contact() {
       'default_contact_id' => '',
       'default_relationship' => '',
       'default_relationship_to' => '1',
+      'default_for_case' => '1',
+      'default_case_roles' => '',
       'allow_url_autofill' => TRUE,
       'dupes_allowed' => FALSE,
       'filters' => array(
@@ -216,10 +218,10 @@ function _webform_edit_civicrm_contact($component) {
     '#default_value' => $component['extra']['default'],
     '#parents' => array('extra', 'default'),
   );
-  if ($c == 1 && $contact_type == 'individual') {
+  if ($contact_type == 'individual') {
     $form['defaults']['default']['#options']['user'] = t('Current User');
   }
-  elseif ($c > 1) {
+  if ($c > 1) {
     $form['defaults']['default']['#options']['relationship'] = t('Relationship to...');
     $to = $component['extra']['default_relationship_to'];
     $form['defaults']['default_relationship_to'] = array(
@@ -238,6 +240,31 @@ function _webform_edit_civicrm_contact($component) {
       '#parents' => array('extra', 'default_relationship'),
     );
   }
+  
+  $case_count = $data['case']['number_of_case'];
+  if ($case_count > 0) {
+    $form['defaults']['default']['#options']['case_roles'] = t('Case roles');
+    $dc = $component['extra']['default_relationship_to'];
+    $form['defaults']['default_for_case'] = array(
+      '#type' => 'select',
+      '#title' => t('For Case'),
+      '#default_value' => $dc,
+      '#parents' => array('extra', 'default_for_case'),
+    );
+    $form['defaults']['default_case_roles'] = array(
+      '#type' => 'select',
+      '#title' => t('Specify Case Role(s)'),
+      '#options' => wf_crm_get_case_roles_options(),
+      '#required' => TRUE,
+      '#default_value' => $component['extra']['default_case_roles'],
+      '#parents' => array('extra', 'default_case_roles'),
+    );
+    $case_type = array();
+    for ($i = 1; $i <= $case_count; $i++) {
+      $form['defaults']['default_for_case']['#options'][$i] = 'Case ' . $i;
+    }
+  }
+
   $form['defaults']['default']['#options']['auto'] = t('Auto - From Filters');
   $form['defaults']['default_contact_id'] = array(
     '#type' => 'textfield',
@@ -899,6 +926,73 @@ function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
   }
   return $found;
 }
+
+/**
+ * Returns a list of all case roles
+ *
+ * @return array
+ */
+function wf_crm_get_case_roles_options() {
+  $filters = array(
+    'return' => ["definition"],
+    'options' => ['limit' => 0],
+  );
+  $result = wf_civicrm_api('CaseType', 'get', $filters);
+  $options = array();
+  $options['case_client'] = t('Case Client');
+  foreach ($result['values'] as $k => $val) {
+    if (isset($val['definition']['caseRoles'])) {
+      foreach ($val['definition']['caseRoles'] as $caseRole) {
+        $caseRoleID = wf_civicrm_api('RelationshipType', 'get', array(
+          'sequential' => 1,
+          'return' => ["id", "label_b_a", "label_a_b"],
+          'name_b_a' => $caseRole['name'],
+          'label_b_a' => $caseRole['name'],
+          'options' => ['or' => [["name_b_a", "label_b_a"]]]
+        ))['values'][0];
+        $options[$caseRoleID['id']] = $caseRoleID['label_b_a'];
+      }
+    }
+  }
+  return $options;
+}
+
+/**
+ * Returns ids of all contacts who are related to given contact for given case
+ *
+ * @param $contact_a
+ * @param $case
+ * @param $case_role
+ * @return array
+ */
+function wf_crm_find_case_roles($contact_a, $case, $case_role) {
+  if ($case_role == 'case_client') {
+    // spl handling; this is not a relationship
+    $result = civicrm_api3('Case', 'get', [
+      'sequential' => 1,
+      'id' => $case,
+      'return' => ["contact_id"],
+    ]);
+    if (isset($result['values'][0]['client_id'])) {
+      $firstCaseClient = reset($result['values'][0]['client_id']);
+      return array($firstCaseClient => $firstCaseClient);
+    }
+    return array();
+  }
+  $params = array(
+    'sequential' => 1,
+    'return' => ["contact_id_b"],
+    'relationship_type_id' => $case_role,
+    'contact_id_a' => $contact_a,
+    'case_id' => $case,
+  );
+  $result = wf_civicrm_api('Relationship', 'get', $params);
+  if (isset($result['values'][0]['contact_id_b'])) {
+    return array($result['values'][0]['contact_id_b'] => $result['values'][0]['contact_id_b']);
+  }
+  return array();
+}
+
 
 /**
  * Format filters for the contact get api

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -241,7 +241,7 @@ function _webform_edit_civicrm_contact($component) {
     );
   }
   
-  $case_count = $data['case']['number_of_case'];
+  $case_count = isset($data['case']['number_of_case']) ? $data['case']['number_of_case'] : 0;
   if ($case_count > 0) {
     $form['defaults']['default']['#options']['case_roles'] = t('Case roles');
     $dc = $component['extra']['default_relationship_to'];

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -218,10 +218,10 @@ function _webform_edit_civicrm_contact($component) {
     '#default_value' => $component['extra']['default'],
     '#parents' => array('extra', 'default'),
   );
-  if ($contact_type == 'individual') {
+  if ($c == 1 && $contact_type == 'individual') {
     $form['defaults']['default']['#options']['user'] = t('Current User');
   }
-  if ($c > 1) {
+  elseif ($c > 1) {
     $form['defaults']['default']['#options']['relationship'] = t('Relationship to...');
     $to = $component['extra']['default_relationship_to'];
     $form['defaults']['default_relationship_to'] = array(

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -261,7 +261,7 @@ abstract class wf_crm_webform_base {
       switch ($component['extra']['default']) {
         case 'user':
           $cid = wf_crm_user_cid();
-          $found = ($c == 1 && $cid) ? array($cid) : array();
+          $found = ($cid) ? array($cid) : array();
           break;
         case 'contact_id':
           if ($component['extra']['default_contact_id']) {
@@ -272,6 +272,22 @@ abstract class wf_crm_webform_base {
           $to = $component['extra']['default_relationship_to'];
           if (!empty($this->ent['contact'][$to]['id']) && !empty($component['extra']['default_relationship'])) {
             $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['extra']['default_relationship']);
+          }
+          break;
+        case 'case_roles':
+          $to = $component['extra']['default_relationship_to'];
+          $case = $component['extra']['default_for_case'];
+
+          if ($to == 1 && empty($this->ent['contact'][$to]['id'])) {
+            // load case client of case (if passed in URL) as default contact
+            $this->findCaseClientForDefaultContact();
+          }
+          if (!empty($this->ent['contact'][$to]['id']) && !empty($this->ent['case'][$case]['id'])) {
+            $found = wf_crm_find_case_roles($this->ent['contact'][$to]['id'], $this->ent['case'][$case]['id'], $component['extra']['default_case_roles']);
+            unset($this->ent['contact'][$c]['reload']);
+          }
+          else {
+            $this->ent['contact'][$c]['reload'] = TRUE;
           }
           break;
         case 'auto':

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -278,9 +278,9 @@ abstract class wf_crm_webform_base {
           $to = $component['extra']['default_relationship_to'];
           $case = $component['extra']['default_for_case'];
 
-          if ($to == 1 && empty($this->ent['contact'][$to]['id'])) {
+          if (empty($this->ent['contact'][$c]['id'])) {
             // load case client of case (if passed in URL) as default contact
-            $this->findCaseClientForDefaultContact();
+            $this->findCaseClientForDefaultContact($c);
           }
           if (!empty($this->ent['contact'][$to]['id']) && !empty($this->ent['case'][$case]['id'])) {
             $found = wf_crm_find_case_roles($this->ent['contact'][$to]['id'], $this->ent['case'][$case]['id'], $component['extra']['default_case_roles']);

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -261,7 +261,7 @@ abstract class wf_crm_webform_base {
       switch ($component['extra']['default']) {
         case 'user':
           $cid = wf_crm_user_cid();
-          $found = ($cid) ? array($cid) : array();
+          $found = ($c == 1 && $cid) ? array($cid) : array();
           break;
         case 'contact_id':
           if ($component['extra']['default_contact_id']) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -102,6 +102,14 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $this->findExistingGrants();
       }
     }
+    // Check if contact reload required: for case roles
+    for ($c = 1; $c <= count($this->data['contact']); ++$c) {
+      if (isset($this->ent['contact'][$c]['reload'])) {
+        $existing_component = $this->getComponent("civicrm_{$c}_contact_1_contact_existing");
+        $this->ent['contact'][$c]['id'] = 0;
+        $this->findContact($existing_component);
+      }
+    }
     // Form alterations for unknown contacts
     if (empty($this->ent['contact'][1]['id'])) {
       if ($this->settings['prefix_unknown']) {
@@ -613,6 +621,29 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       'attributes' => array('id' => "wf-crm-billing-items"),
     ));
   }
+
+ /**
+   * Function to load default contact (cid1) if default loading is set to case_roles
+   */
+  function findCaseClientForDefaultContact() {
+    // Support legacy url param
+    if (empty($_GET["case1"]) && !empty($_GET["caseid"])) {
+      $_GET["case1"] = $_GET["caseid"];
+    }
+    for ($n = 1; $n <= $this->data['case']['number_of_case']; ++$n) {
+      if (isset($_GET["case$n"]) && wf_crm_is_positive($_GET["case$n"])) {
+        $id = $_GET["case$n"];
+        $item = wf_civicrm_api('case', 'getsingle', array('id' => $id));
+        $clients = (array)wf_crm_aval($item, 'client_id');
+        if (count($clients) > 0) {
+          $caseClient = reset($clients);
+          $this->ent['contact'][1]['id'] = $caseClient;
+          return;
+        }
+      }
+    }
+  }
+
 
   /**
    * Find case ids based on url input or "existing case" settings

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -625,7 +625,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
  /**
    * Function to load default contact (cid1) if default loading is set to case_roles
    */
-  function findCaseClientForDefaultContact() {
+  function findCaseClientForDefaultContact($c) {
     // Support legacy url param
     if (empty($_GET["case1"]) && !empty($_GET["caseid"])) {
       $_GET["case1"] = $_GET["caseid"];
@@ -637,7 +637,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $clients = (array)wf_crm_aval($item, 'client_id');
         if (count($clients) > 0) {
           $caseClient = reset($clients);
-          $this->ent['contact'][1]['id'] = $caseClient;
+          $this->ent['contact'][$c]['id'] = $caseClient;
           return;
         }
       }

--- a/js/contact_component.js
+++ b/js/contact_component.js
@@ -44,8 +44,11 @@ var wfCiviContact = (function ($, D) {
             $(this).css('display', 'none');
             $(':checkbox', this).prop('disabled', true);
           }
+          if (val == 'case-roles' && ($(this).is('[class*=form-item-extra-default-relationship-to]') || $(this).is('[class*=form-item-extra-default-for-case]'))) {
+            $(this).removeAttr('style');
+          }
         });
-        if (val === 'auto' || val === 'relationship') {
+        if (val === 'auto' || val === 'relationship' || val == 'case-roles') {
           $('.form-item-extra-randomize, .form-item-extra-dupes-allowed')
             .removeAttr('style')
             .find(':checkbox')


### PR DESCRIPTION
Overview
----------------------------------------
This feature is already existing for non case relationships. We want to load the default value of the existing contact field on a webform through a case relationship
<img width="1156" alt="scrn" src="https://user-images.githubusercontent.com/36624620/48923365-f58d7a00-eed3-11e8-9bc2-6d55c4bc4cca.png">

Before
----------------------------------------
setup of the webform to test what's existing:
When we go to the webform - just as an example - we can add 2 contacts
Contact 1 can be the current user
We can set contact 2's default value to load from a relationship. This can be done by editing the existing contact field of Contact 2 on the webform, and setting the 'default value' to load from a relationship.
See screenshot.
This, however, only sets about non case relationships. There's currently no way to load a contact from case relationships (case roles)

After
----------------------------------------
In the first dropdown where we specify the source of loading (Set default contact from) - we currently have 4 options: None, Specified Contact, Relationship To, Auto - from filters

Now there is another option to this dropdown: 'Case Relationship to'
The second field is to select a contact (remains the same)
The third field where we need to specify the relationship - on selecting 'Case Relationship to' - this will now load only case relationships (case roles)
This option will only be available when cases in enabled on the webform.

In addition if only the case id is given in url and if 'contact 1: existing contact' item in webform config is set to load 'defaults' from 'case roles' and 'case client' is set for contact 1, then this will automatically load the first case client of the case passed in the url. (Previously passing only the case would not autofill anything)
Also 'Current User' option is now available for all contacts (Previously it was only available for contact1)