### PR TITLE
Fix fatal error when custom fields are Edit-ed after they have been placed on the webform

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -53,7 +53,11 @@ class CivicrmSelectOptions extends FormElement {
   protected static function getFieldOptions($form_key) {
     \Drupal::getContainer()->get('civicrm')->initialize();
     $pieces = explode('_', $form_key, 6);
-    list( , , , , $table, $name) = $pieces;
+    list( , , $ent, , $table, $name) = $pieces;
+    // Custom fields - use main entity
+    if (substr($table, 0, 2) == 'cg') {
+      $table = $ent;
+    }
     $params = ['field' => $name, 'context' => 'create'];
     return wf_crm_apivalues($table, 'getoptions', $params);
   }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -65,7 +65,7 @@ class FieldOptions implements FieldOptionsInterface {
       elseif ($table === 'other') {
         if ($field['table'] === 'tag') {
           $split = explode('_', $name);
-          $ret = CRM_Core_BAO_Tag::getTags("civicrm_{$ent}", $ret, wf_crm_aval($split, 1), '- ');
+          $ret = \CRM_Core_BAO_Tag::getTags("civicrm_{$ent}", $ret, wf_crm_aval($split, 1), '- ');
         }
         elseif ($field['table'] === 'group') {
           $ret = wf_crm_apivalues('group', 'get', array('is_hidden' => 0), 'title');

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -182,7 +182,11 @@ class CivicrmOptions extends WebformElementBase {
   }
 
   protected function getFieldOptions($element) {
-    list( , , , , $table, $name) = Utils::wf_crm_explode_key($element['#form_key']);
+    list( , , $ent, , $table, $name) = Utils::wf_crm_explode_key($element['#form_key']);
+    // Custom fields - use main entity
+    if (substr($table, 0, 2) == 'cg') {
+      $table = $ent;
+    }
     $params = ['field' => $name, 'context' => 'create'];
     return wf_crm_apivalues($table, 'getoptions', $params);
   }

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -81,7 +81,11 @@ class CivicrmSelect extends WebformElementBase {
   }
 
   protected function getFieldOptions($element) {
-    list( , , , , $table, $name) = Utils::wf_crm_explode_key($element['#form_key']);
+    list( , , $ent, , $table, $name) = Utils::wf_crm_explode_key($element['#form_key']);
+    // Custom fields - use main entity
+    if (substr($table, 0, 2) == 'cg') {
+      $table = $ent;
+    }
     $params = ['field' => $name, 'context' => 'create'];
     return wf_crm_apivalues($table, 'getoptions', $params);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error fixes when custom fields are added to the webform

Before
----------------------------------------
> Error: Class name must be a valid object or a string in civicrm_api3_generic_getoptions()

Above error is noticed on the webform when custom fields are added to it. To replicate -

- Add custom field with type select on the webform.
- Edit the component from the webform page.

After
----------------------------------------
Fixed.