### PR TITLE
Unable to load file in CiviCRM custom field

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -896,11 +896,11 @@ abstract class wf_crm_webform_base {
     $file = file_load($id);
     if ($file) {
       $config = CRM_Core_Config::singleton();
-      $path = file_unmanaged_copy($file->uri, $config->customFileUploadDir);
+      $path = file_unmanaged_copy($file->getFileUri(), $config->customFileUploadDir);
       if ($path) {
         $result = wf_civicrm_api('file', 'create', array(
           'uri' => str_replace($config->customFileUploadDir, '', $path),
-          'mime_type' => $file->filemime,
+          'mime_type' => $file->getMimeType(),
         ));
         return wf_crm_aval($result, 'id');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Its is possible to create custom field in CiviCRM that contains a file. This file can be set on a webform. However, when the form is saved Drupal the following error.

      Recoverable fatal error: Object of class Drupal\Core\Field\FieldItemList could not be converted to string in Drupal\Core\File\FileSystem->prepareDestination() (line 473 of core/lib/Drupal/Core/File/FileSystem.php).

To reproduce.
- Create a Custom Data Set for Contacts.
- Add a Custom Field of the type file to this set.
- Create a webform with First Name, Last Name and the File Custom Field.
- Test de webform, a upload button for the file is displayed. Uploading works also file.
- Submit the form -> _Recoverable fatal error.

After
----------------------------------------
The error does not show up. The file is saved.

Technical Details
----------------------------------------
In Drupal 8 the file object has a different structure. Use the function instead of trying to access the fields.
