### PR TITLE
Supporting membership autorenewal

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -75,6 +75,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'auto_renew') {
+      $ret = array(1 => t('Yes'), 0 => t('No'));
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = array('field' => $name, 'context' => 'create');
@@ -1231,6 +1234,12 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_end_date'] = array(
         'name' => t('End Date'),
         'type' => 'date',
+      );
+      $fields['membership_auto_renew'] = array(
+        'name' => t('Auto-renew Membership?'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
       );
     }
     // Add campaign fields

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -766,7 +766,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
     }
-    
+
     foreach (wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
         $existing = array();
@@ -1198,8 +1198,20 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
-      if (isset($this->ent['contribution_recur'][1]['id'])) {
-        $params['contribution_recur_id'] = $this->ent['contribution_recur'][1]['id'];
+      if (isset($this->ent['contribution_recur'][1]['id']) && !empty($params['auto_renew'])) {
+        $contributionRecurId = $this->ent['contribution_recur'][1]['id'];
+
+        $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
+          'return' => 'auto_renew',
+          'sequential' => 1,
+          'id' => $contributionRecurId,
+        ]);
+
+        if (!empty($contributionRecur['values'][0]['auto_renew'])) {
+          $params['contribution_recur_id'] = $contributionRecurId;
+        }
+
+        unset($params['auto_renew']);
       }
 
       $result = wf_civicrm_api('membership', 'create', $params);
@@ -1848,6 +1860,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'financial_type_id' =>  $contributionParams['financial_type_id'],
     );
 
+    if ($paymentType === 'deferred' && !empty($contributionParams['auto_renew'])) {
+      $contributionRecurParams['auto_renew'] = 1;
+    }
+
     if(empty($contributionParams['payment_processor_id'])) {
       $contributionRecurParams['payment_processor_id'] = 'null';
     }
@@ -1921,7 +1937,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+      if ($isThereMembershipToBeAutoRenewed) {
+        $params['auto_renew'] = 1;
+      }
+
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {
@@ -1929,6 +1950,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $this->ent['contribution'][1]['id'] = $result['id'];
+  }
+
+  /**
+   * Determines if the webform is configured to have
+   * any membership to be autorenwed or not.
+   */
+  private function isThereMembershipToBeAutoRenewed() {
+    $autoRenewMembership = FALSE;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if (!empty($membership['auto_renew'])) {
+          $autoRenewMembership = TRUE;
+        }
+      }
+    }
+    return $autoRenewMembership;
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1198,18 +1198,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
+      /**
+       * If the webform configured with a recur contribution
+       * and auto-renew for the membership set to True, set we
+       * set the membership contribution_recur_id field to the
+       * point the recuring contribution, since for membership
+       * to be considered auto-renew in CiviCRM core they should
+       * have both this field set to the related recuring contribution
+       * and for the related recuring contribution auto_renew field
+       * set to TRUE.
+       *
+       * Here we ensure
+       */
       if (isset($this->ent['contribution_recur'][1]['id']) && !empty($params['auto_renew'])) {
         $contributionRecurId = $this->ent['contribution_recur'][1]['id'];
 
-        $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
-          'return' => 'auto_renew',
-          'sequential' => 1,
-          'id' => $contributionRecurId,
-        ]);
-
-        if (!empty($contributionRecur['values'][0]['auto_renew'])) {
-          $params['contribution_recur_id'] = $contributionRecurId;
-        }
+        $params['contribution_recur_id'] = $contributionRecurId;
 
         unset($params['auto_renew']);
       }
@@ -1804,7 +1808,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Only if #installments = 1, do we process a single transaction/contribution. #installments = 0 (or not set) in CiviCRM Core means open ended commitment;
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($contributionParams, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval)) {
+    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval)) {
+      if ($isThereMembershipToBeAutoRenewed) {
+        $contributionParams['auto_renew'] = 1;
+      }
+
       $result = $this->contributionRecur($contributionParams);
     }
     else {
@@ -1860,7 +1869,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'financial_type_id' =>  $contributionParams['financial_type_id'],
     );
 
-    if ($paymentType === 'deferred' && !empty($contributionParams['auto_renew'])) {
+    if (!empty($contributionParams['auto_renew'])) {
       $contributionRecurParams['auto_renew'] = 1;
     }
 
@@ -1938,7 +1947,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
     $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
-    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval)) {
       if ($isThereMembershipToBeAutoRenewed) {
         $params['auto_renew'] = 1;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Adding support to allow users to autrenew their memberships when they pay using any offline payment method.


Note that this PR replaces part of what this PR does : https://github.com/colemanw/webform_civicrm/pull/181
in order to make changes as little as possible in each PR.


Before
----------------------------------------
"Webform civicrm" have a limited support for autorenew which require you  :

1-  frequency unit field to be set.
2- frequency interval field to be set.
3- Number of installments > 1

If the 3 conditions above are met and there is a membership configured on the webform then the module will assume by default that it is an autorenew membership which is not necessarily the case.
 for example you might need to pay for certain membership in monthly installments but at the same time you don't it to be autorenewed. or maybe the user want to autorenew the membership but in one installment at each renewal.


After
----------------------------------------
A new field that allow you or the user to select if the membership to be autorenewed or not, To configure a membership to be an autorenew you will have to : 

1- Have this field selected and set to Yes.
2- A frequency interval and unit fields to be set.
3- the membership is paid using an offline payment processor (either  "manual payment" or any payment processor that implements "Payment_Manual" core class).

if the conditions above are met then the membership will be autorenewed.


Hence again; This PR add support for for offline payment processors which are  as described above  (either  "manual payment" or any payment processor that implements "Payment_Manual" core class), I avoided adding support to Live payment processors to make the PR simpler for review but if all agree I will add support for Live processors in another PR.


Technical Details
----------------------------------------

1- The first commit https://github.com/colemanw/webform_civicrm/commit/d80bce9ca7084e0ea808240f117600ea7f8f536b in this PR add the UI on the admin panel to allow admins to show or hide the "autorenew" field

2- The 2nd commit implements the logic bedhinde the autorenew, it is the minimal code needed to make this work, here is some explanation to the changes I have done : 


- This part : 

```
      if (isset($this->ent['contribution_recur'][1]['id']) && !empty($params['auto_renew'])) {
        $contributionRecurId = $this->ent['contribution_recur'][1]['id'];
        $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
          'return' => 'auto_renew',
          'sequential' => 1,
          'id' => $contributionRecurId,
        ]);
        if (!empty($contributionRecur['values'][0]['auto_renew'])) {
          $params['contribution_recur_id'] = $contributionRecurId;
        }
        unset($params['auto_renew']);
      }
```

replaces the old code to allow only memberships configured to be autorenewed to get actually autornewed and not any membership with a recur contribution configured.

- This part : 
```
    if ($paymentType === 'deferred' && !empty($contributionParams['auto_renew'])) {
      $contributionRecurParams['auto_renew'] = 1;
    }
````

Ensure that only manual payment processors payments set the auto_renew field on the recurring contribution.


- This part : 

```
    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval) && $this->contributionIsPayLater) {
      if ($isThereMembershipToBeAutoRenewed) {
        $params['auto_renew'] = 1;
      }

  private function isThereMembershipToBeAutoRenewed() {
    $autoRenewMembership = FALSE;
    foreach ($this->data['membership'] as $contactMemberships) {
      foreach($contactMemberships['membership'] as $membership) {
        if (!empty($membership['auto_renew'])) {
          $autoRenewMembership = TRUE;
        }
      }
    }
    return $autoRenewMembership;
  }
```

Set the "auto_renew" on the recur contribution if there is any membership configured to be autorenewed.


