### PR TITLE
Improving autorenewal user experince

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -75,6 +75,9 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table == 'membership' && $name == 'auto_renew') {
+      $ret = array(1 => t('Yes'), 0 => t('No'));
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = array('field' => $name, 'context' => 'create');
@@ -1231,6 +1234,12 @@ function wf_crm_get_fields($var = 'fields') {
       $fields['membership_end_date'] = array(
         'name' => t('End Date'),
         'type' => 'date',
+      );
+      $fields['membership_auto_renew'] = array(
+        'name' => t('Auto-renew Membership?'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
       );
     }
     // Add campaign fields

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -766,7 +766,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
     }
-    
+
     foreach (wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
         $existing = array();
@@ -1198,8 +1198,20 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       // The api won't let us manually set status without this weird param
       $params['skipStatusCal'] = !empty($params['status_id']);
 
-      if (isset($this->ent['contribution_recur'][1]['id'])) {
-        $params['contribution_recur_id'] = $this->ent['contribution_recur'][1]['id'];
+      if (isset($this->ent['contribution_recur'][1]['id']) && !empty($params['auto_renew'])) {
+        $contributionRecurId = $this->ent['contribution_recur'][1]['id'];
+
+        $contributionRecur = civicrm_api3('ContributionRecur', 'get', [
+          'return' => 'auto_renew',
+          'sequential' => 1,
+          'id' => $contributionRecurId,
+        ]);
+
+        if (!empty($contributionRecur['values'][0]['auto_renew'])) {
+          $params['contribution_recur_id'] = $contributionRecurId;
+        }
+
+        unset($params['auto_renew']);
       }
 
       $result = wf_civicrm_api('membership', 'create', $params);
@@ -1848,6 +1860,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       'financial_type_id' =>  $contributionParams['financial_type_id'],
     );
 
+    if ($paymentType === 'deferred' && !empty($contributionParams['auto_renew'])) {
+      $contributionRecurParams['auto_renew'] = 1;
+    }
+
     if(empty($contributionParams['payment_processor_id'])) {
       $contributionRecurParams['payment_processor_id'] = 'null';
     }
@@ -1921,7 +1937,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
     $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
-    if ($numInstallments != 1 && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+    $isThereMembershipToBeAutoRenewed = $this->isThereMembershipToBeAutoRenewed();
+    if (($numInstallments != 1 || $isThereMembershipToBeAutoRenewed) && !empty($frequencyInterval) && $this->contributionIsPayLater) {
+      if ($isThereMembershipToBeAutoRenewed) {
+        $params['auto_renew'] = 1;
+      }
+
       $result = $this->contributionRecur($params, 'deferred');
     }
     else {
@@ -1929,6 +1950,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     $this->ent['contribution'][1]['id'] = $result['id'];
+  }
+
+  /**
+   * Determines if the webform is configured to have
+   * any membership to be autorenwed or not.
+   */
+  private function isThereMembershipToBeAutoRenewed() {
+    $autoRenewMembership = FALSE;
+    foreach ($this->data['membership'] as $contactMemberships) {
+      foreach($contactMemberships['membership'] as $membership) {
+        if (!empty($membership['auto_renew'])) {
+          $autoRenewMembership = TRUE;
+        }
+      }
+    }
+    return $autoRenewMembership;
   }
 
   /**

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -513,6 +513,29 @@ var wfCiviAdmin = (function ($, D) {
         }
       }).change();
 
+      var autorenewMembershipsTracker = {};
+      var $membershipPageSelect = $('.form-item-membership-1-number-of-membership');
+      $('select[name$=_membership_auto_renew]').change(function(e, type) {
+        var fieldName = $(this).attr('name');
+        autorenewMembershipsTracker[fieldName] = $(this).val();
+
+        autorenew_counter = 0;
+        for(var key in autorenewMembershipsTracker){
+          if (autorenewMembershipsTracker[key] != 0) {
+            autorenew_counter++;
+          }
+        }
+
+        if (autorenew_counter > 1) {
+          if (!$('.wf-crm-membership-autorenew-alert').length) {
+            var msg = Drupal.t("Ensure that the memberships selected to be Auto-Renewed have the same frequency unit and interval or otherwise it might not work well !");
+            $membershipPageSelect.after('<div class="messages error wf-crm-membership-autorenew-alert">' + msg + '</div>');
+          }
+        } else {
+          $('.wf-crm-membership-autorenew-alert').remove();
+        }
+      });
+
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
         // Warning about contribution page with no email


### PR DESCRIPTION
Overview
----------------------------------------
Adding a warning when the admin try to configure a webform with more than one membership with autorenew support, telling the user that both frequency interval and unit of the membership types should be the same in order for the autorenewal to work well.

Before
----------------------------------------
Admins can configure two memberships to autorenew but where each membership type has different frequency interval and unit. 

After
----------------------------------------
Admins can still do the above but a warning will appear warning for the admin : 

![after](https://user-images.githubusercontent.com/6275540/66565139-a71fb300-eb59-11e9-88fa-ef9467a45a36.gif)


Notes
-----------
The only relevant commit in this PR is this one : 

https://github.com/colemanw/webform_civicrm/pull/275/commits/0ec4f9b19e27cf11410cea86b7221b38b961969a

the other two appear here because I created this branch from this PR branch : https://github.com/colemanw/webform_civicrm/pull/274