### PR TITLE
Fix file upload jQuery selector

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -93,7 +93,7 @@ var wfCivi = (function ($, D) {
 
   pub.initFileField = function(field, info) {
     info = info || {};
-    var container = $('div.webform-component[class$="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
+    var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
     if (container.length > 0) {
       if ($('.file', container).length > 0) {
         if ($('.file', container).is(':visible')) {
@@ -113,7 +113,7 @@ var wfCivi = (function ($, D) {
   };
 
   pub.clearFileField = function(field) {
-    var container = $('div.webform-component[class$="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
+    var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
     $('.civicrm-remove-file, .civicrm-file-icon', container).remove();
     $('input[type=file], input[type=submit]', container).show();
   };


### PR DESCRIPTION
Overview
----------------------------------------
Fixes the jQuery selector used to target file fields. Now works better across themes.

Before
----------------------------------------
Files not always shown correctly.

After
----------------------------------------
Files shown correctly.

Technical Details
----------------------------------------
Using the *= to match class works better as class attributes can be in any order