### PR TITLE
Fix incorrect setting of payment instrument

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -766,7 +766,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
     }
-    
+
     foreach (wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
         $existing = array();
@@ -1868,12 +1868,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
     else {
       $paymentProcessorID = $this->data['contribution'][1]['contribution'][1]['payment_processor_id'];
-      $paymentProcessorClassName = civicrm_api3('PaymentProcessor', 'getvalue', array(
-        'return' => 'class_name',
+      $paymentProcessor = civicrm_api3('PaymentProcessor', 'getsingle', array(
+        'return' => ['class_name', 'payment_instrument_id'],
         'id' => $paymentProcessorID,
       ));
 
-      if ($paymentProcessorClassName === 'Payment_Manual') {
+      if ($paymentProcessor['class_name'] === 'Payment_Manual') {
         $this->contributionIsPayLater = TRUE;
       }
     }
@@ -1884,8 +1884,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
       if (!empty($params['payment_processor_id']) && $this->contribution_page['is_monetary']) {
-        $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
-        $params['payment_instrument_id'] = key($defaultPaymentInstrument);
+        if (!empty($paymentProcessor['payment_instrument_id'])) {
+          $params['payment_instrument_id'] = $paymentProcessor['payment_instrument_id'];
+        }
+        else {
+          $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
+          $params['payment_instrument_id'] = key($defaultPaymentInstrument);
+        }
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix setting of incorrect payment instrument. 

Before
----------------------------------------
While doing a contribution using a payment processor with billing mode = 4, eg omnipay pxpay processor, webform civi initially creates a pending payment and then completes it using the ipn/webhook details. When the initial payment is processed, the payment instrument is incorrectly set as the default method(Check) instead of getting the preferred value from the payment processor.

And when the contribution is completed, civicrm thinks that the payment instrument is changed and hence creates an additional financial transaction which can be viewed on the view contribution page-

![image](https://user-images.githubusercontent.com/5929648/65147935-c33da200-da3c-11e9-8701-263145db8106.png)

To replicate -

Create a simple webform with contribution page having payment processor which navigates to its site for payment.

After the payment is done and webform confirmation page is displayed, note the multiple row display on the view contribution page. 

After
----------------------------------------
The initial payment gets a correct payment method value and on completion, no processing is done as before and civi directly sets the status to completed.

The below row is displayed after doing payment using the same processor.

![image](https://user-images.githubusercontent.com/5929648/65148151-40691700-da3d-11e9-8bfc-0d98b4268fc9.png)
