### PR TITLE
Flatten elements now that Contribution config injects nested elements & Make recurring Contributions work in D8WFC

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1738,7 +1738,7 @@ class wf_crm_admin_form {
             }
           }
           elseif ($field['type'] === 'hidden' && !empty($field['expose_list'])) {
-            $elements = $this->webform->getElementsDecoded();
+            $elements = $this->webform->getElementsDecodedAndFlattened();
             $component = $elements[$enabled[$key]];
             $component = WebformArrayHelper::removePrefix($component);
             $component['value'] = $val;

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -659,21 +659,17 @@ class Fields implements FieldsInterface {
         $fields['contribution_installments'] = array(
           'name' => t('Number of Installments'),
           'type' => 'number',
-          'value' => '1',
-          'extra' => array(
-            'integer' => 1,
-            'min' => 0,
-          ),
+          'default_value' => '1',
+          'min' => '0',
+          'step' => '1',
           'set' => 'contributionRecur',
         );
         $fields['contribution_frequency_interval'] = array(
           'name' => t('Interval of Installments'),
           'type' => 'number',
-          'value' => '1',
-          'extra' => array(
-            'integer' => 1,
-            'min' => 1,
-          ),
+          'default_value' => '1',
+          'min' => '0',
+          'step' => '1',
           'set' => 'contributionRecur',
         );
       }


### PR DESCRIPTION
Before
----------------------------------------
To reproduce: Settings -> CiviCRM: Enable CiviCRM Processing; add Contact: First Name, Last Name + Email; add Contribution: select Contribution Page; Contribution Amount and Payment processor. Save Settings. All is well - Elements are created:

![image](https://user-images.githubusercontent.com/5340555/69908003-f0dc8b00-139d-11ea-97af-ad4403579451.png)

Go back to Settings -> CiviCRM -> and hit Save Settings

This produces a Fatal error -> as `civicrm_1_contribution_1_contribution_contribution_page_id` is a nested Element. 

Error: `TypeError: Argument 1 passed to Drupal\webform\Utility\WebformArrayHelper::removePrefix() must be of the type array, null given, called in /Applications/MAMP/htdocs/drupal853.local/modules/webform_civicrm/includes/wf_crm_admin_form.inc on line 1743`

After
----------------------------------------
No error. 

Technical Details
----------------------------------------
use `$elements = $this->webform->getElementsDecodedAndFlattened();`
instead of: `$elements = $this->webform->getElementsDecoded();`

Also
----------------------------------------
Fixed default value for instalments and frequency of recurring contributions fields. 