### PR TITLE
Block interaction with payment form until payment block has fully loaded

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -5,6 +5,13 @@ cj(function($) {
     setting = Drupal.settings.webform_civicrm,
     $processorFields = $('.civicrm-enabled[name$="civicrm_1_contribution_1_contribution_payment_processor_id]"]');
 
+  $(document).ajaxStart(function() {
+    $('#billing-payment-block').closest('form').block();
+  })
+  .ajaxStop(function() {
+    $('#billing-payment-block').closest('form').unblock();
+  });
+
   function getPaymentProcessor() {
     if (!$processorFields.length) {
       return setting.paymentProcessor;


### PR DESCRIPTION
Overview
----------------------------------------
Loading the civicrm payment "billing block" is done via AJAX.  It can take a few seconds to load (sometimes long enough that someone can press the submit button before it has loaded).

Before
----------------------------------------
Possible to submit the form before payment block has loaded - there is no indication to the user that the form has not finished loading.

After
----------------------------------------
Not possible to submit form before payment block has loaded - form is "dimmed" until it loads making it very obvious that it has not finished loading.

Technical Details
----------------------------------------
This uses the jquery blockUI that is already used elsewhere in CiviCRM.  It would be nice to have the loading "spinner" too but I can't work out how to do that!

