### PR TITLE
Cleanup contact relationship tab in the administration form

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -337,7 +337,7 @@ class wf_crm_admin_form {
           'js_select' => $this->addToggle($fsid),
         );
         if ($sid == 'relationship') {
-          $fieldset['#title'] = t('Relationship to :contact', array(':contact' => wf_crm_contact_label($i, $this->data, 'wrap')));
+          $fieldset['#title'] = t('Relationship to @contact', array('@contact' => wf_crm_contact_label($i, $this->data, 'wrap')));
         }
         elseif ((isset($set['max_instances']) && $set['max_instances'] > 1)) {
           $fieldset['#title'] .= ' ' . $i;

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -36,11 +36,17 @@ class FieldOptions implements FieldOptionsInterface {
         $ret = wf_crm_get_contact_relationship_types($data['contact'][$c]['contact'][1]['contact_type'], $data['contact'][$n]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$n]['contact'][1]['contact_sub_type']);
       }
       elseif ($name === 'relationship_permission') {
-        $ret = array(
-          1 => t('!a may view and edit !b', array('!a' => wf_crm_contact_label($c, $data, 'plain'), '!b' => wf_crm_contact_label($n, $data, 'plain'))),
-          2 => t('!a may view and edit !b', array('!a' => wf_crm_contact_label($n, $data, 'plain'), '!b' => wf_crm_contact_label($c, $data, 'plain'))),
+        $ret = [
+          1 => t(':a may view and edit :b', [
+            ':a' => wf_crm_contact_label($c, $data, 'plain'),
+            ':b' => wf_crm_contact_label($n, $data, 'plain'),
+          ]),
+          2 => t(':a may view and edit :b', [
+            ':a' => wf_crm_contact_label($n, $data, 'plain'),
+            ':b' => wf_crm_contact_label($c, $data, 'plain'),
+          ]),
           3 => t('Both contacts may view and edit each other'),
-        );
+        ];
       }
       // If this is a contact reference or shared address field, list webform contacts
       elseif ($name === 'master_id' || wf_crm_aval($field, 'data_type') === 'ContactReference') {


### PR DESCRIPTION
Overview
----------------------------------------
When more contacts are selected in the administration form the option is offered to create a relationship. In rendering this screen not all the variables are substituted.

Before
----------------------------------------

1. In the label HTML markup is shown.
2. In the select the placeholders are shown instead of the contacts

![before](https://user-images.githubusercontent.com/14834891/58231680-da42e080-7d37-11e9-8c66-bb8a476b814e.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/14834891/58231776-1118f680-7d38-11e9-894c-e11d253d2b5f.png)
