### PR TITLE
FileInfo does not work 

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -912,7 +912,7 @@ abstract class wf_crm_webform_base {
         'data_type' => 'File',
         'name' => CRM_Utils_File::cleanFileName($file[$val]['uri']),
         'file_url'=> CRM_Utils_System::url('civicrm/file', "reset=1&id={$val}&eid={$entity_id}", TRUE),
-        'icon' => file_icon_url((object) array('filemime' => $file[$val]['mime_type'])),
+        'icon' => file_icon_class($file[$val]['mime_type']),
       );
     }
     return NULL;

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -515,9 +515,10 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             if ($dt == 'File') {
               $fileInfo = $this->getFileInfo($name, $val, $ent, $n);
               if ($fileInfo && in_array($element['#type'], array('file', 'managed_file'))) {
-                $fileInfo = json_encode($fileInfo);
-                $js = "jQuery(function() {wfCivi.initFileField('$eid', $fileInfo)});";
-                $element['#attached']['js'][$js] = array('type' => 'inline');
+                $element['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
+                  'eid' => $eid,
+                  'fileInfo' => $fileInfo
+                ];
               }
             }
             // Set value for "secure value" elements

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -93,8 +93,9 @@ var wfCivi = (function ($, D, drupalSettings) {
   };
 
   pub.initFileField = function(field, info) {
+    console.log(info);
     info = info || {};
-    var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
+    var container = $('div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled');
     if (container.length > 0) {
       if ($('.file', container).length > 0) {
         if ($('.file', container).is(':visible')) {
@@ -107,14 +108,14 @@ var wfCivi = (function ($, D, drupalSettings) {
       }
       else {
         $(':visible', container).hide();
-        container.append('<input type="submit" class="form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Change') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
+        container.append('<input type="submit" class="button form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Remove') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
       }
-      container.prepend('<span class="civicrm-file-icon"><img alt="' + Drupal.t('File') + '" src="' + info.icon + '" /> ' + (info.name ? ('<a href="'+ info.file_url+ '" target="_blank">'+info.name +'</a>') : '') + '</span>');
+      container.prepend('<span class="file civicrm-file-icon file--'+info.icon+'">' + (info.name ? ('<a href="'+ info.file_url+ '" target="_blank">'+info.name +'</a>') : '') + '</span>');
     }
   };
 
   pub.clearFileField = function(field) {
-    var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
+    var container = $('div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled');
     $('.civicrm-remove-file, .civicrm-file-icon', container).remove();
     $('input[type=file], input[type=submit]', container).show();
   };
@@ -437,6 +438,12 @@ var wfCivi = (function ($, D, drupalSettings) {
       // Handle image file ajax refresh
       $('div.civicrm-enabled[id*=contact-1-contact-image-url]:has(.file)', context).each(function() {
         pub.initFileField(getFieldNameFromClass($(this).parent()));
+      });
+
+      $('form.webform-submission-form').once('civicrm').each(function () {
+        drupalSettings.webform_civicrm.fileFields.forEach(function (fileField){
+          wfCivi.initFileField(fileField.eid, fileField.fileInfo);
+        });
       });
     }
   };

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -93,14 +93,12 @@ var wfCivi = (function ($, D, drupalSettings) {
   };
 
   pub.initFileField = function(field, info) {
-    console.log(info);
     info = info || {};
     var container = $('div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled');
     if (container.length > 0) {
       if ($('.file', container).length > 0) {
         if ($('.file', container).is(':visible')) {
           $('.file', container).hide();
-          info.icon = $('.file a', container).attr('href');
         }
         else {
           return;


### PR DESCRIPTION
Overview
----------------------------------------
Custom Fields in CiviCRM can contain files and civicrm_webforms makes it possible to upload these files. Unfortunately when you try to edit the webforms results, and error is shown.

To reproduce.
1. Create a custom file field on a contact.
2. Create a webform with this field.
3. Use the form to upload a file
4. Go to webform results.
5. Select the edit button: Error `Call to undefined function file_icon_url() in wf_crm_webform_base->getFileInfo()`

After the PR
----------------------------------------
File details are shown (Icon and filename link). See picture
![Selection_004](https://user-images.githubusercontent.com/14834891/64076571-cad41b80-ccc6-11e9-9389-6448ab45f25a.png)


Technical Details
----------------------------------------
Drupal 8 does not work with file icons anymore used the function `file_icon_class`

Drupal 8 does not allow attachment of php generated jQuery snippets to a component. So Javascript with paramaters that are only known at runtime must done in different way. Solution.
* put the parameters in the drupal settings.
* add the JQuery call to the drupal behaviors

Known Issues
------------------------------------------
Clicking on the filelink does not work. The hope is that the following PR will improve this: https://github.com/colemanw/webform_civicrm/pull/249

