### PR TITLE
Issue 2852365 prevent membership overwite

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -973,14 +973,36 @@ class wf_crm_admin_form {
         $this->form['membership'][$c]['membership'][$fs] = array(
           '#type' => 'fieldset',
           '#title' => t('Membership !num for !contact', array('!num' => $n, '!contact' => wf_crm_contact_label($c, $this->data, 'wrap'))),
-          '#attributes' => array('id' => $fs, 'class' => array('web-civi-checkbox-set')),
-          'js_select' => $this->addToggle($fs),
         );
+        $this->form['membership'][$c]['membership'][$fs]["membership_{$c}_membership_{$n}_settings_existing_membership_status"] = array(
+          '#type' => 'select',
+          '#title' => t('Update Existing Membership'),
+          '#options' => array('' => '- ' . t('None') . ' -') + wf_crm_apivalues('membership', 'getoptions', array('field' => 'status_id')),
+          '#default_value' => wf_crm_aval($this->data, "membership:{$c}:{$n}_settings_existing_membership_status", array()),
+          '#multiple' => TRUE,
+        );
+        $this->help($this->form['membership'][$c]['membership'][$fs]["membership_{$c}_membership_{$n}_settings_existing_membership_status"], 'existing_membership_status');
+        $membership_type = wf_crm_aval($this->data, "membership:{$c}:membership:{$n}:membership_type_id");
         foreach ($this->sets as $sid => $set) {
-          if ($set['entity_type'] == 'membership') {
-            foreach ($set['fields'] as $fid => $field) {
-              $fid = "civicrm_{$c}_membership_{$n}_$fid";
-              $this->form['membership'][$c]['membership'][$fs][$fid] = $this->addItem($fid, $field);
+          if ($set['entity_type'] == 'membership' && (!$membership_type || empty($set['sub_types']) || in_array($membership_type, $set['sub_types']))) {
+            $fs1 = "membership_{$c}_membership_{$n}_fieldset_$sid";
+            if ($sid == 'membership') {
+              $pos = &$this->form['membership'][$c]['membership'][$fs];
+            }
+            else {
+              $pos = &$this->form['membership'][$c]['membership'][$fs]['wrap'];
+            }
+            $pos[$fs1] = array(
+              '#type' => 'fieldset',
+              '#title' => $set['label'],
+              '#attributes' => array('id' => $fs1, 'class' => array('web-civi-checkbox-set')),
+              'js_select' => $this->addToggle($fs1),
+            );
+            if (isset($set['fields'])) {
+              foreach ($set['fields'] as $fid => $field) {
+                $fid = "civicrm_{$c}_membership_{$n}_$fid";
+                $pos[$fs1][$fid] = $this->addItem($fid, $field);
+              }
             }
           }
         }

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -382,6 +382,14 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function existing_membership_status() {
+    print '<p>' .
+      t('If a matching membership of the chosen type already exists for the Contact 1, it will be autofilled and updated.') .
+      '</p><p>' .
+      t('Note: a membership can also be autofilled by passing "membership1_1 for the first membership of the first contact. For the second membership of the first contact user membership1_2", etc. in the url.') .
+      '</p>';
+  }
+
   public static function existing_grant_status() {
     print '<p>' .
       t('If a matching grant of the chosen type already exists for the applicant, it will be autofilled and updated.') .

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -587,30 +587,52 @@ abstract class wf_crm_webform_base {
    * @param $cid
    * @return array
    */
-  protected function findMemberships($cid) {
+  protected function findMemberships($c, $cid) {
     static $status_types;
-    static $membership_types;
-    if (!isset($membership_types)) {
-      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', array('is_active' => 1, 'return' => 'id')));
-    }
-    $existing = wf_crm_apivalues('membership', 'get', array(
-      'contact_id' => $cid,
-      // Limit to only enabled membership types
-      'membership_type_id' => array('IN' => $membership_types),
-    ));
-    if (!$existing) {
-      return array();
-    }
     if (!$status_types) {
       $status_types = wf_crm_apivalues('membership_status', 'get');
     }
-    // Attempt to order memberships by most recent and active
+
+    for ($n = 1; $n <= $this->data['membership'][$c]['number_of_membership']; ++$n) {
+      // Populate via url argument
+      if (isset($_GET["membership{$c}_{$n}"]) && wf_crm_is_positive($_GET["membership{$c}_{$n}"])) {
+        $id = $_GET["membership{$c}_{$n}"];
+        $item = wf_civicrm_api('membership', 'getsingle', array('id' => $id, 'return' => array('contact_id')));
+        if ($item['contact_id'] == $cid) {
+          $this->ent['membership'][$cid][$n] = ['id' => $id];
+        }
+
+      }
+      elseif (!empty($this->data['membership'][$c][$n.'_settings_existing_membership_status'])) {
+        if (empty($this->data['membership'][$c]['membership'][$n]['membership_type_id'])) {
+          watchdog('webform_civicrm', "Membership type to update hasn't been set, so won't try to update activity. location = %1, webform contact number : %2, membership number : %3", array('%1' => request_uri(), '%2' => $c, '%3' => $n), WATCHDOG_ERROR);
+          continue;
+        }
+
+        $params = array(
+          'sequential' => 1,
+          'contact_id' => $cid,
+          'status_id' => array('IN' => (array)$this->data['membership'][$c][$n.'_settings_existing_membership_status']),
+          'membership_type_id' => $this->data['membership'][$c]['membership'][$n]['membership_type_id'],
+          'options' => array('limit' => 1),
+        );
+        $items = wf_crm_apivalues('membership', 'get', $params);
+        if (isset($items[0]['id'])) {
+          $this->ent['membership'][$cid][$n] = array('id' => $items[0]['id']);
+          break;
+        }
+      }
+    }
+
     $active = $expired = array();
-    foreach ($existing as $membership) {
-      $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
-      $membership['status'] = $status_types[$membership['status_id']]['label'];
-      $list = $membership['is_active'] ? 'active' : 'expired';
-      array_unshift($$list, $membership);
+    if (isset($this->ent['membership']) && isset($this->ent['membership'][$cid])) {
+      foreach ($this->ent['membership'][$cid] as $n => $mid) {
+        $membership = wf_civicrm_api('Membership', 'getsingle', ['id' => $mid['id']]);
+        $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
+        $membership['status'] = $status_types[$membership['status_id']]['label'];
+        $list = $membership['is_active'] ? 'active' : 'expired';
+        array_unshift($$list, $membership);
+      }
     }
     return array_merge($active, $expired);
   }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -593,47 +593,39 @@ abstract class wf_crm_webform_base {
       $status_types = wf_crm_apivalues('membership_status', 'get');
     }
 
+    $active = $expired = array();
     for ($n = 1; $n <= $this->data['membership'][$c]['number_of_membership']; ++$n) {
       // Populate via url argument
       if (isset($_GET["membership{$c}_{$n}"]) && wf_crm_is_positive($_GET["membership{$c}_{$n}"])) {
         $id = $_GET["membership{$c}_{$n}"];
-        $item = wf_civicrm_api('membership', 'getsingle', array('id' => $id, 'return' => array('contact_id')));
-        if ($item['contact_id'] == $cid) {
-          $this->ent['membership'][$cid][$n] = ['id' => $id];
+        $membership = wf_civicrm_api('membership', 'getsingle', array('id' => $id, 'return' => array('contact_id')));
+        if ($membership['contact_id'] == $cid) {
+          $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
+          $membership['status'] = $status_types[$membership['status_id']]['label'];
+          $list = $membership['is_active'] ? 'active' : 'expired';
+          array_unshift($$list, $membership);
         }
 
       }
       elseif (!empty($this->data['membership'][$c][$n.'_settings_existing_membership_status'])) {
-        if (empty($this->data['membership'][$c]['membership'][$n]['membership_type_id'])) {
-          watchdog('webform_civicrm', "Membership type to update hasn't been set, so won't try to update activity. location = %1, webform contact number : %2, membership number : %3", array('%1' => request_uri(), '%2' => $c, '%3' => $n), WATCHDOG_ERROR);
-          continue;
-        }
-
         $params = array(
           'sequential' => 1,
           'contact_id' => $cid,
           'status_id' => array('IN' => (array)$this->data['membership'][$c][$n.'_settings_existing_membership_status']),
-          'membership_type_id' => $this->data['membership'][$c]['membership'][$n]['membership_type_id'],
-          'options' => array('limit' => 1),
         );
-        $items = wf_crm_apivalues('membership', 'get', $params);
-        if (isset($items[0]['id'])) {
-          $this->ent['membership'][$cid][$n] = array('id' => $items[0]['id']);
-          break;
+        if (!empty($this->data['membership'][$c]['membership'][$n]['membership_type_id'])) {
+          $params['membership_type_id'] = $this->data['membership'][$c]['membership'][$n]['membership_type_id'];
+        }
+        $memberships = wf_crm_apivalues('membership', 'get', $params);
+        foreach($memberships as $membership) {
+          $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
+          $membership['status'] = $status_types[$membership['status_id']]['label'];
+          $list = $membership['is_active'] ? 'active' : 'expired';
+          array_unshift($$list, $membership);
         }
       }
     }
 
-    $active = $expired = array();
-    if (isset($this->ent['membership']) && isset($this->ent['membership'][$cid])) {
-      foreach ($this->ent['membership'][$cid] as $n => $mid) {
-        $membership = wf_civicrm_api('Membership', 'getsingle', ['id' => $mid['id']]);
-        $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
-        $membership['status'] = $status_types[$membership['status_id']]['label'];
-        $list = $membership['is_active'] ? 'active' : 'expired';
-        array_unshift($$list, $membership);
-      }
-    }
     return array_merge($active, $expired);
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1132,7 +1132,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (!isset($types)) {
       $types = wf_crm_apivalues('membership_type', 'get');
     }
-    $existing = $this->findMemberships($cid);
+    $existing = $this->findMemberships($c, $cid);
     foreach (wf_crm_aval($this->data, "membership:$c:membership", array()) as $n => $params) {
       $membershipStatus = "";
       $membershipEndDate = "";

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -395,7 +395,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
    */
   private function loadMemberships($c, $cid) {
     $today = date('Y-m-d');
-    foreach ($this->findMemberships($cid) as $num => $membership) {
+    foreach ($this->findMemberships($c, $cid) as $num => $membership) {
       // Only show 1 expired membership, and only if there are no active ones
       if (!$membership['is_active'] && $num) {
         break;


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the issue over overwriting existing memberships. 

See https://www.drupal.org/project/webform_civicrm/issues/2852365

Before
----------------------------------------

There was an issue with the webform civicrm module overwriting existing membership records. 

After
----------------------------------------

Overwriting of existing membership is now a setting on the form, to overwrite an activity membership of the same type with the selected status. 

![screenshot from 2019-02-22 14-57-12](https://user-images.githubusercontent.com/4126292/53246887-31da9d00-36b2-11e9-89a2-cef92de47e5a.png)

In addition it is also possible to update an existing membership by the url. E.g. by passing membership1_1=_id_ for the first membership of the first contact. For the second membership of the first contact use _membership1_2_.


Notice for upgrading
----------------------------------------

When this fix is merged there should be a notice for upgrading existing installations. Installations which used webforms to renew existing memberships should do some extra configuration after upgrading. The configuration is setting the Update Existing Membership field to a set of configured statuses.