### PR TITLE
cherry pick of 'Fix getCreditCardCSSNames() which is deleted from core civi' from 7.x-4.x

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -873,11 +873,8 @@ abstract class wf_crm_webform_base {
    * @return void
    */
   function addPaymentJs() {
-    $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
-    CRM_Core_Resources::singleton()
-      ->addCoreResources()
-      ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
-      ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    CRM_Core_Resources::singleton()->addCoreResources();
+    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -873,8 +873,18 @@ abstract class wf_crm_webform_base {
    * @return void
    */
   function addPaymentJs() {
-    CRM_Core_Resources::singleton()->addCoreResources();
-    CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    $currentVer = CRM_Core_BAO_Domain::version();
+    if (version_compare($currentVer, '5.8') <= 0 && method_exists('CRM_Core_Payment_Form', 'getCreditCardCSSNames')) {
+      $credit_card_types = CRM_Core_Payment_Form::getCreditCardCSSNames();
+      CRM_Core_Resources::singleton()
+        ->addCoreResources()
+        ->addSetting(array('config' => array('creditCardTypes' => $credit_card_types)))
+        ->addScriptFile('civicrm', 'templates/CRM/Core/BillingBlock.js', -10, 'html-header');
+    }
+    else {
+      CRM_Core_Resources::singleton()->addCoreResources();
+      CRM_Financial_Form_Payment::addCreditCardJs(NULL, 'html-header');
+    }
   }
 
   /**


### PR DESCRIPTION
This is identical to the fix in the 7.x branch, and is necessary for payment to work, with any Drupal 8 version.