### PR TITLE
Fix payment_processor_id in test mode so CiviCRM always uses the correct processor

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -948,4 +948,22 @@ abstract class wf_crm_webform_base {
     return CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
   }
 
+  /**
+   * Historically webform_civicrm was configured with the live payment processor ID and the is_test flag.
+   * But this is not how CiviCRM expects it to work and this can cause problems where payments use the live processor
+   *   instead of test.  So we "fix" the processor ID here to be the correct one for live/test.
+   * An "improved" fix would involve changing the configuration saved by the user but this avoids that.
+   *
+   * @throws \CiviCRM_API3_Exception
+   */
+  protected function fixPaymentProcessorID() {
+    // Check for is_test and payment_processor_id (pay later = 0 is set to '' here. is_test has no meaning for pay later).
+    if (!empty($this->data['contribution'][1]['contribution'][1]['is_test'])
+        && !empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id'])) {
+      $paymentProcessor = \Civi\Payment\System::singleton()->getById($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
+      $paymentProcessor = \Civi\Payment\System::singleton()->getByName($paymentProcessor->getPaymentProcessor()['name'], TRUE);
+      $this->data['contribution'][1]['contribution'][1]['payment_processor_id'] = $paymentProcessor->getPaymentProcessor()['id'];
+    }
+  }
+
 }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -43,6 +43,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $this->node = $node;
     $this->settings = $node->webform_civicrm;
     $this->data = $this->settings['data'];
+    $this->fixPaymentProcessorID();
     $this->enabled = wf_crm_enabled_fields($node);
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');
@@ -766,7 +767,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
     }
-    
+
     foreach (wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
         $existing = array();
@@ -1931,11 +1932,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params = $this->data['contribution'][1]['contribution'][1];
     $processor_type = wf_civicrm_api('payment_processor', 'getsingle', array('id' => $params['payment_processor_id']));
     $paymentProcessor = \Civi\Payment\System::singleton()->getById($params['payment_processor_id']);
-    // Ideally we would pass the correct id for the test processor through but that seems not to be the
-    // case so load it here.
-    if (!empty($params['is_test'])) {
-      $paymentProcessor = \Civi\Payment\System::singleton()->getByName($processor_type['name'], TRUE);
-    }
+
     // Add contact details to params (most processors want a first_name and last_name)
     $contact = wf_civicrm_api('contact', 'getsingle', array('id' => $this->ent['contact'][1]['id']));
     $params += $contact;
@@ -2078,26 +2075,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (empty($params[$key])) {
         $params[$key] = $value;
       }
-    }
-
-    // Fix bug for testing.
-    if ($params['is_test'] == 1) {
-      $liveProcessorName = wf_civicrm_api('payment_processor', 'getvalue', array(
-        'id' => $params['payment_processor_id'],
-        'return' => 'name',
-      ));
-      // Lookup current domain for multisite support
-      static $domain = 0;
-      if (!$domain) {
-        $domain = wf_civicrm_api('domain', 'get', array('current_domain' => 1, 'return' => 'id'));
-        $domain = wf_crm_aval($domain, 'id', 1);
-      }
-      $params['payment_processor_id'] = wf_civicrm_api('payment_processor', 'getvalue', array(
-        'return' => 'id',
-        'name' => $liveProcessorName,
-        'is_test' => 1,
-        'domain_id' => $domain,
-      ));
     }
 
     if (empty($params['payment_instrument_id'])) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -21,6 +21,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     $this->node = $form['#node'];
     $this->settings = $this->node->webform_civicrm;
     $this->data = $this->settings['data'];
+    $this->fixPaymentProcessorID();
     $this->ent['contact'] = array();
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');


### PR DESCRIPTION
Overview
----------------------------------------
webform_civicrm uses the live payment_processor_id internally and calls various CiviCRM functions based on that ID.  It attempts before final payment to select the test ID but this is not always reliable and causes problems with various payment processors (eg. stripe) which cannot be used in test mode without custom code to handle webform_civicrm submissions.

See https://www.drupal.org/project/webform_civicrm/issues/2420809 and https://www.drupal.org/project/webform_civicrm/issues/2756937

Before
----------------------------------------
Wrong payment_processor_id used in test mode (the live one is used)

After
----------------------------------------
The correct payment_processor_id is used throughout.

Technical Details
----------------------------------------
I didn't convert the settings because this would require updating existing configurations.  So instead I update the payment_processor_id immediately after the settings have been loaded.

Comments
----------------------------------------
@KarinG @eileenmcnaughton 
