### PR TITLE
Fix state/province from being cleared from addresses when province isn't a submitted field

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -766,13 +766,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $existing = array_merge(array(array()), $result['values']);
         }
         foreach ($contact[$location] as $i => $params) {
-          // Translate state/prov abbr to id
-          if (!empty($params['state_province_id'])) {
-            $config = CRM_Core_Config::singleton();
-            if (!($params['state_province_id'] = wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $config->defaultContactCountry)))) {
-              $params['state_province_id'] = '';
-            }
-          }
           // Substitute county stub ('-' is a hack to get around required field when there are no available counties)
           if (isset($params['county_id']) && $params['county_id'] === '-') {
             $params['county_id'] = '';


### PR DESCRIPTION
## Overview
State/Province are being cleared from a CiviCRM contact's address when a webform is submitted that does not have a State/Province field for that address. Resulting in corrupted data anytime someone submits a form without a State/Province field.

## Before
Create a webform that has some address fields that are not State/Province. Have a CiviCRM contact that has multiple addresses with a State/Province. Submit the form for that contact. All addresses will be cleared.

### Form (home address)
![screen shot 2019-01-18 at 4 04 52 pm](https://user-images.githubusercontent.com/5994928/51412793-d8270600-1b3a-11e9-9a77-1c228113bb81.png)

### Before Submitting
![screen shot 2019-01-18 at 4 06 00 pm](https://user-images.githubusercontent.com/5994928/51412857-fd1b7900-1b3a-11e9-97e6-a3783fe1cce4.png)

### After Submitting (notice even billing is affected)
![screen shot 2019-01-18 at 4 06 47 pm](https://user-images.githubusercontent.com/5994928/51412889-18868400-1b3b-11e9-8d5e-9df9f9075d31.png)

## After
Now when you submit a webform that has no State/Province, it does not clear the State/Province. Or if you do have a State/Province field, it only modifies it for that specific address.

## Technical Details
We are on CiviCRM 5.8.2. It seems like there was some code in there that was converting the `state_province_id` from an abbr to an id, but it was already an id.

## Comments
First time diving into the code for this module so forgive me if I'm missing a key element here. We just upgraded CiviCRM from 4.6 to 5.8 last weekend and been fighting bugs.