### PR TITLE
Adjust the checkbox label to be the option's label

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1472,28 +1472,27 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   * Process the submission into the details of the activity.
   */
  private function formatSubmissionDetails(&$params, $activity_number) {
-   /*
     // Format details as html
     $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
     // Add webform results to details
     if (!empty($this->data['activity'][$activity_number]['details']['entire_result'])) {
+      /*
+      // @todo port
       module_load_include('inc', 'webform', 'includes/webform.submissions');
       $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
       $params['details'] .= drupal_render($submission);
+      */
     }
     if (!empty($this->data['activity'][$activity_number]['details']['view_link'])) {
-      $params['details'] .= '<p>' . l(t('View Webform Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}", array(
-          'absolute' => TRUE,
-          'alias' => TRUE
-        )) . '</p>';
+      $params['details'] .= '<p>' . $this->submission->toLink(t('View Webform Submission'), 'canonical', [
+        'absolute' => TRUE,
+      ])->toString() . '</p>';
     }
     if (!empty($this->data['activity'][$activity_number]['details']['edit_link'])) {
-      $params['details'] .= '<p>' . l(t('Edit Submission'), "node/{$this->node->nid}/submission/{$this->submission->sid}/edit", array(
-          'absolute' => TRUE,
-          'alias' => TRUE
-        )) . '</p>';
+      $params['details'] .= '<p>' . $this->submission->toLink(t('Edit Submission'), 'edit-form', [
+        'absolute' => TRUE,
+      ])->toString() . '</p>';
     }
-    */
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1472,6 +1472,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   * Process the submission into the details of the activity.
   */
  private function formatSubmissionDetails(&$params, $activity_number) {
+   /*
     // Format details as html
     $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
     // Add webform results to details
@@ -1492,6 +1493,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           'alias' => TRUE
         )) . '</p>';
     }
+    */
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1476,12 +1476,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['details'] = nl2br(wf_crm_aval($params, 'details', ''));
     // Add webform results to details
     if (!empty($this->data['activity'][$activity_number]['details']['entire_result'])) {
-      /*
-      // @todo port
-      module_load_include('inc', 'webform', 'includes/webform.submissions');
-      $submission = webform_submission_render($this->node, $this->submission, NULL, 'html');
-      $params['details'] .= drupal_render($submission);
-      */
+      $view_builder = \Drupal::entitTypeManager()->getViewBuilder('webform_submission');
+      $submission = $view_builder->view($this->submission);
+      $params['details'] .=  \Drupal::service('renderer')->renderPlain($submission);
     }
     if (!empty($this->data['activity'][$activity_number]['details']['view_link'])) {
       $params['details'] .= '<p>' . $this->submission->toLink(t('View Webform Submission'), 'canonical', [

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -150,6 +150,9 @@ class CivicrmOptions extends WebformElementBase {
       $element['#type'] = 'checkbox';
       // Reset the element label, the checkbox label, to be the first option's value.
       $element['#title'] = reset($element['#options']);
+      // Remove the options array to prevent invalid validation.
+      // @see \Drupal\Core\Form\FormValidator::performRequiredValidation
+      unset($element['#options']);
     }
 
     if (!empty($element['#default_option'])) {

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -148,6 +148,8 @@ class CivicrmOptions extends WebformElementBase {
     // A single static radio should be shown as a checkbox
     if (!$use_live_options && !$as_list && count($element['#options']) === 1) {
       $element['#type'] = 'checkbox';
+      // Reset the element label, the checkbox label, to be the first option's value.
+      $element['#title'] = reset($element['#options']);
     }
 
     if (!empty($element['#default_option'])) {

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -137,6 +137,10 @@ class CivicrmOptions extends WebformElementBase {
       $element['#options'] = $new;
     }
 
+    if (!empty($element['#default_option'])) {
+      $element['#default_value'] = $element['#default_option'];
+    }
+
     $element['#type'] = 'select';
     if (!$as_list) {
       $element['#type'] = $is_multiple ? 'checkboxes' : 'radios';
@@ -150,13 +154,10 @@ class CivicrmOptions extends WebformElementBase {
       $element['#type'] = 'checkbox';
       // Reset the element label, the checkbox label, to be the first option's value.
       $element['#title'] = reset($element['#options']);
+      $element['#return_value'] = key($element['#options']);
       // Remove the options array to prevent invalid validation.
       // @see \Drupal\Core\Form\FormValidator::performRequiredValidation
       unset($element['#options']);
-    }
-
-    if (!empty($element['#default_option'])) {
-      $element['#default_value'] = $element['#default_option'];
     }
     parent::prepare($element, $webform_submission);
   }


### PR DESCRIPTION
Overview
----------------------------------------
When a single option is chosen for a CiviCRM Options element, it converts to a checkbox. The checkbox label, however, is the element's title - not the option. For activities this means the checkbox is always labeled "Activity Type". Now it matches the value.



Before
----------------------------------------
<img width="610" alt="Screen Shot 2019-05-07 at 10 09 28 PM" src="https://user-images.githubusercontent.com/3698644/57346615-cf236a00-7114-11e9-974c-d8bb9aa10660.png">


After
----------------------------------------
<img width="573" alt="Screen Shot 2019-05-07 at 9 59 49 PM" src="https://user-images.githubusercontent.com/3698644/57346595-b9ae4000-7114-11e9-9156-8180d22d1e42.png">

