### PR TITLE
Prevent add element from failing

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -82,6 +82,7 @@ class CivicrmContact extends WebformElementBase {
    * @see _webform_render_civicrm_contact()
    */
   public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    \Drupal::service('civicrm')->initialize();
     // Webform removes values which equal their defaults but does not populate
     // they keys.
     $ensure_keys_have_values = [

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -133,6 +133,7 @@ class CivicrmOptions extends WebformElementBase {
    * {@inheritdoc}
    */
   public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    \Drupal::service('civicrm')->initialize();
     $as_list = !empty($element['#extra']['aslist']);
     $is_multiple = !empty($element['#extra']['multiple']);
     $use_live_options = !empty($element['#civicrm_live_options']);

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -49,6 +49,7 @@ class CivicrmSelect extends WebformElementBase {
    * {@inheritdoc}
    */
   public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    \Drupal::service('civicrm')->initialize();
     parent::prepare($element, $webform_submission);
     if (empty($element['#options'])) {
       $element['#options'] = $this->getFieldOptions($element);


### PR DESCRIPTION
Overview
----------------------------------------
A solution for>
https://www.drupal.org/project/webform_civicrm/issues/3104870

Before
----------------------------------------
For certain users civicrm would not be loaded properly and "add element"  would fail to load

After
----------------------------------------
Make sure that civicrm is loaded before trying to load civicrm elements
