### PR TITLE
Add ability to create new case based on existing case

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -642,6 +642,12 @@ class wf_crm_admin_form {
         '#multiple' => TRUE,
       );
       $this->help($this->form['caseTab']['case'][$fs]["case_{$n}_settings_existing_case_status"], 'existing_case_status');
+      $this->form['caseTab']['case'][$fs]["case_{$n}_settings_duplicate_case"] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Create new case based on existing case'),
+        '#default_value' => wf_crm_aval($this->data, "case:{$n}:duplicate_case", 0),
+      );
+      $this->help($this->form['caseTab']['case'][$fs]["case_{$n}_settings_duplicate_case"], 'duplicate_case_status');
       $case_type = wf_crm_aval($this->data, "case:{$n}:case:1:case_type_id");
       foreach ($this->filterCaseSets($case_type) as $sid => $set) {
         $fs1 = "case_case_{$n}_fieldset_$sid";

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -378,7 +378,7 @@ class wf_crm_admin_help {
     print '<p>' .
       t('If a matching case of the chosen type already exists for the client, it will be autofilled and updated.') .
       '</p><p>' .
-      t('Note: a case can also be autofilled by passing "case1", etc. in the url. To create a new case based on an existing case also append "newcase1=yes" etc.') .
+      t('Note: a case can also be autofilled by passing "case1", etc. in the url. To create a new case based on an existing case also append "newcase1=1" etc.') .
       '</p>';
   }
 

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -384,11 +384,11 @@ class wf_crm_admin_help {
 
   public static function duplicate_case_status() {
     print '<p>' .
-      t('This forces a new case to be created based on an existing case.') .
+      t('Choosing this option means a new case will always be created even when an existing case has been selected. If an existing case has been selected the data for this case will NOT be updated.') .
       '</p><p>' .
       t('Useful if you want to pre-fill a form with existing case data, allow the user to make updates and then create a new case with their updates.') .
       '</p><p>' .
-      t('Note: Populate the existing case by selecting an option from the Update Existing Case drop-down or by passing "case1=[caseid]" in the url etc') .
+      t('Note: Populate the existing case by selecting an option from the Update Existing Case drop-down or by passing "case1=[caseid]" in the url etc.') .
       '</p>';
   }
 

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -378,7 +378,17 @@ class wf_crm_admin_help {
     print '<p>' .
       t('If a matching case of the chosen type already exists for the client, it will be autofilled and updated.') .
       '</p><p>' .
-      t('Note: a case can also be autofilled by passing "case1", etc. in the url. To create a new case based on an existing case also append "newcase1=1" etc.') .
+      t('Note: a case can also be autofilled by passing "case1", etc. in the url.') .
+      '</p>';
+  }
+
+  public static function duplicate_case_status() {
+    print '<p>' .
+      t('This forces a new case to be created based on an existing case.') .
+      '</p><p>' .
+      t('Useful if you want to pre-fill a form with existing case data, allow the user to make updates and then create a new case with their updates.') .
+      '</p><p>' .
+      t('Note: Populate the existing case by selecting an option from the Update Existing Case drop-down or by passing "case1=[caseid]" in the url etc') .
       '</p>';
   }
 

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -378,7 +378,7 @@ class wf_crm_admin_help {
     print '<p>' .
       t('If a matching case of the chosen type already exists for the client, it will be autofilled and updated.') .
       '</p><p>' .
-      t('Note: a case can also be autofilled by passing "case1", etc. in the url.') .
+      t('Note: a case can also be autofilled by passing "case1", etc. in the url. To create a new case based on an existing case also append "newcase1=yes" etc.') .
       '</p>';
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1260,7 +1260,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
         // Set some defaults in create mode
-        if (empty($this->ent['case'][$n]['id']) || !empty($this->ent['case'][$n]['new'])) {
+        // Create duplicate case based on existing case if 'duplicate_case' checkbox is checked
+        if (empty($this->ent['case'][$n]['id']) || $this->data['case'][$n]['duplicate_case'] == 1) {
           if (empty($params['case_type_id'])) {
             // Abort if no case type.
             continue;

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1260,7 +1260,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
         // Set some defaults in create mode
-        if (empty($this->ent['case'][$n]['id'])) {
+        if (empty($this->ent['case'][$n]['id']) || !empty($this->ent['case'][$n]['new'])) {
           if (empty($params['case_type_id'])) {
             // Abort if no case type.
             continue;

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1261,7 +1261,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         $params = $data['case'][1];
         // Set some defaults in create mode
         // Create duplicate case based on existing case if 'duplicate_case' checkbox is checked
-        if (empty($this->ent['case'][$n]['id']) || $this->data['case'][$n]['duplicate_case'] == 1) {
+        if (empty($this->ent['case'][$n]['id']) || !empty($this->data['case'][$n]['duplicate_case'])) {
           if (empty($params['case_type_id'])) {
             // Abort if no case type.
             continue;

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -660,6 +660,10 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             $item = wf_civicrm_api('case', 'getsingle', array('id' => $id));
             if (array_intersect((array)wf_crm_aval($item, 'client_id'), $clients)) {
               $this->ent['case'][$n] = array('id' => $id);
+              // Check if want to create new case based on existing case
+              if(isset($_GET["newcase$n"]) && $_GET["newcase$n"] == 'yes') {
+                $this->ent['case'][$n]['new'] = 'yes';
+              }
             }
           }
           // Populate via search

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -661,8 +661,8 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             if (array_intersect((array)wf_crm_aval($item, 'client_id'), $clients)) {
               $this->ent['case'][$n] = array('id' => $id);
               // Check if want to create new case based on existing case
-              if(isset($_GET["newcase$n"]) && $_GET["newcase$n"] == 'yes') {
-                $this->ent['case'][$n]['new'] = 'yes';
+              if(isset($_GET["newcase$n"]) && $_GET["newcase$n"] == 1) {
+                $this->ent['case'][$n]['new'] = 1;
               }
             }
           }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -660,10 +660,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             $item = wf_civicrm_api('case', 'getsingle', array('id' => $id));
             if (array_intersect((array)wf_crm_aval($item, 'client_id'), $clients)) {
               $this->ent['case'][$n] = array('id' => $id);
-              // Check if want to create new case based on existing case
-              if(isset($_GET["newcase$n"]) && $_GET["newcase$n"] == 1) {
-                $this->ent['case'][$n]['new'] = 1;
-              }
             }
           }
           // Populate via search


### PR DESCRIPTION
Overview
----------------------------------------
Add ability to create a new case based on an existing case.

I have a use case where users need to create the same type of case every two years using a webform. The case includes about 300 custom fields. To make it more user-friendly, instead of letting them start from scratch, I want to pre-fill the form based on their previous case data.

This is a very simple addition that I think adds some more flexibility to webform_civicrm and will benefit others with similiar use-cases.

Comments
----------------------------------------
This is my first PR! :)
