### PR TITLE
Fix a bug when new multi-value fields are added to the webform.

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1656,6 +1656,11 @@ class wf_crm_admin_form {
         if (substr($key, 0, 7) == 'civicrm') {
           ++$i;
           $field = wf_crm_get_field($key);
+          if (substr($key, -11) === '_createmode') {
+            // Update webform's settings with 'Create mode' value for custom group.
+            $this->settings['data']['config']['create_mode'][$key] = $val;
+          }
+
           if (!isset($enabled[$key])) {
             $val = (array) $val;
             if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
@@ -1686,10 +1691,6 @@ class wf_crm_admin_form {
             webform_component_update($component);
           }
 
-          if (substr($key, -11) === '_createmode') {
-            // Update webform's settings with 'Create mode' value for custom group.
-            $this->settings['data']['config']['create_mode'][$key] = $val;
-          }
         }
         // add empty fieldsets for custom civicrm sets with no fields, if "add dynamically" is checked
         elseif (strpos($key, 'settings_dynamic_custom') && $val == 1) {


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3065727

Steps to reproduce:
- create multi-value set of custom fields on Contacts.  Add some fields
- add data to a contact
- create a webform, in CiviCRM tab add custom fields just created
- view the webform with ?cid=  for the contact you added data to

Before
----------------------------------------
The existing values are not loaded.
Go back to the webform and resave the config.
Then reload the webform - should show values.

After
----------------------------------------
The values are loaded as expected

Technical Details
----------------------------------------
Previously, the 'createmode' keys are wrongly converted to arrays since the
code path for `!isset($enabled[$key])` is followed. This
results in multi-value fields not being loaded by the webform.

