### PR TITLE
Converted wf_crm_get_matching_rules to api only

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -287,10 +287,10 @@ function wf_crm_get_matching_rules($contact_type) {
   static $rules;
   $contact_type = ucfirst($contact_type);
   if (!$rules) {
-    $rules = array_fill_keys(array('Individual', 'Organization', 'Household'), array());
-    $dao = CRM_Core_DAO::executeQuery('SELECT * FROM civicrm_dedupe_rule_group');
-    while ($dao->fetch()) {
-      $rules[$dao->contact_type][$dao->id] = $dao->title;
+    $rules = array_fill_keys(['Individual', 'Organization', 'Household'], []);
+    $values = wf_crm_apivalues('RuleGroup', 'get');
+    foreach ($values as $value) {
+      $rules[$value['contact_type']][$value['id']] = $value['title'];
     }
   }
   return $rules[$contact_type];


### PR DESCRIPTION
Overview
----------------------------------------
Another function that is converted to api only

To Test
-----------------------------------------
This is the place where the function is shown in the interface
![matching-rule](https://user-images.githubusercontent.com/14834891/59767092-da37f100-92a1-11e9-908c-d8000c543dda.png)

This PR can be tested with The function can be tested with https://github.com/colemanw/webform_civicrm/pull/233 .