### PR TITLE
Fix relationship if multiple contact elements are included in the form

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -267,7 +267,7 @@ function _webform_edit_civicrm_contact($component) {
       '#options' => array('' => '- ' . t('None') . ' -'),
       '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:contact'),
     );
-    $form['filters']['relationship']['type'] = array(
+    $form['filters']['relationship']['types'] = array(
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => t('Specify Relationship(s)'),
@@ -281,7 +281,7 @@ function _webform_edit_civicrm_contact($component) {
       $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
       foreach ($rtypes as $k => $v) {
         $all_relationship_types[$i][] = array('key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain'));
-        $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['type']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
+        $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['types']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
       }
       if (!$rtypes) {
         $all_relationship_types[$i][] = array('key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']])) . ' -');
@@ -541,7 +541,7 @@ function wf_crm_contact_search($node, $component, $params, $contacts, $str = NUL
     $c = $params['relationship']['contact'];
     $relations = NULL;
     if (!empty($contacts[$c]['id'])) {
-      $relations = wf_crm_find_relations($contacts[$c]['id'], wf_crm_aval($params['relationship'], 'type'));
+      $relations = wf_crm_find_relations($contacts[$c]['id'], wf_crm_aval($params['relationship'], 'types'));
       $params['id'] = array('IN' => $relations);
     }
     if (!$relations) {

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -59,6 +59,7 @@ class CivicrmContact extends WebformElementBase {
         'private' => FALSE,
         'default' => '',
         'default_contact_id' => '',
+        'default_relationship_to' => '',
         'default_relationship' => '',
         'allow_url_autofill' => TRUE,
         'dupes_allowed' => FALSE,
@@ -284,6 +285,10 @@ class CivicrmContact extends WebformElementBase {
     }
     elseif ($c > 1) {
       $form['defaults']['default']['#options']['relationship'] = $this->t('Relationship to :contact', [':contact' => wf_crm_contact_label(1, $data)]);
+      $form['defaults']['default_relationship_to'] = [
+        '#type' => 'select',
+        '#default_value' => $element_properties['default_relationship_to'],
+      ];
       $form['defaults']['default_relationship'] = [
         '#type' => 'select',
         '#multiple' => TRUE,

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -147,7 +147,8 @@ class CivicrmContact extends WebformElementBase {
     $form = parent::form($form, $form_state);
     $form['element']['value']['#access'] = FALSE;
     $form['element']['multiple']['#access'] = FALSE;
-
+    $webform = $form_state->getFormObject()->getWebform();
+    $data = $webform->getHandler('webform_civicrm')->getConfiguration()['settings']['data'];
 
     \Drupal::getContainer()->get('civicrm')->initialize();
     $element_properties = $form_state->get('element_properties');
@@ -304,14 +305,13 @@ class CivicrmContact extends WebformElementBase {
       ],
     ];
     $cid = $element_properties['default_contact_id'];
-    if ($cid && $name = wf_crm_contact_access($element_properties,
-        ['check_permissions' => 1], $cid)) {
-          $form['defaults']['default_contact_id']['#default_value'] = $cid;
-          $form['defaults']['default_contact_id']['#attributes'] = [
-            'data-civicrm-name' => $name,
-            'data-civicrm-id' => $cid,
-          ];
-        }
+    if ($cid && $name = wf_crm_contact_access($element_properties, ['check_permissions' => 1], $cid)) {
+      $form['defaults']['default_contact_id']['#default_value'] = $cid;
+      $form['defaults']['default_contact_id']['#attributes'] = [
+        'data-civicrm-name' => $name,
+        'data-civicrm-id' => $cid,
+      ];
+    }
     $form['defaults']['allow_url_autofill'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Use contact id from URL'),
@@ -375,28 +375,26 @@ class CivicrmContact extends WebformElementBase {
         '#options' => ['' => '- ' . $this->t('None') . ' -'],
         '#default_value' => wf_crm_aval($element_properties['filters'], 'relationship:contact'),
       ];
-      $form['filters']['relationship']['type'] = [
+      $form['filters']['relationship']['types'] = [
         '#type' => 'select',
         '#multiple' => TRUE,
         '#title' => $this->t('Specify Relationship(s)'),
         '#options' => ['' => '- ' . $this->t('Any relation') . ' -'],
-        '#default_value' => wf_crm_aval($element_properties['filters'], 'relationship:type'),
+        '#default_value' => wf_crm_aval($element_properties['filters'], 'relationship:types'),
       ];
       // Fill relationship data for defaults and filters
-      /*
       $all_relationship_types = array_fill(1, $c - 1, array());
       for ($i = 1; $i < $c; ++$i) {
         $form['defaults']['default_relationship_to']['#options'][$i] = $form['filters']['relationship']['contact']['#options'][$i] = wf_crm_contact_label($i, $data, 'plain');
         $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
         foreach ($rtypes as $k => $v) {
           $all_relationship_types[$i][] = ['key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain')];
-          $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['type']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
+          $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['types']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
         }
         if (!$rtypes) {
           $all_relationship_types[$i][] = ['key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', ['@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']]]) . ' -'];
         }
       }
-      */
       $form['#attributes']['data-reltypes'] = json_encode($all_relationship_types);
     }
     $form['filters']['check_permissions'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
Fix relationship if multiple contact elements are included in the form

Before
----------------------------------------
- Multiple contact elements do not work on d8 webforms. I've added 2 contact existing field on the below webform, but only first contact element is loaded.

![image](https://user-images.githubusercontent.com/5929648/67502577-b3e8ee80-f6a3-11e9-8b06-656ec82600bf.png)

- Relationships are not populated in the edit element form.

![image](https://user-images.githubusercontent.com/5929648/67502297-4c32a380-f6a3-11e9-9584-e50688b0b192.png)

- If second contact element form is edited and saved, it gets stored as "Generic Element"

![image](https://user-images.githubusercontent.com/5929648/67502457-83a15000-f6a3-11e9-92aa-abff27d6063d.png)


After
----------------------------------------
- Relationships are correctly displayed.

![image](https://user-images.githubusercontent.com/5929648/67502723-00342e80-f6a4-11e9-8f8f-fac0ff757660.png)

- All contact elements on the webform are loaded.

![image](https://user-images.githubusercontent.com/5929648/67502826-2c4faf80-f6a4-11e9-972d-f6c8774b7969.png)


Comments
----------------------------------------
@KarinG Sharing my inprogress work (in case you need). The remaining fix needed here is to populate the second contact element with the correct related cid.