### PR TITLE
Empty submission for Datetime custom field resulting in default (now)…

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2357,8 +2357,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         // Fudge together date and time fields
         if ($field['type'] === 'time' && substr($name, -8) === 'timepart') {
           $name = str_replace('_timepart', '', $name);
-          // Add date (default to today)
-          $date = wf_crm_aval($this->data, "$ent:$c:$table:$n:$name", date('Ymd'));
+          $date = wf_crm_aval($this->data, "$ent:$c:$table:$n:$name", '');
           $val = $date . str_replace(':', '', $val);
         }
         // Only known contacts are allowed to empty a field


### PR DESCRIPTION
… getting saved in Civi

Overview
----------------------------------------
If there are civi datetime custom fields included in webform, empty submission of fields results in storing submission date (today's) in civi.
Note this only happens if there is time section included. If it's just date field, it works fine.

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/3448551/62824274-5ad4e880-bb93-11e9-8a0f-2c10f2da8b6a.png)

![image](https://user-images.githubusercontent.com/3448551/62824283-77712080-bb93-11e9-84f2-95d8415532f4.png)

Aug 10 17:01:15  [info] $$data before saveCustomDate() = Array
(
.............
    [cg6] => Array
        (
            [1] => Array
                (
                    [custom_11] => 20190813011500
                    [custom_12] => 20190810
                    [custom_13] => 20190810
                )
        )
)


After
----------------------------------------
![image](https://user-images.githubusercontent.com/3448551/62824289-8d7ee100-bb93-11e9-88b2-8d018df6b4f3.png)

Aug 10 17:03:49  [info] $$data before saveCustomData() = Array
(
.............
    [cg6] => Array
        (
            [1] => Array
                (
                    [custom_11] => 20190813011500
                    [custom_12] => 
                    [custom_13] => 
                `)`
        )
)

Technical Details
----------------------------------------
The code which fudges date and time together, populates date with default (Today) before merging with time, causing the problem. 
The date section on the other hand doesn't use default, therefore any date fields without time-part works fine.
There might be some original intention which i'm unaware of. Even if there is, it's not consistent with how just date fields work.