### PR TITLE
Fixed roles retrieval in webform

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -941,7 +941,7 @@ function wf_crm_get_fields($var = 'fields') {
       foreach (wf_crm_apivalues('case_type', 'get') as $case_type) {
         foreach ($case_type['definition']['caseRoles'] as $role) {
           foreach (wf_crm_get_relationship_types() as $rel_type) {
-            if ($rel_type['name_b_a'] == $role['name']) {
+            if (in_array($role['name'], [$rel_type['name_b_a'], $rel_type['label_b_a']])) {
               if (!isset($fields['case_role_' . $rel_type['id']])) {
                 $fields['case_role_' . $rel_type['id']] = array(
                   'name' => $rel_type['label_b_a'],


### PR DESCRIPTION
Overview
----------------------------------------
Case roles in webform weren't being retrieved correctly from Civi when the label and the name were different.

Before
----------------------------------------
Under the case tab in webform, the correct case roles were not being retrieved. 

After
----------------------------------------
Correct case roles now being retrieved under the case tab in webform.

Technical Details
----------------------------------------
Used label and name to check against relationship type name stored in case type definition.