### PR TITLE
d8WC - Fix select all link in custom field section

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1470,9 +1470,9 @@ class wf_crm_admin_form {
   private function addToggle($name) {
     return array('#markup' =>
     '<div class="web-civi-js-select">
-      <a href="javascript:wfCiviAdmin.selectReset(' . "'all', '#$name'" . ')">' . t('Select All') . '</a> |
-      <a href="javascript:wfCiviAdmin.selectReset(' . "'none', '#$name'" . ')">' . t('Select None') . '</a> |
-      <a href="javascript:wfCiviAdmin.selectReset(' . "'reset', '#$name'" . ')">' . t('Restore') . '</a>
+      <a class="all" href="#">' . t('Select All') . '</a> |
+      <a class="none" href="#">' . t('Select None') . '</a> |
+      <a class="reset" href="#">' . t('Restore') . '</a>
     </div>',
     );
   }

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -389,6 +389,12 @@ var wfCiviAdmin = (function ($, D) {
       }
       $('.dynamic-custom-checkbox input', context).once('wf-civi-dynamic').each(handleDynamicCustom).change(handleDynamicCustom);
 
+      $('.web-civi-js-select a').once('wf-civi').click(function() {
+        var $fieldset = $(this).closest('fieldset');
+        pub.selectReset($(this).attr('class'), $fieldset);
+        return false;
+      });
+
       $('select[id*=contact-type], select[id*=contact-sub-type]', context).once('wf-civi-relationship').change(function() {
         relationshipOptions();
       });


### PR DESCRIPTION
Overview
----------------------------------------
'Select All' button doesn't work for custom field groups in webform civicrm

Before
----------------------------------------
If you enable a set of custom fields in the webform civicrm tab for a contact - eg Student Details
You often get a little button that says "Select All" 
eg

![image](https://user-images.githubusercontent.com/5929648/59025152-2da54a80-8871-11e9-953c-b72831cbed7c.png)

If you click that, it takes me to this link `...admin/structure/webform/manage/testwebform/wfCiviAdmin.selectReset('all',%20'#civicrm_2cg301_fieldset')`

which is page not found

After
----------------------------------------
select all works correctly.

![image](https://user-images.githubusercontent.com/5929648/59025286-74934000-8871-11e9-8248-0ebedced28b1.png)



