### PR TITLE
Autofill related contacts on same page

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -253,7 +253,7 @@ function _webform_edit_civicrm_contact($component) {
       '#parents' => array('extra', 'default_custom_ref'),
     );
   }
-  
+
   $case_count = isset($data['case']['number_of_case']) ? $data['case']['number_of_case'] : 0;
   if ($case_count > 0) {
     $form['defaults']['default']['#options']['case_roles'] = t('Case roles');
@@ -918,8 +918,8 @@ function wf_crm_find_relations($cid, $types = array(), $current = TRUE) {
     }
     $params = [
       'return' => ['contact_id_a', 'contact_id_b', 'relationship_type_id', 'end_date'],
-      'contact_id_a' => 'user_contact_id',
-      'contact_id_b' => 'user_contact_id',
+      'contact_id_a' => $cid,
+      'contact_id_b' => $cid,
       'options' => ['or' => [['contact_id_a', 'contact_id_b']]],
     ];
     if ($type_ids) {

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -134,7 +134,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
             }
           }
           // Populate related contacts
-          elseif ($c == 1 && $i > $c && $field == 'existing') {
+          elseif ($i > $c && $field == 'existing') {
             $related_component = $this->getComponent($fid);
             if (wf_crm_aval($related_component['extra'], 'default') == 'relationship') {
               $old_related_cid = wf_crm_aval($this->ent, "contact:$i:id");


### PR DESCRIPTION
Overview
----------------------------------------
I have a webform where 5 contacts are added with relations as below:
- Contact 2 (Organization) is an **Employer of** Contact 1 (individual)
- Contact 3 (Individual) is **Parent of** Contact 1 (Individual)
- Contact 5 (Organization) is an **Employer of** Contact 4 (Individual)

**How it works**

- Contact 2 gets auto-filled when Contact 1 is selected.
- Contact 3 is **not** auto filled with the parent of Contact 1.
- Contact 5 is **not** auto filled with employer of Contact 4. 

_The above scenarios work fine where there is a page break on the webform but not when on the same page._

**How it should work**

- Contact 2 gets auto-filled with the employer when Contact 1 is selected.
- Contact 3 gets auto-filled with the parent of Contact 1.
- Contact 5 is auto-filled with the employer of Contact 4.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/7393885/71258577-8a270d80-235c-11ea-8dcc-eb31d21f1263.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/7393885/71258600-9d39dd80-235c-11ea-92ef-15e0643eb753.gif)


Technical Details
----------------------------------------

1. Condition here: https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/includes/wf_crm_webform_ajax.inc#L137 only checks for $c == 1 which makes autofill work for only Contact Removing $c == 1 makes it work for all contact fields.
2. In function wf_crm_find_relations it was giving zero results if relationship type was anything other than employee/employer. It happened because the parameters were missing the contact id parameter. Used $cid to fetch relatioships for given contact id.
