### PR TITLE
Use field options service for options elements

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -52,10 +52,8 @@ class CivicrmSelectOptions extends FormElement {
 
   protected static function getFieldOptions($form_key) {
     \Drupal::getContainer()->get('civicrm')->initialize();
-    $pieces = explode('_', $form_key, 6);
-    list( , , , , $table, $name) = $pieces;
-    $params = ['field' => $name, 'context' => 'create'];
-    return wf_crm_apivalues($table, 'getoptions', $params);
+    $field_options = \Drupal::service('webform_civicrm.field_options');
+    return $field_options->get(['form_key' => $form_key], 'create', []);
   }
 
   public static function processSelectOptions(&$element, FormStateInterface $form_state, &$complete_form) {

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -182,9 +182,9 @@ class CivicrmOptions extends WebformElementBase {
   }
 
   protected function getFieldOptions($element) {
-    list( , , , , $table, $name) = Utils::wf_crm_explode_key($element['#form_key']);
-    $params = ['field' => $name, 'context' => 'create'];
-    return wf_crm_apivalues($table, 'getoptions', $params);
+    \Drupal::getContainer()->get('civicrm')->initialize();
+    $field_options = \Drupal::service('webform_civicrm.field_options');
+    return $field_options->get(['form_key' => $element['#form_key']], 'create', []);
   }
 
   /**


### PR DESCRIPTION
Instead of using custom logic in the elements, use the field options service which has proper handling for the different tables.

This was uncovered with tags. Specifically this handling

```
        if ($field['table'] === 'tag') {
          $split = explode('_', $name);
          $ret = wf_crm_get_tags($ent, wf_crm_aval($split, 1));
        }
```