### PR TITLE
WIP: line item total text from label fix, membership line items display amount updates

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -461,6 +461,10 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           if ($table == 'contribution' && in_array($name, array('line_total', 'total_amount'))) {
             $element['#attributes']['class'][] = 'contribution-line-item';
           }
+          // For membership line-items
+          if ($table == 'membership' && in_array($name, array('fee_amount'))) {
+            $element['#attributes']['class'][] = 'contribution-line-item';
+          }
           // Provide live options from the Civi DB
           if (!empty($element['#civicrm_live_options']) && isset($element['#options'])) {
             $params = [
@@ -571,10 +575,11 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
   private function displayLineItems() {
     $rows = [];
     $total = 0;
+    $elements = $this->node->getElementsDecoded();
+
     // Support hidden contribution field
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (!$this->line_items && isset($this->enabled[$fid])) {
-      $elements = $this->node->getElementsDecoded();
       $field = $elements[$this->enabled[$fid]];
       if ($field['#type'] === 'hidden') {
         $this->line_items[] = [
@@ -583,6 +588,24 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           'element' => 'civicrm_1_contribution_1',
           'label' => !empty($field['name']) ? $field['name'] : t('Contribution Amount'),
         ];
+      }
+    }
+
+    // add membership line items if membership fee form elements are hidden
+    for ($c=1; $c<=30; $c++) {
+      for ($m=1 ; $m<=9; $m++) {
+        $membership_fid = 'civicrm_' . $c . '_membership_' . $m . '_membership_fee_amount';
+        if (!empty($this->enabled[$membership_fid]) && !empty($elements[$this->enabled[$membership_fid]])) {
+          if ($field['#type'] === 'hidden') {
+            $field = $elements[$this->enabled[$membership_fid]];
+            $this->line_items[] = [
+              'line_total' => $field['value'],
+              'qty'        => 1,
+              'element'    => 'civicrm_' . $c . 'membership_' . $m,
+              'label'      => !empty($field['name']) ? $field['name'] : t('Membership Fee'), // update for membership type id in label
+            ];
+          }
+        }
       }
     }
 

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -596,8 +596,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       for ($m=1 ; $m<=9; $m++) {
         $membership_fid = 'civicrm_' . $c . '_membership_' . $m . '_membership_fee_amount';
         if (!empty($this->enabled[$membership_fid]) && !empty($elements[$this->enabled[$membership_fid]])) {
+          $field = $elements[$this->enabled[$membership_fid]];
           if ($field['#type'] === 'hidden') {
-            $field = $elements[$this->enabled[$membership_fid]];
             $this->line_items[] = [
               'line_total' => $field['value'],
               'qty'        => 1,

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -100,7 +100,7 @@ cj(function($) {
   function calculateLineItemAmount() {
     var fieldKey = $(this).data('civicrmFieldKey'),
       amount = getFieldAmount(fieldKey),
-      label = $(this).closest('div.webform-component').find('label').text() || Drupal.t('Contribution'),
+      label = $('label[for=' + this.id + ']').text() || Drupal.t('Contribution'),
       lineKey = fieldKey.split('_').slice(0, 4).join('_');
     updateLineItem(lineKey, amount, label);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Updates line item table to show membership line items for membership fee fields. Updates contribution line item text to pull from contribution amount field label.
Seems to make memberships connect to contributions fine, MembershipPayment Records are created (although did this really make that work?)

Sorry about the fields being black background in the screenshots, that's my Gnome/GTK theme being wonky
The membership fee field has a value of 15
The membership fee 2 field has a value of 25
Contribution amount field value of 0

Not sure about why table line items listing is backwards from field order.

Before
----------------------------------------
Membership line items don't show and totals don't update when fee fields are changed.
![membership-line-item-table-before](https://user-images.githubusercontent.com/1508311/59958971-6a2d9480-9474-11e9-8dc1-f5cfba797308.png)

After
----------------------------------------
Membership line items show and totals update
![membership-line-item-table-after](https://user-images.githubusercontent.com/1508311/59958977-731e6600-9474-11e9-83e0-fe6e89e81789.png)

Contribution contains membership line items.
Membership records tied to contributions with MembershipPayments

