### PR TITLE
WIP - Show civicrm settings on the contact edit form

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -123,6 +123,12 @@ class CivicrmContact extends WebformElementBase {
         'weight' => 0,
         'value' => '',
         'required' => 0,
+        //Also include it here since it is needed for elements to show on the form.
+        'widget' => 'autocomplete',
+        'search_prompt' => '',
+        'none_prompt' => '',
+        'results_display' => ['display_name'],
+        'show_hidden_contact' => 0,
         'extra' => [
           'search_prompt' => '',
           'none_prompt' => '',


### PR DESCRIPTION
Overview
----------------------------------------
Show civicrm settings on the contact edit form

Before
----------------------------------------
No civicrm fields are displayed on the existing contact element form.

![image](https://user-images.githubusercontent.com/5929648/57448762-cd25ec00-7277-11e9-91fc-20790d196ca9.png)


After
----------------------------------------
Elements are displayed -

![image](https://user-images.githubusercontent.com/5929648/57448813-f47cb900-7277-11e9-8358-e4ac2b6b56da.png)


Technical Details
----------------------------------------
Adding as a main key of the element_properties lets the WebformElementBase know of the def property that need to be set for the element. If no value is available, it removes the complete property from display. See https://github.com/drupalprojects/webform/blob/8.x-5.x/src/Plugin/WebformElementBase.php#L3106 unless there is an `#access` key specified.

Comments
----------------------------------------
This is still unfinished as saving the element form kinda saves the filled values but the type of the existing contact remains as "CiviCRM Contact". Thoughts @KarinG @mglaman?

Also reported here - https://www.drupal.org/project/webform_civicrm/issues/3032306
