### PR TITLE
Fixed file access issue according to new security update in CiviCRM.

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -948,10 +948,11 @@ abstract class wf_crm_webform_base {
       $entity_id = $this->ent[$entity][$n]['id'];
     }
     if (!empty($file[$val])) {
+      $fileHash = CRM_Core_BAO_File::generateFileHash($entity_id, $val);
       return array(
         'data_type' => 'File',
         'name' => CRM_Utils_File::cleanFileName($file[$val]['uri']),
-        'file_url'=> CRM_Utils_System::url('civicrm/file', "reset=1&id={$val}&eid={$entity_id}", TRUE),
+        'file_url'=> CRM_Utils_System::url('civicrm/file', "reset=1&id={$val}&eid={$entity_id}&fcs={$fileHash}", TRUE),
         'icon' => file_icon_url((object) array('filemime' => $file[$val]['mime_type'])),
       );
     }


### PR DESCRIPTION
Overview
----------------------------------------
Related to Issue: https://www.drupal.org/project/webform_civicrm/issues/3037226

When using Webform CiviCRM to create an Activity for a Case. Since CiviCRM 5.10.3, the file attachments can no longer be opened from a Case Activity using the Activity View. The URL to the file on the Activity no longer returns the file

**Steps to reproduce:**

1. Create an Activity for a CiviCRM Case using Webform
2. Upload and attach a file to the Activity using Webform
3. Open CiviCRM, locate the Activity and view the file
4. File URL does not work, file is not returned

Before
----------------------------------------
File URL does not work and file is not returned. 

After
----------------------------------------
File URL working as expected. 

Comments
----------------------------------------
_Agileware Ref: CIVIWF-3_
