### PR TITLE
Fatal error with Activities, Fix tokens, Improved Select/Radio/Checkbox and live options support

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1978,22 +1978,7 @@ class wf_crm_admin_form {
       if ($options = Utils::wf_crm_field_options($field, 'component_insert', $settings['data'])) {
         $field['options'] = $options;
         $field['extra']['items'] = wf_crm_array2str($options);
-
-        $as_list = !empty($field['extra']['aslist']);
-        $is_multiple = !empty($field['extra']['multiple']);
-        $use_live_options = !empty($field['civicrm_live_options']);
-
-        if (!$as_list) {
-          $field['type'] = $is_multiple ? 'checkboxes' : 'radios';
-        }
-        else if ($is_multiple) {
-          $field['multiple'] = TRUE;
-        }
-
-        // A single static radio should be shown as a checkbox
-        if (!$use_live_options && !$as_list && count($options) === 1) {
-          $field['type'] = 'checkbox';
-        }
+        $field['type'] = 'civicrm_options';
       }
     }
     if ($field['type'] == 'civicrm_contact') {

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1796,6 +1796,7 @@ class wf_crm_admin_form {
           [$this, 'stringifyFormattableMarkup'],
           empty($enabled_element['extra']) ? [] : $enabled_element['extra']
         );
+        $enabled_element = array_map([$this, 'stringifyFormattableMarkup'], $enabled_element);
         $element_plugin = $webform_element_manager->getElementInstance([
           '#type' => $enabled_element['type'],
         ]);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1356,7 +1356,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Save activity data
    */
   private function processActivities() {
-    foreach (wf_crm_aval($this->data, 'activity', array()) as $n => $data) {
+    $activities = wf_crm_aval($this->data, 'activity', array());
+    foreach ($activities as $n => $data) {
       if (is_array($data)) {
         $params = $data['activity'][1];
         // Create mode
@@ -1371,7 +1372,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
           // Automatic source_contact_id - default to current user or contact 1
           if (empty($data['activity'][1]['source_contact_id'])) {
-            if (user_is_logged_in()) {
+            if (\Drupal::currentUser()->isAuthenticated()) {
               $params['source_contact_id'] = wf_crm_user_cid();
             }
             elseif (!empty($this->ent['contact'][1]['id'])) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -685,9 +685,10 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
    * Find activity ids based on url input or "existing activity" settings
    */
   private function findExistingActivities() {
+    $request = \Drupal::request();
     // Support legacy url param
-    if (empty($_GET["activity1"]) && !empty($_GET["aid"])) {
-      $_GET["activity1"] = $_GET["aid"];
+    if (empty($request->query->get('activity1')) && !empty($request->query->get('aid'))) {
+      $request->query->set('activity1', $request->query->get('aid'));
     }
     for ($n = 1; $n <= $this->data['activity']['number_of_activity']; ++$n) {
       if (!empty($this->data['activity'][$n]['activity'][1]['target_contact_id'])) {
@@ -698,17 +699,18 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           }
         }
         if ($targets) {
-          if (isset($_GET["activity$n"]) && wf_crm_is_positive($_GET["activity$n"])) {
-            $id = $_GET["activity$n"];
-            $item = wf_civicrm_api('activity', 'getsingle', array('id' => $id, 'return' => array('target_contact_id')));
+          if (wf_crm_is_positive($request->query->get("activity$n"))) {
+            $id = $request->query->get("activity$n");
+            $item = wf_civicrm_api('activity', 'getsingle', ['id' => $id, 'return' => ['target_contact_id']]);
             if (array_intersect($targets, $item['target_contact_id'])) {
-              $this->ent['activity'][$n] = array('id' => $id);
+              $this->ent['activity'][$n] = ['id' => $id];
             }
           }
           elseif (!empty($this->data['activity'][$n]['existing_activity_status'])) {
             // If the activity type hasn't been set, bail.
             if (empty($this->data['activity'][$n]['activity'][1]['activity_type_id'])) {
-              watchdog('webform_civicrm', "Activity type to update hasn't been set, so won't try to update activity. location = %1, webform activity number : %2", array('%1' => request_uri(), '%2' => $n), WATCHDOG_ERROR);
+              $logger = \Drupal::logger('webform_civicrm');
+              $logger->error("Activity type to update hasn't been set, so won't try to update activity. location = %1, webform activity number : %2", ['%1' => $request->getRequestUri(), '%2' => $n]);
               continue;
             }
             // The api doesn't accept an array of target contacts so we'll do it as a loop

--- a/src/Element/CivicrmSelect.php
+++ b/src/Element/CivicrmSelect.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\webform_civicrm\Element;
 
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element\Select;
 
 /**

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -402,14 +402,14 @@ class Fields implements FieldsInterface {
         'expose_list' => TRUE,
         'exposed_empty_option' => '- ' . t('Automatic') . ' -',
       );
-      $fields['activity_assignee_contact_id'] = array(
+      $fields['activity_assignee_contact_id'] = [
         'name' => t('Assign Activity # to'),
         'type' => 'select',
         'expose_list' => TRUE,
         'empty_option' => t('No One'),
-        'extra' => array('multiple' => 1),
+        'extra' => ['multiple' => 1],
         'data_type' => 'ContactReference',
-      );
+      ];
       $fields['activity_location'] = array(
         'name' => t('Activity # Location'),
         'type' => 'textfield',

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -19,6 +19,31 @@ class Fields implements FieldsInterface {
    * {@inheritdoc}
    */
   public function get($var = 'fields') {
+    if ($var === 'tokens') {
+      return [
+        'display_name' => t('display name'),
+        'first_name' => t('first name'),
+        'nick_name' => t('nickname'),
+        'middle_name' => t('middle name'),
+        'last_name' => t('last name'),
+        'individual_prefix' => t('name prefix'),
+        'individual_suffix' => t('name suffix'),
+        'gender' => t('gender'),
+        'birth_date' => t('birth date'),
+        'job_title' => t('job title'),
+        'current_employer' => t('current employer'),
+        'contact_id' => t('contact id'),
+        'street_address' => t('street address'),
+        'city' => t('city'),
+        'state_province' => t('state/province abbr'),
+        'state_province_name' => t('state/province full'),
+        'postal_code' => t('postal code'),
+        'country' => t('country'),
+        'world_region' => t('world region'),
+        'phone' => t('phone number'),
+        'email' => t('email'),
+      ];
+    }
     return $this->wf_crm_get_fields($var);
   }
 

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Drupal\webform_civicrm\Plugin\WebformElement;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Render\Markup;
+use Drupal\webform\Plugin\WebformElementBase;
+use Drupal\webform\WebformSubmissionInterface;
+
+/**
+ * Provides a 'civicrm_options' element.
+ *
+ * @WebformElement(
+ *   id = "civicrm_options",
+ *   label = @Translation("CiviCRM Options"),
+ *   description = @Translation("Provides a CiviCRM powered radios."),
+ *   category = @Translation("CiviCRM"),
+ * )
+ *
+ * @see \Drupal\webform_example_element\Element\WebformExampleElement
+ * @see \Drupal\webform\Plugin\WebformElementBase
+ * @see \Drupal\webform\Plugin\WebformElementInterface
+ * @see \Drupal\webform\Annotation\WebformElement
+ */
+class CivicrmOptions extends WebformElementBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDefaultProperties() {
+    return [
+        'form_key' => '',
+        'pid' => 0,
+        'value' => '',
+        'empty_option' => '',
+        'empty_value' => '',
+        'options' => [],
+        'options_randomize' => FALSE,
+        'expose_list' => TRUE,
+        'exposed_empty_option' => '- ' . t('Automatic') . ' -',
+        'civicrm_live_options' => 1,
+        'default_option' => '',
+        'data_type' => NULL,
+        'extra' => [],
+      ] + parent::getDefaultProperties();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function form(array $form, FormStateInterface $form_state) {
+    $form = parent::form($form, $form_state);
+
+    // Get element properties.
+    $element_properties = $form_state->getValues() ?: $form_state->get('element_properties');
+
+    // Options.
+    $form['options'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Element options'),
+      '#open' => TRUE,
+      '#prefix' => '<div id="webform-civicrm-options-wrapper">',
+      '#suffix' => '</div>',
+    ];
+
+    if ($element_properties['civicrm_live_options']) {
+      $live_options_description = t('You cannot control the presentation of live options. They will be loaded from the CiviCRM database every time the form is displayed.');
+    }
+    else {
+      $live_options_description = t('Drag the arrows to re-order these options. Click the "enabled" checkbox to show/remove an item from the form. Set the label as you want it to appear on the form.');
+    }
+
+    $form['options']['civicrm_live_options'] = [
+      '#type' => 'radios',
+      '#options' => [
+        t('<strong>Static Options</strong> (fully configurable)'),
+        t('<strong>Live Options</strong> (update automatically)'),
+      ],
+      '#description' => Markup::create(
+        '<p>' . $live_options_description . '</p>' .
+        '<p>' . t('Check the "default" box for an option to be selected by default when a user views the form.') . '</p>'),
+      '#ajax' => [
+        'callback' => [static::class, 'ajaxCallback'],
+        'wrapper' => 'webform-civicrm-options-wrapper',
+        'progress' => ['type' => 'fullscreen'],
+      ],
+    ];
+
+    $form['options']['options'] = [
+      '#type' => 'civicrm_select_options',
+      '#live_options' => $element_properties['civicrm_live_options'],
+      '#default_option' => $element_properties['default_option'],
+      '#form_key' => $this->configuration['#form_key']
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfigurationFormProperties(array &$form, FormStateInterface $form_state) {
+    $properties = parent::getConfigurationFormProperties($form, $form_state);
+    // Get additional properties off of the options element.
+    $select_options = $form['properties']['options']['options'];
+    $properties['#default_option'] = $select_options['#default_option'];
+    $properties['#default_value'] = $select_options['#default_option'];
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    $as_list = !empty($element['#extra']['aslist']);
+    $is_multiple = !empty($element['#extra']['multiple']);
+    $use_live_options = !empty($element['#civicrm_live_options']);
+
+    $element['#type'] = 'select';
+    if (!$as_list) {
+      $element['#type'] = $is_multiple ? 'checkboxes' : 'radios';
+    }
+    else if ($is_multiple) {
+      $element['#multiple'] = TRUE;
+    }
+
+    // A single static radio should be shown as a checkbox
+    if (!$use_live_options && !$as_list && count($element['#options']) === 1) {
+      $element['#type'] = 'checkbox';
+    }
+
+    if (!empty($element['#default_option'])) {
+      $element['#default_value'] = $element['#default_option'];
+    }
+    parent::prepare($element, $webform_submission);
+  }
+
+  public function getPluginLabel() {
+    return 'CiviCRM Options';
+  }
+
+  /**
+   * Ajax callback.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The properties element.
+   */
+  public static function ajaxCallback(array $form, FormStateInterface $form_state) {
+    $radio = $form_state->getTriggeringElement();
+    $element = NestedArray::getValue($form, array_slice($radio['#array_parents'], 0, -2));
+    return $element;
+  }
+
+}


### PR DESCRIPTION
Overview
----------------------------------------
Add support for Activities

<img width="1792" alt="Screen Shot 2019-05-01 at 11 49 44 AM" src="https://user-images.githubusercontent.com/3698644/57029402-42a21480-6c07-11e9-889c-ce4e71131c82.png">

An Activity element allows for static and live options.

They persist. However, the label doesn't change to be the single value. (need to see if this is how D7 worked or not.)

<img width="1792" alt="Screen Shot 2019-05-01 at 11 50 21 AM" src="https://user-images.githubusercontent.com/3698644/57029438-58afd500-6c07-11e9-9a18-f4fd518c54b5.png">
