### PR TITLE
Switch to api for loading event/participant info

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -617,37 +617,18 @@ abstract class wf_crm_webform_base {
 
   /**
    * Fetch info and remaining spaces for events
-   *
-   * @param $events
-   *   Array of event info to fill (reference)
    */
   protected function loadEvents() {
     if (!empty($this->events)) {
       $now = time();
-      // Fetch event info
-      $dao = CRM_Core_DAO::executeQuery('SELECT id, title, start_date, end_date, event_type_id, max_participants, financial_type_id
-      FROM civicrm_event WHERE id IN (' . implode(',', array_keys($this->events)) . ')');
-      while ($dao->fetch()) {
-        $this->events[$dao->id]['title'] = $dao->title;
-        $this->events[$dao->id]['start_date'] = $dao->start_date;
-        $this->events[$dao->id]['end_date'] = $dao->end_date;
-        $this->events[$dao->id]['event_type_id'] = $dao->event_type_id;
-        $this->events[$dao->id]['financial_type_id'] = $dao->financial_type_id;
-        $this->events[$dao->id]['full'] = FALSE;
-        $this->events[$dao->id]['ended'] = $dao->end_date && strtotime($dao->end_date) < $now;
-        if ($this->events[$dao->id]['max_participants'] = $dao->max_participants) {
-          $remaining = CRM_Event_BAO_Participant::eventFull($dao->id, TRUE, FALSE);
-          if (is_string($remaining)) {
-            $this->events[$dao->id]['full'] = TRUE;
-            $this->events[$dao->id]['remaining'] = 0;
-            $this->events[$dao->id]['full_message'] = $remaining;
-          }
-          else {
-            $this->events[$dao->id]['remaining'] = $remaining ? $remaining : $dao->max_participants;
-          }
-        }
+      $events = wf_crm_apivalues('Event', 'get', [
+        'return' => ['title', 'start_date', 'end_date', 'event_type_id', 'max_participants', 'financial_type_id', 'event_full_text', 'is_full'],
+        'id' => ['IN' => array_keys($this->events)],
+      ]);
+      foreach ($events as $id => $event) {
+        $this->events[$id] = $event + $this->events[$id] + ['available_places' => 0];
+        $this->events[$id]['ended'] = !empty($event['end_date']) && strtotime($event['end_date']) < $now;
       }
-      $dao->free();
     }
   }
 

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -455,12 +455,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if ($event['ended']) {
           form_set_error($eid, t('Sorry, you can no longer register for %event.', array('%event' => $event['title'])));
         }
-        elseif ($event['max_participants'] && $event['count'] > $event['remaining']) {
-          if (!empty($event['full'])) {
-            form_set_error($eid, '<em>' . $event['title'] . '</em>: ' . $event['full_message']);
+        elseif ($event['max_participants'] && $event['count'] > $event['available_places']) {
+          if (!empty($event['is_full'])) {
+            form_set_error($eid, '<em>' . $event['title'] . '</em>: ' . $event['event_full_text']);
           }
           else {
-            form_set_error($eid, format_plural($event['remaining'],
+            form_set_error($eid, format_plural($event['available_places'],
               'Sorry, you tried to register !count people for %event but there is only 1 space remaining.',
               'Sorry, you tried to register !count people for %event but there are only @count spaces remaining.',
               array('%event' => $event['title'], '!count' => $event['count'])));

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -385,14 +385,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         continue;
       }
       $participants = current(wf_crm_aval($this->data['contact'], "$c:contact", array()));
-      $firstName = CRM_Utils_Array::value('first_name', $participants);
-      $lastName = CRM_Utils_Array::value('last_name', $participants);
 
-      $participantName = "{$firstName} {$lastName}";
+      $participantName = ($participants['first_name'] ?? '') . ' ' . ($participants['last_name'] ?? '');
       if (!trim($participantName)) {
-        $participantName = CRM_Utils_Array::value('webform_label', $participants);
+        $participantName = $participants['webform_label'] ?? NULL;
         if (!empty($this->existing_contacts[$c])) {
-          $participantName = CRM_Contact_BAO_Contact::displayName($this->existing_contacts[$c]);
+          $participantName = wf_crm_apivalues('contact', 'get', $this->existing_contacts[$c], 'display_name')[0];
         }
       }
       foreach (wf_crm_aval($par, 'participant', array()) as $n => $p) {
@@ -407,7 +405,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               'entity_table' => 'civicrm_participant',
               'event_id' => $eid,
               'contact_ids' => $contacts,
-              'unit_price' => $p['fee_amount'],
+              'unit_price' => $p['fee_amount'] ?? 0,
               'element' => "civicrm_{$c}_participant_{$n}_participant_{$id_and_type}",
               'contact_label' => $participantName,
             );
@@ -418,28 +416,29 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Subtract events already registered for - this only works with known contacts
     $cids = array_filter($this->existing_contacts);
     if ($this->events && $cids) {
-      $dao = CRM_Core_DAO::executeQuery("SELECT event_id, contact_id
-      FROM civicrm_participant p, civicrm_participant_status_type s
-      WHERE s.id = p.status_id AND s.is_counted = 1
-      AND event_id IN (" . implode(',', array_keys($this->events)) . ")
-      AND contact_id IN (" . implode(',', $cids) . ")
-      AND is_test = 0");
-      while ($dao->fetch()) {
-        if (isset($this->events[$dao->event_id])) {
-          if (!(--$this->events[$dao->event_id]['count'])) {
-            unset($this->events[$dao->event_id]);
+      $status_types = wf_crm_apivalues('participant_status_type', 'get', ['is_counted' => 1, 'return' => 'id']);
+      $existing = wf_crm_apivalues('Participant', 'get', [
+        'return' => ['event_id', 'contact_id'],
+        'event_id' => ['IN' => array_keys($this->events)],
+        'status_id' => ['IN' => array_keys($status_types)],
+        'contact_id' => ['IN' => $cids],
+        'is_test' => 0,
+      ]);
+      foreach ($existing as $participant) {
+        if (isset($this->events[$participant['event_id']])) {
+          if (!(--$this->events[$participant['event_id']]['count'])) {
+            unset($this->events[$participant['event_id']]);
           }
         }
         foreach ($this->line_items as $k => &$item) {
-          if ($dao->event_id == $item['event_id'] && in_array($dao->contact_id, $item['contact_ids'])) {
-            unset($this->line_items[$k]['contact_ids'][array_search($dao->contact_id, $item['contact_ids'])]);
+          if ($participant['event_id'] == $item['event_id'] && in_array($participant['contact_id'], $item['contact_ids'])) {
+            unset($this->line_items[$k]['contact_ids'][array_search($participant['contact_id'], $item['contact_ids'])]);
             if (!(--$item['qty'])) {
               unset($this->line_items[$k]);
             }
           }
         }
       }
-      $dao->free();
     }
     $this->loadEvents();
     // Add event info to line items
@@ -455,7 +454,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if ($event['ended']) {
           form_set_error($eid, t('Sorry, you can no longer register for %event.', array('%event' => $event['title'])));
         }
-        elseif ($event['max_participants'] && $event['count'] > $event['available_places']) {
+        elseif (!empty($event['max_participants']) && $event['count'] > $event['available_places']) {
           if (!empty($event['is_full'])) {
             form_set_error($eid, '<em>' . $event['title'] . '</em>: ' . $event['event_full_text']);
           }
@@ -1026,11 +1025,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $n = $this->data['participant_reg_type'] == 'separate' ? $c : 1;
     if ($p = wf_crm_aval($this->data, "participant:$n:participant")) {
       // Fetch existing participant records
-      $existing = array();
-      $dao = CRM_Core_DAO::executeQuery("SELECT id, event_id FROM civicrm_participant WHERE contact_id = $cid AND is_test = 0");
-      while ($dao->fetch()) {
-        $existing[$dao->event_id] = $dao->id;
-      }
+      $existing = wf_crm_apivalues('Participant', 'get', [
+        'return' => ["event_id"],
+        'contact_id' => $cid,
+        'is_test' => 0,
+      ]);
+      $existing = array_column($existing, 'id', 'event_id');
       foreach ($p as $e => $params) {
         $remove = array();
         $fid = "civicrm_{$c}_participant_{$e}_participant_event_id";

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -306,23 +306,20 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
    * @param int $c
    */
   private function loadParticipants($c) {
-    $select = array('id', 'event_id', 'role_id', 'status_id');
-    if (array_key_exists('participant_campaign_id', $this->all_fields)) {
-      $select[] = 'campaign_id';
-    }
     $status_types = wf_crm_apivalues('participant_status_type', 'get');
-    $dao = CRM_Core_DAO::executeQuery('SELECT ' . implode(',', $select) . '
-      FROM civicrm_participant
-      WHERE contact_id = ' . $this->ent['contact'][$c]['id'] . ' AND event_id IN (' . implode(',', array_keys($this->events)) . ")"
-    );
-    while ($dao->fetch()) {
-      $par = array();
-      foreach ($select as $sel) {
-        $par['participant'][1][$sel] = $dao->$sel;
+    $participants = wf_crm_apivalues('participant', 'get', [
+      'contact_id' => $this->ent['contact'][$c]['id'],
+      'event_id' => ['IN' => array_keys($this->events)],
+    ]);
+    foreach ($participants as $row) {
+      $par = [];
+      // v3 participant api returns some non-standard keys with participant_ prepended
+      foreach (['id', 'event_id', 'role_id', 'status_id', 'campaign_id'] as $sel) {
+        $par['participant'][1][$sel] = $row[$sel] = $row[$sel] ?? $row['participant_' . $sel] ?? NULL;
       }
-      $par += $this->getCustomData($dao->id, 'Participant');
-      $status = $status_types[$dao->status_id];
-      foreach ($this->events[$dao->event_id]['form'] as $event) {
+      $par += $this->getCustomData($row['id'], 'Participant');
+      $status = $status_types[$row['status_id']];
+      foreach ($this->events[$row['event_id']]['form'] as $event) {
         if ($event['contact'] == $c) {
           // If status has been set by admin or exposed to the form, use it as a filter
           if (in_array($status['id'], $event['status_id']) ||
@@ -344,7 +341,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         }
       }
     }
-    $dao->free();
   }
 
   /**

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -279,15 +279,15 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             $this->setMessage(t('Sorry, %event has ended.', array('%event' => $event['title'])), 'warning');
           }
         }
-        elseif ($event['full']) {
+        elseif (!empty($event['is_full'])) {
           if (!empty($reg['show_remaining'])) {
-            $this->setMessage('<em>' . check_plain($event['title']) . '</em>: ' . check_plain($event['full_message']), 'warning');
+            $this->setMessage('<em>' . check_plain($event['title']) . '</em>: ' . check_plain($event['event_full_text']), 'warning');
           }
         }
         else {
           $reg['block_form'] = FALSE;
-          if ($event['max_participants'] && ($reg['show_remaining'] == 'always' || intval($reg['show_remaining']) >= $event['remaining'])) {
-            $this->setMessage(format_plural($event['remaining'],
+          if (!empty($event['max_participants']) && ($reg['show_remaining'] == 'always' || intval($reg['show_remaining']) >= $event['available_places'])) {
+            $this->setMessage(format_plural($event['available_places'],
               '%event has 1 remaining space.',
               '%event has @count remaining spaces.',
               array('%event' => $event['title'])));


### PR DESCRIPTION
Overview
----------------------------------------
Removes a direct query and internal function call in favor of the api.

Before
----------------------------------------
BAO & SQL :(

After
----------------------------------------
API :)

Technical Details
----------------------------------------
Renames some of the array keys we were passing around within the webform to match the standard keys from the api.