### PR TITLE
Replace usage of `watchdog` in saveCustomValues

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -769,7 +769,10 @@ abstract class wf_crm_webform_base {
         $result = CRM_Core_BAO_CustomValueTable::setValues($single_param);
         if (!empty($result['is_error'])) {
           $file = explode('/', $bt[0]['file']);
-          watchdog('webform_civicrm', 'The CiviCRM "CustomValueTable::setValues" function returned the error: "%msg" when called by line !line of !file with the following parameters: "!params"', array('%msg' => $result['error_message'], '!line' => $bt[0]['line'], '!file' => array_pop($file), '!params' => print_r($single_param, TRUE)), WATCHDOG_ERROR);
+          \Drupal::logger('webform_civicrm')->error(
+            'The CiviCRM "CustomValueTable::setValues" function returned the error: "%msg" when called by line !line of !file with the following parameters: "!params"',
+            ['%msg' => $result['error_message'], '!line' => $bt[0]['line'], '!file' => array_pop($file), '!params' => print_r($single_param, TRUE)]
+          );
         }
       }
     }


### PR DESCRIPTION
If `CRM_Core_BAO_CustomValueTable` fails inserting values, Webform CiviCRM silently fails and reports the error. This was using `watchdog` and not properly using the logger.

Discovered while debugging https://www.drupal.org/project/webform_civicrm/issues/3099346