### PR TITLE
Prepopulate billing fields

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -98,6 +98,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
       }
+      if (!$this->billing_params && !empty($this->data['contact'][1])) {
+        $this->prefillBillingFields();
+      }
     }
     // Even though this object is destroyed between page submissions, this trick allows us to persist some data - see above
     $form_state['civicrm']['ent'] = $this->ent;
@@ -1633,6 +1636,31 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   }
 
   /**
+   * Use previously entered information to populate billing fields.
+   */
+  private function prefillBillingFields() {
+    $params = array();
+    foreach (array('first_name', 'middle_name', 'last_name') as $name) {
+      if (!empty($this->data['contact'][1]['contact'][1][$name])) {
+        $params["billing_$name"] = $this->data['contact'][1]['contact'][1][$name];
+      }
+    }
+    if (!empty($this->data['contact'][1]['address'][1])) {
+      foreach ($this->data['contact'][1]['address'][1] as $field => $value) {
+        if ($value) {
+          if ($field == 'state_province_id') {
+            $value = wf_crm_state_abbr($value, 'id', wf_crm_aval($this->data['contact'][1]['address'][1], 'country_id'));
+          }
+          $params['billing_' . $field . '-5'] = $value;
+        }
+      }
+    }
+    if ($params) {
+      drupal_add_js(array('webform_civicrm' => array('billingSubmission' => $params)), 'setting');
+    }
+  }
+
+  /**
    * Normalize and validate billing input
    * @return bool
    */
@@ -1682,9 +1710,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       form_set_error('billing_email', ts('An email address is required to complete this transaction.'));
       $valid = FALSE;
     }
-    if ($valid) {
-      $this->billing_params = $params;
-    }
+    $this->billing_params = $params;
     // Since billing fields are not "real" form fields they get cleared if the page reloads.
     // We add a bit of js to fix this annoyance.
     drupal_add_js(array('webform_civicrm' => array('billingSubmission' => $params)), 'setting');

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -26,7 +26,7 @@ cj(function($) {
         $('#billing-payment-block').trigger('crmLoad').trigger('crmFormLoad');
         if (setting.billingSubmission) {
           $.each(setting.billingSubmission, function(key, val) {
-            $('[name="' + key + '"]').val(val);
+            $('[name="' + key + '"]', '#billing-payment-block').val(val).change();
           });
         }
         // When an express payment button is clicked, skip the billing fields and submit the form with a placeholder


### PR DESCRIPTION
Overview
----------------------------------------
Time-saver for users filling out the contribution form - prepopulates it with previously-entered name & address.

Before
----------------------------------------
Billing fields are always blank for anonymous users.

After
----------------------------------------
Billing fields are pre-filled with name & address entered on previous pages of the webform.

To Recreate
------------------

1. Create a webform with name & address on page 1, and contribution page on page 2.
2. Fill out form as anon user.
3. Without patch, billing fields on page 2 are blank.
4. With patch, billing fields on page 2 will reflect data entered on page 1.