### PR TITLE
Sync state/province with the country on the form

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -341,9 +341,10 @@ var wfCivi = (function ($, D, drupalSettings) {
   }
 
   function countrySelect() {
+
     var name = parseName($(this).attr('name'));
     var countryId = $(this).val();
-    var stateSelect = $(this).parents('form.webform-submission-form').find('select.civicrm-enabled[name*="['+(name.replace('country', 'state_province'))+']"]');
+    var stateSelect = $(this).parents('form.webform-submission-form').find('select.civicrm-enabled[name*="'+name.replace('country', 'state_province')+'"]');
     if (stateSelect.length) {
       populateStates(stateSelect, countryId);
     }
@@ -424,7 +425,7 @@ var wfCivi = (function ($, D, drupalSettings) {
       });
 
       // Add handler to country field to trigger ajax refresh of corresponding state/prov
-      $('form.webform-submission-form .civicrm-enabled[name*="_address_country_id]"]').once('civicrm').change(countrySelect);
+      $('form.webform-submission-form .civicrm-enabled[name*="_address_country_id"]').once('civicrm').change(countrySelect);
 
       // Show/hide address fields when sharing an address
       $('form.webform-submission-form .civicrm-enabled[name*="_address_master_id"]').once('civicrm').change(function(){

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -341,7 +341,6 @@ var wfCivi = (function ($, D, drupalSettings) {
   }
 
   function countrySelect() {
-
     var name = parseName($(this).attr('name'));
     var countryId = $(this).val();
     var stateSelect = $(this).parents('form.webform-submission-form').find('select.civicrm-enabled[name*="'+name.replace('country', 'state_province')+'"]');

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -317,7 +317,9 @@ var wfCivi = (function ($, D, drupalSettings) {
       $.each(data, function(key, val) {
         $el.append('<option value="'+key+'">'+val+'</option>');
       });
-      $el.val(value);
+      if (value in data) {
+        $el.val(value);
+      }
     }
     else {
       $el.append('<option value="-">'+Drupal.t('- N/A -')+'</option>');


### PR DESCRIPTION
Overview
----------------------------------------
Synchronizes the states (or the provinces, or the departments) with the country when both address fields are on the form

Before
----------------------------------------
The state select list is filled when the form opens with the state list of the default country (on a update it is the statelist of the selected country)

After
----------------------------------------
When the country is updated the state list is also updated.

Technical Details
----------------------------------------
Just removed some obsolete brackets

