### PR TITLE
Allow case roles to be assigned to multiple contacts

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -956,6 +956,9 @@ function wf_crm_get_fields($var = 'fields') {
                   'data_type' => 'ContactReference',
                   'set' => 'caseRoles',
                   'empty_option' => t('None'),
+                  'extra' => array(
+                    'multiple' => 1,
+                  ),
                 );
               }
               $fields['case_role_' . $rel_type['id']]['case_types'][] = $case_type['id'];

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1299,12 +1299,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           foreach ($params as $param => $val) {
             if ($val && strpos($param, 'role_') === 0) {
               foreach ((array) $params['client_id'] as $client) {
-                wf_civicrm_api('relationship', 'create', array(
-                  'relationship_type_id' => substr($param, 5),
-                  'contact_id_a' => $client,
-                  'contact_id_b' => $val,
-                  'case_id' => $result['id'],
-                ));
+                foreach ((array) $val as $contactB) {
+                  wf_civicrm_api('relationship', 'create', array(
+                    'relationship_type_id' => substr($param, 5),
+                    'contact_id_a' => $client,
+                    'contact_id_b' => $contactB,
+                    'case_id' => $result['id'],
+                  ));
+                }
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------

![image](https://user-images.githubusercontent.com/5929648/50324130-414b3780-0503-11e9-89d8-fdd717ff6b33.png)

As shown in the above screenshot, role "Bargaining Committee Member" is assigned to multiple contacts from Manage Case Screen. But this is not provided by webform CiviCRM yet. 

Before
----------------------------------------
Only single contact can be assigned to a case role on webform submission.

![image](https://user-images.githubusercontent.com/5929648/50324101-1cef5b00-0503-11e9-9bc7-4ee3c189f12e.png)


After
----------------------------------------
Multiple contacts can be selected.

![image](https://user-images.githubusercontent.com/5929648/50324119-30022b00-0503-11e9-8373-7abf88d1d4a8.png)


