### PR TITLE
Pagebreaks and fieldsets

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1729,7 +1729,7 @@ class wf_crm_admin_form {
                  */
                 // @todo Properly handle fieldset creation.
                 // self::insertComponent($field, $enabled, $this->settings, !isset($previous_data['data'][$type][$c]));
-                self::insertComponent($field, $enabled, $this->settings);
+                self::insertComponent($field, $enabled, $this->settings, TRUE);
                 $created[] = $field['name'];
                 if (isset($field['civicrm_condition'])) {
                   $this->addConditionalRule($field, $enabled);
@@ -1999,8 +1999,8 @@ class wf_crm_admin_form {
     if ($ent !== 'contribution' &&
       ($ent !== 'participant' || wf_crm_aval($settings['data'], 'participant_reg_type') === 'separate')
     ) {
-      // @todo Properly handle fieldset creation.
-      // self::addFieldset($c, $field, $enabled, $settings, $ent, $create_fieldsets);
+       $fieldset_key = self::addFieldset($c, $field, $enabled, $settings, $ent, $create_fieldsets);
+       $field['parent'] = $fieldset_key;
     }
     // Create page break for contribution page
     if ($name === 'contribution_page_id') {
@@ -2065,11 +2065,14 @@ class wf_crm_admin_form {
         // @todo We cannot define a default weight.
         // $new_set['weight'] = 200 + (array_search($type, self::$fieldset_entities, TRUE) * 10 + $c);
       }
-      // @todo use WebformElementManager and get defaults
-      // @see \Drupal\webform\Plugin\WebformElement\Fieldset::getDefaultProperties
-      // $new_set += webform_component_invoke('fieldset', 'defaults');
+      $webform_element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
+      $element_plugin = $webform_element_manager->getElementInstance([
+        '#type' => $new_set['type'],
+      ]);
+      $new_set = array_merge($element_plugin->getDefaultProperties(), $new_set);
       $enabled[$sid] = $new_set;
     }
+    return $sid;
   }
 
   /**
@@ -2126,22 +2129,6 @@ class wf_crm_admin_form {
       }
     }
     return $ret;
-  }
-
-  /**
-   * Is this a new entity being added to the form?
-   *
-   * If so, create a new fieldset for them.
-   * Otherwise only use an existing one if it exists.
-   * This way we respect the user's choice and don't add a fieldset if they've already deleted it.
-   *
-   * @param $field_key
-   * @return bool
-   */
-  private function isNewFieldset($field_key) {
-    list(, $c, $ent) =  Utils::wf_crm_explode_key($field_key);
-    $type = in_array($ent, self::$fieldset_entities) ? $ent : 'contact';
-    return !isset($this->node->webform_civicrm['data'][$type][$c]);
   }
 
   /**

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1806,7 +1806,12 @@ class wf_crm_admin_form {
         unset($enabled_element['name']);
         $stub_form_state->setValues($enabled_element);
         $properties = $element_plugin->getConfigurationFormProperties($stub_form, $stub_form_state);
-        $this->webform->setElementProperties($enabled_key, $properties);
+
+        $parent_key = '';
+        if (isset($enabled_element['parent'])) {
+          $parent_key = $enabled_element['parent'];
+        }
+        $this->webform->setElementProperties($enabled_key, $properties, $parent_key);
       }
       // Update existing contact fields
       foreach ($existing as $fid => $id) {
@@ -2006,7 +2011,7 @@ class wf_crm_admin_form {
         'form_key' => 'contribution_pagebreak',
         'title' => (string) t('Payment'),
       ];
-      // self::addPageBreak($field);
+      self::addPageBreak($field);
     }
     // Merge defaults and create webform component
     $field += ['extra' => []];

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -569,6 +569,7 @@ class Fields implements FieldsInterface {
         // @todo moved in order since we can't pass `weight`.
         $fields['contribution_total_amount'] = array(
             'name' => 'Contribution Amount',
+            'parent' => 'contribution_pagebreak',
           ) + $moneyDefaults;
         // @todo moved in order since we can't pass `weight`.
         $fields['contribution_payment_processor_id'] = array(
@@ -588,10 +589,12 @@ class Fields implements FieldsInterface {
           'extra' => array(
             'hidden_type' => 'hidden',
           ),
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_note'] = array(
           'name' => t('Contribution Note'),
           'type' => 'textarea',
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_soft'] = array(
           'name' => t('Soft Credit To'),
@@ -599,6 +602,7 @@ class Fields implements FieldsInterface {
           'expose_list' => TRUE,
           'extra' => array('multiple' => TRUE),
           'data_type' => 'ContactReference',
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_honor_contact_id'] = array(
           'name' => t('In Honor/Memory of'),
@@ -606,11 +610,13 @@ class Fields implements FieldsInterface {
           'expose_list' => TRUE,
           'empty_option' => t('No One'),
           'data_type' => 'ContactReference',
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_honor_type_id'] = array(
           'name' => t('Honoree Type'),
           'type' => 'select',
           'expose_list' => TRUE,
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_is_test'] = array(
           'name' => t('Payment Processor Mode'),
@@ -618,16 +624,18 @@ class Fields implements FieldsInterface {
           'expose_list' => TRUE,
           'extra' => array('civicrm_live_options' => 1),
           'value' => 0,
-          'weight' => 9997,
+          'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_source'] = array(
           'name' => t('Contribution Source'),
           'type' => 'textfield',
+          'parent' => 'contribution_pagebreak',
         );
         // Line items
         $fields['contribution_line_total'] = array(
             'name' => t('Line Item Amount'),
             'set' => 'line_items',
+            'parent' => 'contribution_pagebreak',
           ) + $moneyDefaults;
         $fields['contribution_financial_type_id'] = array(
           'name' => t('Financial Type'),
@@ -637,6 +645,7 @@ class Fields implements FieldsInterface {
           'value' => 1,
           'default' => 1,
           'set' => 'line_items',
+          'parent' => 'contribution_pagebreak',
         );
         $sets['contributionRecur'] = array('entity_type' => 'contribution', 'label' => t('Recurring Contribution'));
         $fields['contribution_frequency_unit'] = array(


### PR DESCRIPTION
Fieldset generation and contribution page break support. Ensures the contribution page break is inserted properly. Adds fieldset generation so that the fieldset can be easily changed into a page, for proper page breaks.

Needs experimenting. And currently, the fieldset generation is defaulted to TRUE. The check done in D7 might not be needed in D8. Tries to prevent adding the fieldset if it was already possibly added and removed.

<img width="1372" alt="Screen Shot 2019-10-03 at 10 41 56 PM" src="https://user-images.githubusercontent.com/3698644/66179558-1748a900-e62f-11e9-813d-2d72bd75aa42.png">
