### PR TITLE
Fix contact element filters on webforms

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -267,12 +267,12 @@ function _webform_edit_civicrm_contact($component) {
       '#options' => array('' => '- ' . t('None') . ' -'),
       '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:contact'),
     );
-    $form['filters']['relationship']['types'] = array(
+    $form['filters']['relationship']['filter_relationship_types'] = array(
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => t('Specify Relationship(s)'),
       '#options' => array('' => '- ' . t('Any relation') . ' -'),
-      '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:type'),
+      '#default_value' => wf_crm_aval($component['extra']['filters'], 'relationship:filter_relationship_types'),
     );
     // Fill relationship data for defaults and filters
     $all_relationship_types = array_fill(1, $c - 1, array());
@@ -281,7 +281,7 @@ function _webform_edit_civicrm_contact($component) {
       $rtypes = wf_crm_get_contact_relationship_types($contact_type, $data['contact'][$i]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$i]['contact'][1]['contact_sub_type']);
       foreach ($rtypes as $k => $v) {
         $all_relationship_types[$i][] = array('key' => $k, 'value' => $v . ' ' . wf_crm_contact_label($i, $data, 'plain'));
-        $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['types']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
+        $form['defaults']['default_relationship']['#options'][$k] = $form['filters']['relationship']['filter_relationship_types']['#options'][$k] = $v . ' ' . wf_crm_contact_label($i, $data, 'plain');
       }
       if (!$rtypes) {
         $all_relationship_types[$i][] = array('key' => '', 'value' => '- ' . t('No relationship types defined for @a to @b', array('@a' => $contact_types[$contact_type], '@b' => $contact_types[$data['contact'][$i]['contact'][1]['contact_type']])) . ' -');
@@ -814,17 +814,28 @@ function wf_crm_search_filters($node, array $component) {
   $element_manager = \Drupal::service('plugin.manager.webform.element');
   $contact_element = $element_manager->getElementInstance($component);
   $params = ['is_deleted' => 0];
-  $params['contact_type'] = $contact_element->getElementProperty($component, 'contact_type');
-  $filters = $contact_element->getElementProperty($component, 'filters');
-  foreach ($filters as $key => $val) {
-    if (is_array($val)) {
-      $val = array_filter($val);
-    }
-    if (!empty($val)) {
-      if ($key === 'tag' || $key === 'group') {
-        $val = array_fill_keys($val, 1);
+  $contactFilters = [
+    'contact_type',
+    'contact_sub_type',
+    'tag',
+    'group',
+    'relationship' => [
+      'contact',
+      'types',
+    ],
+  ];
+  foreach ($contactFilters as $key => $filter) {
+    //Add Relationship filter
+    if ($key === 'relationship') {
+      foreach ($filter as $val) {
+        $filterVal = $contact_element->getElementProperty($component, "filter_relationship_{$val}");
+        if ($filterVal) {
+          $params['relationship'][$val] = $filterVal;
+        }
       }
-      $params[$key] = $val;
+    }
+    else {
+      $params[$filter] = $contact_element->getElementProperty($component, $filter);
     }
   }
   return $params;

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -216,7 +216,7 @@ function wf_crm_get_contact_types() {
         $contact_types[strtolower($type['name'])] = $type['label'];
         continue;
       }
-      $sub_types[strtolower($data[$type['parent_id']]['name'])][$type['name']] = $type['label'];
+      $sub_types[strtolower($data[$type['parent_id']]['name'])][strtolower($type['name'])] = $type['label'];
     }
   }
   return array($contact_types, $sub_types);

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -267,7 +267,7 @@ abstract class wf_crm_webform_base {
         case 'relationship':
           $to = $component['#default_relationship_to'];
           if (!empty($component['#default_relationship']) && !empty($this->ent['contact'][$to]['id'])) {
-            $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['default_relationship']);
+            $found = wf_crm_find_relations($this->ent['contact'][$to]['id'], $component['#default_relationship']);
           }
           break;
         case 'auto':

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -28,7 +28,66 @@
             []
           );
         });
-      })
+      });
+
+
+      function changeDefault() {
+        var val = $(this).val().replace(/_/g, '-');
+
+        $('[data-drupal-selector=edit-defaults] > div > .form-item', context).not('.form-item-properties-default, .form-item-properties-allow-url-autofill').each(function() {
+          if (val.length && $(this).is('[class*=form-item-properties-default-'+val+']')) {
+            $(this).removeAttr('style');
+          }
+          else {
+            $(this).css('display', 'none');
+            $(':checkbox', this).prop('disabled', true);
+          }
+        });
+        if (val === 'auto' || val === 'relationship') {
+          $('.form-item-properties-randomize, .form-item-properties-dupes-allowed')
+            .removeAttr('style')
+            .find(':checkbox')
+            .removeAttr('disabled');
+        }
+        $('[data-drupal-selector=edit-properties-default-relationship-to]', context).each(changeDefaultRelationTo);
+      }
+
+      function changeDefaultRelationTo() {
+        var c = $(this).val(),
+        types = $('[data-drupal-selector=edit-properties-filter-relationship-types]').data('reltypes')[c],
+        placeholder = types.length ? false : '- ' + Drupal.ts('No relationship types available for these contact types') + ' -';
+
+        CRM.utils.setOptions('[data-drupal-selector=edit-properties-default-relationship]', types, placeholder);
+        // Provide default to circumvent "required" validation error
+        if ($('[data-drupal-selector=edit-properties-default]').val() !== 'relationship' && !types.length && types[0].key === '') {
+          CRM.utils.setOptions('[data-drupal-selector=edit-properties-default-relationship]', {key: '-', value: '-'});
+          $('[data-drupal-selector=edit-properties-default-relationship]').val('-');
+        }
+      }
+
+      function changeFiltersRelationTo() {
+        var c = $(this).val(),
+        types = $('[data-drupal-selector=edit-properties-filter-relationship-types]').data('reltypes')[c];
+        $('.form-item-properties-filter-relationship-types', context).toggle(!!c);
+        if (c) {
+          CRM.utils.setOptions('[data-drupal-selector=edit-properties-filter-relationship-types]', types);
+        }
+      }
+
+      $('[data-drupal-selector=edit-properties-default]', context).change(changeDefault).each(changeDefault);
+      $('[data-drupal-selector=edit-properties-default-relationship-to]', context).change(changeDefaultRelationTo);
+      $('[data-drupal-selector=edit-properties-filter-relationship-contact]', context).change(changeFiltersRelationTo).each(changeFiltersRelationTo);
+      $('[data-drupal-selector=edit-properties-widget]', context).change(function() {
+        if ($(this).val() == 'hidden') {
+          $('.form-item-properties-search-prompt', context).css('display', 'none');
+          $('.form-item-properties-show-hidden-contact', context).removeAttr('style');
+        }
+        else {
+          $('.form-item-properties-search-prompt', context).removeAttr('style');
+          $('.form-item-properties-show-hidden-contact', context).css('display', 'none');
+        }
+      }).change();
+
     }
   }
 })(jQuery, Drupal, drupalSettings)

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -126,7 +126,7 @@ var wfCivi = (function ($, D, drupalSettings) {
   var stateProvinceCache = {};
 
   function getFormClass(webformId) {
-    return '.webform-submission-' + webformId.replace('_', '-') + '-form'
+    return '.webform-submission-' + webformId.replace(/_/g, '-') + '-form'
   }
 
   function resetFields(num, nid, clear, op, toHide, hideOrDisable, showEmpty, speed, defaults) {

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -354,7 +354,7 @@ var wfCivi = (function ($, D, drupalSettings) {
   function getCids(nid) {
     var formClass = getFormClass(nid);
     var cids = $(formClass).data('civicrm-ids') || {};
-    $(formClass + ' .civicrm-enabled:input[name$="_contact_1_contact_existing]"]').each(function() {
+    $(formClass + ' .civicrm-enabled:input[name$="_contact_1_contact_existing"]').each(function() {
       var cid = $(this).val();
       if (cid) {
         var n = parseName($(this).attr('name')).split('_');

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -64,6 +64,12 @@ function webform_civicrm_menu() {
  * Implements hook_form_alter().
  */
 function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'webform_edit_form' && !empty($form['webform_ui_elements'])
+    && !empty((int) preg_grep('/^civicrm_/', array_keys($form['webform_ui_elements'])))) {
+    \Drupal::service('civicrm')->initialize();
+    \CRM_Core_Resources::singleton()->addCoreResources();
+  }
+
   /*
   // Alter back-end webform component edit forms
   if ($form_id == 'webform_component_edit_form') {

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -64,8 +64,7 @@ function webform_civicrm_menu() {
  * Implements hook_form_alter().
  */
 function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id == 'webform_edit_form' && !empty($form['webform_ui_elements'])
-    && !empty((int) preg_grep('/^civicrm_/', array_keys($form['webform_ui_elements'])))) {
+  if ($form_id == 'webform_edit_form' && $form_state->getFormObject()->getEntity()->getHandlers()->has('webform_civicrm')) {
     \Drupal::service('civicrm')->initialize();
     \CRM_Core_Resources::singleton()->addCoreResources();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix contact element filters on webforms.

Before
----------------------------------------
- Filter section missing.
- Default option breaks for multiple contacts.

<img width="843" alt="Screenshot 2019-11-03 at 11 08 47 AM" src="https://user-images.githubusercontent.com/5929648/68081054-921f0280-fe2d-11e9-9e40-83daff18935f.png">


After
----------------------------------------
- Filter section added and working on the webform

![image](https://user-images.githubusercontent.com/5929648/68081069-e4f8ba00-fe2d-11e9-9ef2-8d474f969495.png)

- Contact subtype, relationship, groups & tag filters work correctly on the webform.

![image](https://user-images.githubusercontent.com/5929648/68081092-43be3380-fe2e-11e9-98a4-f7b769330189.png)


Comments
----------------------------------------
ping @KarinG 
