### PR TITLE
Use attachment api instead of internal functions

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -942,19 +942,14 @@ abstract class wf_crm_webform_base {
         'icon' => $val,
       );
     }
-    $file = wf_crm_apivalues('file', 'get', $val);
-    $entity_id = '';
-    if ($entity && $n && (strpos($fieldName, 'custom_') === 0 || strpos($fieldName, 'file_') === 0)) {
-      $entity_id = $this->ent[$entity][$n]['id'];
-    }
+    $file = wf_crm_apivalues('Attachment', 'get', $val);
     if (!empty($file[$val])) {
-      $fileHash = CRM_Core_BAO_File::generateFileHash($entity_id, $val);
-      return array(
+      return [
         'data_type' => 'File',
-        'name' => CRM_Utils_File::cleanFileName($file[$val]['uri']),
-        'file_url'=> CRM_Utils_System::url('civicrm/file', "reset=1&id={$val}&eid={$entity_id}&fcs={$fileHash}", TRUE),
-        'icon' => file_icon_url((object) array('filemime' => $file[$val]['mime_type'])),
-      );
+        'name' => $file[$val]['name'],
+        'file_url'=> $file[$val]['url'],
+        'icon' => file_icon_url((object) ['filemime' => $file[$val]['mime_type']]),
+      ];
     }
     return NULL;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Use the attachment api to future-proof file handling.

Before
----------------------------------------
More code, less stable.

After
----------------------------------------
Less code, more stable.
