### PR TITLE
Only show custom reference option if such a field exists

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -241,15 +241,18 @@ function _webform_edit_civicrm_contact($component) {
       '#parents' => array('extra', 'default_relationship'),
     );
   }
-  $form['defaults']['default']['#options']['custom_ref'] = t('Custom reference field');
-  $form['defaults']['default_custom_ref'] = array(
-    '#type' => 'select',
-    '#title' => t('Specify Custom Field'),
-    '#options' => wf_crm_get_custom_ref_options(),
-    '#required' => TRUE,
-    '#default_value' => $component['extra']['default_custom_ref'],
-    '#parents' => array('extra', 'default_custom_ref'),
-  );
+  $custom_ref_options = wf_crm_get_custom_ref_options();
+  if ($custom_ref_options) {
+    $form['defaults']['default']['#options']['custom_ref'] = t('Custom reference field');
+    $form['defaults']['default_custom_ref'] = array(
+      '#type' => 'select',
+      '#title' => t('Specify Custom Field'),
+      '#options' => $custom_ref_options,
+      '#required' => TRUE,
+      '#default_value' => $component['extra']['default_custom_ref'],
+      '#parents' => array('extra', 'default_custom_ref'),
+    );
+  }
   
   $case_count = isset($data['case']['number_of_case']) ? $data['case']['number_of_case'] : 0;
   if ($case_count > 0) {


### PR DESCRIPTION
Overview
----------------------------------------
We recently introduced the ability to use a custom reference field as the default value for an existing contact. This prevents a potential bug with the existing contact configuration form.

Before
----------------------------------------
The existing contact configuration form may fail validation and not save if no contact reference custom fields exist.

After
----------------------------------------
Form saves without errors.

See https://www.drupal.org/project/webform_civicrm/issues/3024260