### PR TITLE
Use api to retrieve civi settings

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -28,8 +28,7 @@ function wf_crm_state_abbr($input, $ret = 'abbreviation', $country_id = NULL) {
   $vars = array(1 => array($input, $ret == 'id' ? 'String' : 'Integer'));
   if ($ret === 'id') {
     if (!$country_id || $country_id === 'default') {
-      $config = CRM_Core_Config::singleton();
-      $country_id = (int) $config->defaultContactCountry;
+      $country_id = (int) wf_crm_get_civi_setting('defaultContactCountry', 1228);
     }
     $sql .= ' AND country_id = %2';
     $vars[2] = array($country_id, 'Integer');
@@ -87,8 +86,7 @@ function wf_crm_format_event($event, $format) {
   // Date format
   foreach ($format as $value) {
     if (strpos($value, 'dateformat') === 0) {
-      $config = CRM_Core_Config::singleton();
-      $date_format = $config->$value;
+      $date_format = wf_crm_get_civi_setting($value);
     }
   }
   $event = (object) $event;
@@ -107,7 +105,7 @@ function wf_crm_format_event($event, $format) {
     // Avoid showing redundant end-date if it is the same as the start date
     $same_day = substr($event->start_date, 0, 10) == substr($event->end_date, 0, 10);
     if (!$same_day || in_array('dateformatDatetime', $format) || in_array('dateformatTime', $format)) {
-      $end_format = (in_array('dateformatDatetime', $format) && $same_day) ? $config->dateformatTime : $date_format;
+      $end_format = (in_array('dateformatDatetime', $format) && $same_day) ? wf_crm_get_civi_setting('dateformatTime') : $date_format;
       $title[] = CRM_Utils_Date::customFormat($event->end_date, $end_format);
     }
   }
@@ -711,4 +709,14 @@ function wf_crm_custom_types_map_array() {
   );
 
   return $custom_types;
+}
+
+/**
+ * @param string $setting_name
+ * @param mixed $default_value
+ * @return mixed
+ */
+function wf_crm_get_civi_setting($setting_name, $default_value = NULL) {
+  $settings = wf_civicrm_api('Setting', 'get', ['sequential' => 1, 'return' => $setting_name]);
+  return wf_crm_aval($settings, "values:0:$setting_name", $default_value);
 }

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -23,18 +23,19 @@ use Drupal\webform_civicrm\Utils;
  * @return string or integer
  */
 function wf_crm_state_abbr($input, $ret = 'abbreviation', $country_id = NULL) {
-  $input_type = $ret == 'id' ? 'abbreviation' : 'id';
-  $sql = "SELECT $ret FROM civicrm_state_province WHERE $input_type = %1";
-  $vars = array(1 => array($input, $ret == 'id' ? 'String' : 'Integer'));
-  if ($ret === 'id') {
+  $params = ['sequential' => 1];
+  if ($ret == 'id') {
+    $params['abbreviation'] = $input;
     if (!$country_id || $country_id === 'default') {
       $country_id = (int) wf_crm_get_civi_setting('defaultContactCountry', 1228);
     }
-    $sql .= ' AND country_id = %2';
-    $vars[2] = array($country_id, 'Integer');
   }
-  $sql .= ' LIMIT 0, 1';
-  return CRM_Core_DAO::singleValueQuery($sql, $vars);
+  else {
+    $params['id'] = $input;
+  }
+  $params['country_id'] = $country_id;
+  $result = wf_crm_apivalues('StateProvince', 'get', $params, $ret);
+  return wf_crm_aval($result, 0);
 }
 
 /**

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -2106,7 +2106,7 @@ class wf_crm_admin_form {
    * Default value callback
    */
   public static function get_default_contact_cs($fid, $options) {
-    return CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'checksum_timeout', NULL, 7);
+    return wf_crm_get_civi_setting('checksum_timeout', 7);
   }
 
   /**

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -350,7 +350,7 @@ class wf_crm_admin_help {
   public static function activity_assignee_contact_id() {
     civicrm_initialize();
     print '<p>';
-    if (CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'activity_assignee_notification')) {
+    if (wf_crm_get_civi_setting('activity_assignee_notification')) {
       print t('A copy of this activity will be emailed to the assignee.');
     }
     else {

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -65,7 +65,7 @@ abstract class wf_crm_webform_base {
         return $this->_contribution_page;
 
       case 'tax_rate':
-        $taxSettings = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
+        $taxSettings = wf_crm_get_civi_setting('contribution_invoice_settings');
         if (is_array($taxSettings) && !empty($taxSettings['invoicing'])) {
           if ($this->contribution_page) {
             // tax integration

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -363,8 +363,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $country_id = $this->crmValues[$ckey];
           }
           else {
-            $config = CRM_Core_Config::singleton();
-            $country_id = $config->defaultContactCountry;
+            $country_id = (int) wf_crm_get_civi_setting('defaultContactCountry', 1228);
           }
           $states = Utils::wf_crm_get_states($country_id);
           if ($states && !array_key_exists(strtoupper($element['#value']), $states)) {
@@ -802,8 +801,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         foreach ($contact[$location] as $i => $params) {
           // Translate state/prov abbr to id
           if (!empty($params['state_province_id'])) {
-            $config = CRM_Core_Config::singleton();
-            if (!($params['state_province_id'] = wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $config->defaultContactCountry)))) {
+            $default_country = wf_crm_get_civi_setting('defaultContactCountry', 1228);
+            if (!($params['state_province_id'] = wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $default_country)))) {
               $params['state_province_id'] = '';
             }
           }
@@ -1445,7 +1444,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $this->processAttachments('activity', $n, $result['id'], empty($params['id']));
           }
           if (!empty($params['assignee_contact_id'])) {
-            if (CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::SYSTEM_PREFERENCES_NAME, 'activity_assignee_notification')) {
+            if (wf_crm_get_civi_setting('activity_assignee_notification')) {
               // Send email to assignees. TODO: Move to CiviCRM API?
               $assignees = wf_crm_apivalues('contact', 'get', array(
                 'id' => array('IN' => (array) $params['assignee_contact_id']),

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -177,15 +177,15 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
   private function addResources() {
     $this->form['#attached']['library'][] = 'webform_civicrm/forms';
 
-    $config = CRM_Core_Config::singleton();
+    $default_country = wf_crm_get_civi_setting('defaultContactCountry', 1228);
     // Variables to push to the client-side
     $js_vars = array();
     // JS Cache eliminates the need for most ajax state/province callbacks
     foreach ($this->data['contact'] as $c) {
       if (!empty($c['number_of_address'])) {
         $js_vars += [
-          'defaultCountry' => $config->defaultContactCountry,
-          'defaultStates' => Utils::wf_crm_get_states($config->defaultContactCountry),
+          'defaultCountry' => $default_country,
+          'defaultStates' => Utils::wf_crm_get_states($default_country),
           'noCountry' => t('- First Choose a Country -'),
           'callbackPath' => Url::fromUserInput('/webform-civicrm/js', ['alias' => TRUE])->toString(),
         ];
@@ -599,7 +599,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
 
       if ($itemTaxRate !== NULL) {
         // Change the line item label to display the tax rate it contains
-        $taxSettings = CRM_Core_BAO_Setting::getItem(CRM_Core_BAO_Setting::CONTRIBUTE_PREFERENCES_NAME, 'contribution_invoice_settings');
+        $taxSettings = wf_crm_get_civi_setting('contribution_invoice_settings');
 
         if (($itemTaxRate !== 0) && ($taxSettings['tax_display_settings'] !== 'Do_not_show')) {
           $item['label'] .= ' (' . t('includes !rate @tax', ['!rate' => (float) $itemTaxRate . '%', '@tax' => $taxSettings['tax_term']]) . ')';


### PR DESCRIPTION
This is a cherry-pick of 3da7c660406217a23d759dcf2772b7221aafec11 from the 7.x-5.x branch.

The goal is to use the api more and reduce usage of Civi internals like `CRM_Core_BAO_Setting` and `CRM_Core_Config`.