### PR TITLE
d8WC - Fix issue in adding file fields on webform

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1987,6 +1987,9 @@ class wf_crm_admin_form {
       $field['extra']['contact_type'] = $contact_type;
       $stop = null;
     }
+    if ($field['type'] == 'file') {
+      $field['type'] = 'managed_file';
+    }
     if (isset($field['value_callback'])) {
       $method = 'get_default_' . $table . '_' . $name;
       $field['value'] = self::$method($field['form_key'], $options);


### PR DESCRIPTION
Overview
----------------------------------------
File fields are not added on d8 webform.

Before
----------------------------------------
To replicate -
- Create a custom field in civi with type = file.
- Create a webform and add this field from the civi settings page.
- The file field is incorrectly added with type = generic element.

![image](https://user-images.githubusercontent.com/5929648/59024357-63493400-886f-11e9-8248-8b30b2d3cde6.png)


After
----------------------------------------
Delete the incorrect element and add the file field again after this patch. It is added correctly.

![image](https://user-images.githubusercontent.com/5929648/59024423-81169900-886f-11e9-9476-5777c91bc944.png)

