### PR TITLE
Changing Decimal numbers calculation to be more accurate

### DIFF
--- a/includes/wf_crm_money_operations.inc
+++ b/includes/wf_crm_money_operations.inc
@@ -1,0 +1,44 @@
+<?php
+
+class wf_crm_money_operations {
+
+  /**
+   * The digits after decimal precision we are
+   * using, it is big enough to make sure
+   * rounding will work fine.
+   */
+  const CALCULATION_PRECISION_SCALE = 8;
+
+  /**
+   * CiviCRM stores all financial amounts
+   * inside database as decimal(10,2), which
+   * means only two digits are allowed after
+   * the decimal and thus we are choosing the
+   * same number for rounding the final amount.
+   */
+  const ROUNDING_DECIMAL_SCALE = 2;
+
+  public static function add($leftOperand, $rightOperand) {
+    $result = bcadd($leftOperand, $rightOperand, self::CALCULATION_PRECISION_SCALE);
+    return self::round($result);
+  }
+
+  public static function subtract($leftOperand, $rightOperand) {
+    $result = bcsub($leftOperand, $rightOperand, self::CALCULATION_PRECISION_SCALE);
+    return self::round($result);
+  }
+
+  public static function multiply($leftOperand, $rightOperand) {
+    $result = bcmul($leftOperand, $rightOperand, self::CALCULATION_PRECISION_SCALE);
+    return self::round($result);
+  }
+
+  public static function divide($leftOperand, $rightOperand) {
+    $result = bcdiv($leftOperand, $rightOperand, self::CALCULATION_PRECISION_SCALE);
+    return self::round($result);
+  }
+
+  public static function round($amount) {
+    return round($amount, self::ROUNDING_DECIMAL_SCALE, PHP_ROUND_HALF_UP);
+  }
+}

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -6,6 +6,7 @@
  */
 
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
+module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_money_operations');
 
 /**
  * Class wf_crm_webform_base

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1627,16 +1627,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
 
       if (!is_null($itemTaxRate)) {
-        $item['line_total'] = $item['unit_price'] * (int) $item['qty'];
-        $item['tax_amount'] = ($itemTaxRate / 100) * $item['line_total'];
-        $this->totalContribution += ($item['unit_price'] * (int) $item['qty']) + $item['tax_amount'];
+        $item['line_total'] = wf_crm_money_operations::multiply($item['unit_price'], (int) $item['qty']);
+        $item['tax_amount'] = wf_crm_money_operations::multiply(($itemTaxRate / 100), $item['line_total']);
+
+        $lineItemTotalAmount = wf_crm_money_operations::add($item['line_total'], $item['tax_amount']);
+        $this->totalContribution = wf_crm_money_operations::add($this->totalContribution, $lineItemTotalAmount);
       }
       else {
-        $item['line_total'] = $item['unit_price'] * (int) $item['qty'];
-        $this->totalContribution += $item['line_total'];
+        $item['line_total'] = wf_crm_money_operations::multiply($item['unit_price'], (int) $item['qty']);
+        $this->totalContribution = wf_crm_money_operations::add($this->totalContribution, $item['line_total']);
       }
     }
-    return round($this->totalContribution, 2);
+    return wf_crm_money_operations::round($this->totalContribution);
   }
 
   /**
@@ -1820,19 +1822,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
     // if ($installments === 0) or $installments is not defined we treat as an open-ended recur
     $contributionFirstAmount = $contributionRecurAmount = $contributionParams['total_amount'];
-    $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);;
+    $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);
     if ($numInstallments > 0) {
-      // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $numInstallments) * 100) / 100;
-      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($numInstallments - 1);
-      $salesTaxFirstAmount = $salesTaxFirstAmount - floor(($salesTaxFirstAmount / $numInstallments) * 100) / 100 * ($numInstallments - 1);
+      $contributionRecurAmount = wf_crm_money_operations::divide($contributionParams['total_amount'], $numInstallments);
+      $contributionFirstAmount = $contributionRecurAmount;
+      $salesTaxFirstAmount = wf_crm_money_operations::divide($salesTaxFirstAmount, $numInstallments);
 
       // Calculate the line_items for the first contribution:
       // At this point line_items are set to the full (non-installment) amounts.
       foreach ($this->line_items as $key => $k) {
-        $this->line_items[$key]['unit_price'] = $k['unit_price'] / $numInstallments;
-        $this->line_items[$key]['line_total'] = $k['line_total'] / $numInstallments;
-        $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $numInstallments;
+        $this->line_items[$key]['unit_price'] = wf_crm_money_operations::divide($k['unit_price'], $numInstallments);
+        $this->line_items[$key]['line_total'] = wf_crm_money_operations::divide($k['line_total'], $numInstallments);
+
+        if (!empty($k['tax_amount'])) {
+          $this->line_items[$key]['tax_amount'] = wf_crm_money_operations::divide($k['tax_amount'], $numInstallments);
+        }
       }
     }
 
@@ -2032,7 +2036,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
     $params['skipRecentView'] = $params['skipLineItem'] = 1;
     $params['contact_id'] = $this->ent['contact'][1]['id'];
-    $params['total_amount'] = round($this->totalContribution, 2);
+    $params['total_amount'] = wf_crm_money_operations::round($this->totalContribution);
 
     // Most payment processors expect this (normally be set by contribution page processConfirm)
     $params['contactID'] = $params['contact_id'];
@@ -2047,10 +2051,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if (isset($this->form_state['civicrm']['line_items'])) {
       foreach ($this->form_state['civicrm']['line_items'] as $lineItem) {
         if (!empty($lineItem['tax_amount'])) {
-          $params['tax_amount'] += $lineItem['tax_amount'];
+          $params['tax_amount'] = wf_crm_money_operations::add($params['tax_amount'], $lineItem['tax_amount']);
         }
       }
-      $params['tax_amount'] = round($params['tax_amount'], 2);
+      $params['tax_amount'] = wf_crm_money_operations::round($params['tax_amount']);
     }
     $params['description'] = t('Webform Payment: @title', array('@title' => $this->node->title));
     if (!isset($params['source'])) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -560,7 +560,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
 
     $taxRates = CRM_Core_PseudoConstant::getTaxRates();
     foreach ($this->line_items as $item) {
-      $total += $item['line_total'];
+      $total = wf_crm_money_operations::add($total, $item['line_total']);
       // Sales Tax integration
       if (!empty($item['financial_type_id'])) {
         $itemTaxRate = isset($taxRates[$item['financial_type_id']]) ? $taxRates[$item['financial_type_id']] : NULL;
@@ -578,11 +578,12 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         }
 
         // Add calculation for financial type that contains tax
-        $item['tax_amount'] = ($itemTaxRate / 100) * $item['line_total'];
-        $total += $item['tax_amount'];
+        $item['tax_amount'] = wf_crm_money_operations::multiply(($itemTaxRate / 100), $item['line_total']);
+        $total = wf_crm_money_operations::add($total, $item['tax_amount']);
         $label = $item['label'] . ($item['qty'] > 1 ? " ({$item['qty']})" : '');
+        $lineTotalWithTax = wf_crm_money_operations::add($item['line_total'], $item['tax_amount']);
         $rows[] = array(
-          'data' => array($label, CRM_Utils_Money::format($item['line_total'] + $item['tax_amount'])),
+          'data' => array($label, CRM_Utils_Money::format($lineTotalWithTax)),
           'class' => array($item['element'], 'line-item'),
           'data-amount' => $item['line_total'] + $item['tax_amount'],
           'data-tax' => (float)$itemTaxRate,


### PR DESCRIPTION
Note 

**Hence that the work below is not tested by our QA team yet and I am opening this PR  as a try to get some concept approval first before proceeding**


Before
----------------------------------------
1- Create a membership type with fee = 55.68
2- Configure a webform with 12 installments and the membership defined above
3- Submit the webform
4- A contribution will be created with the amount = 4.75 and a recur contribution will be created with amount = 4.63 . both are wrong since : 

55.68/12 = 4.64

which should be the amount of the both the created contribution and the recur contribution.

![2019-12-10 01_12_27-ads2@ad com ads2@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/70481230-a0c29e80-1aea-11ea-885d-7a76a2996b5a.png)

![2019-12-10 01_12_35-ads2@ad com ads2@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/70481234-a3bd8f00-1aea-11ea-8218-d1c37da2d5c3.png)


The issue above is caused by the following lines : 

```
 $contributionRecurAmount = floor(($contributionParams['total_amount'] / $numInstallments) * 100) / 100;
$contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($numInstallments - 1);
```

The first line result is : 

$contributionRecurAmount = floor((55.68/ 12) * 100) / 100 = 4.63 

and the 2nd line : 
$contributionFirstAmount = 55.68 - 4.63  * (12-1) =  55.68 - 50.93 = 4.75

The main issue is caused by the wrong 4.63 which should have been 4.47, but since floating point numbers are used and floating points operations are not accurate  in general, 4.63 resulted instead.

CiviCRM core has many issues in general when it come to money calculation, one of them that it is  stores all money in database as decimal(10, 2) which make it hard to get correct results in some cases specially when dealing with payment plans with more than one installment, but at least accurate method of calculation should still be performed on money in case the core get changed in the future, and floating point arithmetic is  not accurate by design and should never be used when doing money calculations.

After
----------------------------------------
There are many options to resolve the floating point arithmetic issues, I decided to abstract the work inside a new class called **wf_crm_money_operations**  which contains methods for money addition, subtraction, division and multiplying. 

Technically this new class use bcmath PHP extension to do these operations and I replaced all the money calculations inside the module to use the methods in this new class.


![2019-12-10 01_40_27-qwos02@ad com qwos02@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/70482422-19772a00-1aee-11ea-8504-85888efbde1e.png)

![2019-12-10 01_40_38-qwos02@ad com qwos02@ad com _ m7civi519](https://user-images.githubusercontent.com/6275540/70482431-1e3bde00-1aee-11ea-9462-25a294b3b05f.png)




