### PR TITLE
use flattened webform elements (so that civicrm elements can be inside a flexbox)

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -310,7 +310,7 @@ function wf_crm_get_matching_rules($contact_type) {
  */
 function wf_crm_enabled_fields(WebformInterface $webform, $submission = NULL, $show_all = FALSE) {
   $enabled = array();
-  $elements = $webform->getElementsDecoded();
+  $elements = $webform->getElementsDecodedAndFlattened();
   if (!empty($elements) || ($show_all)) {
     $handler_collection = $webform->getHandlers('webform_civicrm');
     if (!$handler_collection->has('webform_civicrm')) {


### PR DESCRIPTION
When going through the webform elements to match against wf_crm_get_fields, we should use getElementsDecodedAndFlattened instead of just getElementsDecoded, so that flexboxes don't get in the way.

This is rebased version of #208.