### PR TITLE
Better feedback on removing CiviCRM fields

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1620,12 +1620,12 @@ class wf_crm_admin_form {
         list(, $c, $ent, $n, $table, $name) = explode('_', $key, 6);
         $info = '';
         $element = $this->webform->getElement($id);
-        $info = '<em>' . $element['#title'];
+        $info = '<em>' . $this->getSettings()["{$c}_webform_label"];
         if ($info && isset($this->sets[$table]['max_instances'])) {
           $info .= ' ' . $this->sets[$table]['label'] . ' ' . $n;
         }
         $info .= $info ? ':</em> ' : '';
-        $msg .= '<li>' . $info . $this->node->webform['components'][$id]['name'] . '</li>';
+        $msg .= '<li>' . $info . $element['#title'] . '</li>';
       }
       $msg .= '</ul><p>' . t('Would you like them to be automatically removed from the webform? This is recommended unless you need to keep webform-results information from these fields. (They can still be deleted manually later if you choose not to remove them now.)') . '</p><p><em>' . t('Note: Deleting webform components cannot be undone, and will result in the loss of webform-results info for those elements. Data in the CiviCRM database will not be affected.') . '</em></p>';
       $this->form_state->set('msg', $msg);


### PR DESCRIPTION
Overview
----------------------------------------
On deleting CiviCRM fields, confirmation of the user is asked. The description of this field is improved (or made the same as in Drupal 7 webforms).

To replay:
------------------------------------------------------------------------------------------
Create a form with 2 contacts. Label the contact Parent and the second contact Child. Add an address to the first contact. Start deleting fields (so you get the feedback). Delete
* The gender of the parent
* The external id of the child
* The city of the address

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/14834891/59630957-efe4d380-9146-11e9-80c3-b292ab81a945.png)
The label of the contact is not used, which makes it less clear which field it is.

After
----------------------------------------
![after](https://user-images.githubusercontent.com/14834891/59630875-b8762700-9146-11e9-8845-ba47bd49ed79.png)

Technical Details
----------------------------------------
This PR also removes the use of `$this->node->` on line 1628, that causes a warning
