### PR TITLE
Use attachment api instead of internal functions + including file_icon_class

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -930,18 +930,14 @@ abstract class wf_crm_webform_base {
         'icon' => $val,
       );
     }
-    $file = wf_crm_apivalues('file', 'get', $val);
-    $entity_id = '';
-    if ($entity && $n && (strpos($fieldName, 'custom_') === 0 || strpos($fieldName, 'file_') === 0)) {
-      $entity_id = $this->ent[$entity][$n]['id'];
-    }
+    $file = wf_crm_apivalues('Attachment', 'get', $val);
     if (!empty($file[$val])) {
-      return array(
+      return [
         'data_type' => 'File',
-        'name' => CRM_Utils_File::cleanFileName($file[$val]['uri']),
-        'file_url'=> CRM_Utils_System::url('civicrm/file', "reset=1&id={$val}&eid={$entity_id}", TRUE),
-        'icon' => file_icon_url((object) array('filemime' => $file[$val]['mime_type'])),
-      );
+        'name' => $file[$val]['name'],
+        'file_url'=> $file[$val]['url'],
+        'icon' => file_icon_url((object) ['filemime' => $file[$val]['mime_type']]),
+      ];
     }
     return NULL;
   }


### PR DESCRIPTION
The same as https://github.com/colemanw/webform_civicrm/pull/249 but now file_icon_class instead of file_icon_url. So now it runs on Drupal 8

This also fixes the known issue of https://github.com/colemanw/webform_civicrm/pull/264. Now it is possible to download the file shown by the fileInfo. Unfortunately the attachment api generates a absolute url instead a relative one. This causes Chrome to open a seperate window.

