### PR TITLE
Add participant to civicrm data en to webform menu

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1092,6 +1092,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 unset($params['status_id']);
               }
               $result = wf_civicrm_api('participant', 'create', $params);
+              $this->ent['participant'][$n]['id'] = $result['id'];
+
               // Update line-item
               foreach ($this->line_items as &$item) {
                 if ($item['element'] == "civicrm_{$n}_participant_{$e}_participant_{$id_and_type}") {

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -364,6 +364,13 @@ function webform_civicrm_webform_submission_actions($node, $submission) {
           'query' => array('action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data['contribution'][1]['id']),
         );
       }
+      if (!empty($data['participant'][1]['id'])) {
+        $actions['civicrm_action participant_view'] = array(
+          'title' => t('View Participant'),
+          'href' => 'civicrm/contact/view/participant',
+          'query' => array('action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data['participant'][1]['id']),
+        );
+      }
     }
   }
   return $actions;


### PR DESCRIPTION
Overview
----------------------------------------
- When a webform is used to enrol a participant in an event the participant id is stored with the webform submission data.
- The data is used to generate a link in the webform results that can be used to jump directly to the Event Registration
- The participation_id is now also added to the trigger data of the `webform_civirules`, so that CiviRules actions can be used that act on Event Registration data.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/14834891/61188519-9a85de80-a680-11e9-923e-6595bf699de9.png)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/14834891/61188527-b5f0e980-a680-11e9-830c-5dfd2b5ac8b6.png)

Technical Details
----------------------------------------
* The participant id is added to the `civicrm_data` field (that contains the php serialized information of the CiviCRM entities, that are created in the form of the `webform_civicrm_submission` table.

Comments
----------------------------------------
The menu is a nice to have, the motivation is better cooperation with CiviRules
