### PR TITLE
Use api to get state names instead of direct query (port from the 7 branch)

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -65,45 +65,43 @@ class Utils {
    * @param null|int|string $param
    */
   public static function wf_crm_get_states($param = NULL) {
-    $ret = array();
+    $ret = [];
     if (!$param || $param == 'default') {
-      $provinceLimit = Utils::wf_crm_get_civi_setting('provinceLimit');
+      $settings = wf_civicrm_api('Setting', 'get', [
+        'sequential' => 1,
+        'return' => 'provinceLimit',
+      ]);
+      $provinceLimit = wf_crm_aval($settings, "values:0:provinceLimit");
       if (!$param && $provinceLimit) {
         $param = (array) $provinceLimit;
       }
       else {
-        $param = [(int) Utils::wf_crm_get_civi_setting('defaultContactCountry', 1228)];
+        $settings = wf_civicrm_api('Setting', 'get', [
+          'sequential' => 1,
+          'return' => 'defaultContactCountry',
+        ]);
+        $param = [(int) wf_crm_aval($settings, "values:0:defaultContactCountry", 1228)];
       }
     }
     else {
-      $param = array((int) $param);
+      $param = [(int) $param];
     }
-    $states = wf_crm_apivalues('state_province', 'get', array(
+    $states = wf_crm_apivalues('state_province', 'get', [
       'return' => 'abbreviation,name',
       'sort' => 'name',
-      'country_id' => array('IN' => $param)
-    ));
+      'country_id' => ['IN' => $param],
+    ]);
     foreach ($states as $state) {
       $ret[strtoupper($state['abbreviation'])] = $state['name'];
     }
     // Localize the state/province names if in an non-en_US locale
     $tsLocale = CRM_Utils_System::getUFLocale();
-    if ($tsLocale != '' and $tsLocale != 'en_US') {
+    if ($tsLocale !== '' && $tsLocale !== 'en_US') {
       $i18n = CRM_Core_I18n::singleton();
-      $i18n->localizeArray($ret, array('context' => 'province'));
+      $i18n->localizeArray($ret, ['context' => 'province']);
       CRM_Utils_Array::asort($ret);
     }
     return $ret;
-  }
-
-  /**
-   * @param string $setting_name
-   * @param mixed $default_value
-   * @return mixed
-   */
-  public static function wf_crm_get_civi_setting($setting_name, $default_value = NULL) {
-    $settings = wf_civicrm_api('Setting', 'get', ['sequential' => 1, 'return' => $setting_name]);
-    return wf_crm_aval($settings, "values:0:$setting_name", $default_value);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
The `Utils::wf_crm_get_states_` function used a direct database query. This is replaced by api calls. It is a port from the same replacement on the 7.x-5.x branch.

Before and After
----------------------------------------
No change in behaviour.

Technical Details
----------------------------------------
* The function `wf_crm_get_civi_setting` is also placed in the Utils class.
* Utils is started now with an old school import `include_once __DIR__ . '/../includes/utils.inc';` . In the future, this import must disappear (maybe by moving more functions from utils.inc to this class).

Comments
----------------------------------------
Changes in the 7 branch were created at
- https://github.com/colemanw/webform_civicrm/commit/3da7c660406217a23d759dcf2772b7221aafec11 
- https://github.com/colemanw/webform_civicrm/commit/513a33ab24d83c2be2b75293f423074caf7cf600

