### PR TITLE
Fix removal of civicrm handler when a field is unselected

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -177,6 +177,7 @@ class wf_crm_admin_form {
     $this->form['delete']['#value'] = t('Remove Fields and Save Settings');
     $this->form['disable']['#value'] = t('Leave Fields and Save Settings');
     $this->form['cancel']['#value'] = t('Cancel (go back)');
+    $this->form['form_state'] = $this->form_state;
     return $this->form;
   }
 
@@ -1617,9 +1618,8 @@ class wf_crm_admin_form {
       foreach ($delete_me as $key => $id) {
         list(, $c, $ent, $n, $table, $name) = explode('_', $key, 6);
         $info = '';
-        if ($ent == 'contact' || $ent == 'participant') {
-          $info = '<em>' . wf_crm_contact_label($c, wf_crm_aval($this->node, 'webform_civicrm:data'));
-        }
+        $element = $this->webform->getElement($id);
+        $info = '<em>' . $element['#title'];
         if ($info && isset($this->sets[$table]['max_instances'])) {
           $info .= ' ' . $this->sets[$table]['label'] . ' ' . $n;
         }
@@ -1640,19 +1640,19 @@ class wf_crm_admin_form {
     $deleted = 0;
     if ($button === 'edit-delete' || ($button === 'edit-disable' && $this->settings['nid'])) {
       foreach ($delete_me as $id) {
-        $field = $this->node->webform['components'][$id];
+        $field = $this->webform->getElementDecoded($id);
         unset($enabled[$field['form_key']]);
         ++$deleted;
         if ($button === 'edit-delete') {
-          webform_component_delete($this->node, $field);
+          $this->webform->deleteElement($field['#form_key']);
         }
         else {
           $field['form_key'] = 'disabled' . substr($field['form_key'], 7);
-          webform_component_update($field);
+          $this->webform->setElementProperties($field['#form_key'], $field);
         }
       }
       if ($deleted == 1) {
-        $p = array('%name' => $field['name']);
+        $p = array('%name' => $field['#title']);
         drupal_set_message($button === 'edit-delete' ? t('Deleted field: %name', $p) : t('Disabled field: %name', $p));
       }
       else {
@@ -2027,8 +2027,9 @@ class wf_crm_admin_form {
     }
     // Merge defaults and create webform component
     $field += ['extra' => []];
-
-    $enabled[$field['form_key']] = $field;
+    if (empty($enabled[$field['form_key']])) {
+      $enabled[$field['form_key']] = $field;
+    }
   }
 
   /**

--- a/src/Form/WebformCiviCRMSettingsForm.php
+++ b/src/Form/WebformCiviCRMSettingsForm.php
@@ -70,6 +70,10 @@ class WebformCiviCRMSettingsForm extends FormBase {
     $webform = $this->getWebform();
     $handler_collection = $webform->getHandlers('webform_civicrm');
     $values = $form_state->getValues();
+    if (!isset($values['nid']) && !empty($form['form_state'])) {
+      $values += $form['form_state']->getValues();
+      $form_state->setValues($values);
+    }
 
     $has_handler = $handler_collection->has('webform_civicrm');
     $remove_handler = empty($values['nid']);


### PR DESCRIPTION
Overview
----------------------------------------
Unselecting a single field from a civi setting page on a webform results in all civi fields being lost

Before
----------------------------------------
To replicate -

- Create a webform with 3 basic contact fields - first name, last name and job title.
- Save.
- Open civicrm tab and unselect job title and re-save.
- The complete civicrm fields are removed from the webform.

After
----------------------------------------
works fine.

Comments
----------------------------------------
Drupal Issue - https://www.drupal.org/project/webform_civicrm/issues/3051616