### PR TITLE
Take field disabled status into account when considering if a contact can be created

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -73,7 +73,7 @@ function _webform_edit_civicrm_contact($component) {
   $enabled = wf_crm_enabled_fields($node);
   list(, $c, ) = explode('_', $component['form_key'], 3);
   $contact_type = $data['contact'][$c]['contact'][1]['contact_type'];
-  wf_crm_update_existing_component($component, $enabled, $data);
+  wf_crm_update_existing_component($component, $enabled, $data, $node);
   $allow_create = $component['extra']['allow_create'];
 
   // Load scripts & css
@@ -860,12 +860,13 @@ function wf_crm_contact_fields($node, $con) {
  *   Array of enabled fields
  * @param $data
  *   Array of crm entity data
+ * @param stdClass $node
  */
-function wf_crm_update_existing_component(&$component, $enabled, $data) {
+function wf_crm_update_existing_component(&$component, $enabled, $data, $node) {
   list(, $c, ) = explode('_', $component['form_key'], 3);
   if (!empty($data['contact'][$c])) {
     $contact_type = $data['contact'][$c]['contact'][1]['contact_type'];
-    $allow_create = wf_crm_name_field_exists($enabled, $c, $contact_type);
+    $allow_create = wf_crm_name_field_exists($enabled, $c, $contact_type, $node);
     if ($allow_create != $component['extra']['allow_create']) {
       $component['extra']['none_prompt'] = $allow_create ? t('+ Create new +') : t('- None Found -');
       $component['extra']['allow_create'] = $allow_create;

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1705,7 +1705,7 @@ function wf_crm_apivalues($entity, $operation, $params = array(), $value = NULL)
 }
 
 /**
- * Check if a name or email field exists for this contact.
+ * Check if a (non-disabled) name or email field exists for this contact.
  * This determines whether a new contact can be created on the webform.
  *
  * @param $enabled
@@ -1714,12 +1714,13 @@ function wf_crm_apivalues($entity, $operation, $params = array(), $value = NULL)
  *   Contact #
  * @param $contact_type
  *   Contact type
+ * @param stdClass $node
  * @return int
  */
-function wf_crm_name_field_exists($enabled, $c, $contact_type) {
+function wf_crm_name_field_exists($enabled, $c, $contact_type, $node) {
   foreach (wf_crm_required_contact_fields($contact_type) as $f) {
     $fid = 'civicrm_' . $c . '_contact_1_' . $f['table'] . '_' . $f['name'];
-    if (!empty($enabled[$fid])) {
+    if (!empty($enabled[$fid]) && empty($node->webform['components'][$enabled[$fid]]['extra']['disabled'])) {
       return 1;
     }
   }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1683,7 +1683,7 @@ class wf_crm_admin_form {
                   'form_key' => $key,
                   'weight' => $i,
                 );
-                self::insertComponent($field, $enabled, $this->settings, $this->isNewFieldset($key));
+                self::insertComponent($field, $enabled, $this->settings, $this->node, $this->isNewFieldset($key));
                 $created[] = $field['name'];
                 if (isset($field['civicrm_condition'])) {
                   $this->addConditionalRule($field, $enabled);
@@ -1737,7 +1737,7 @@ class wf_crm_admin_form {
       // Update existing contact fields
       foreach ($existing as $fid => $id) {
         if (substr($fid, -8) === 'existing') {
-          wf_crm_update_existing_component($this->node->webform['components'][$id], $enabled, $this->data);
+          wf_crm_update_existing_component($this->node->webform['components'][$id], $enabled, $this->data, $this->node);
         }
       }
     }
@@ -1842,9 +1842,10 @@ class wf_crm_admin_form {
    *   Array of enabled fields (reference)
    * @param $settings
    *   webform_civicrm configuration for this form
+   * @param stdClass $node
    * @param bool $create_fieldsets
    */
-  public static function insertComponent(&$field, &$enabled, $settings, $create_fieldsets = FALSE) {
+  public static function insertComponent(&$field, &$enabled, $settings, $node, $create_fieldsets = FALSE) {
     $options = NULL;
     list(, $c, $ent, $n, $table, $name) = explode('_', $field['form_key'], 6);
     $contact_type = wf_crm_aval($settings['data']['contact'], "$c:contact:1:contact_type");
@@ -1871,7 +1872,7 @@ class wf_crm_admin_form {
     if ($name == 'existing') {
       $vals = $enabled + $settings;
       // Set the allow_create flag based on presence of name or email fields
-      $field['extra']['allow_create'] = $a = wf_crm_name_field_exists($vals, $c, $contact_type);
+      $field['extra']['allow_create'] = $a = wf_crm_name_field_exists($vals, $c, $contact_type, $node);
       $field['extra']['none_prompt'] = $a ? t('+ Create new +') : t('- None Found -');
       if ($c == 1 && $contact_type == 'individual') {
         // Default to hidden field for 1st contact
@@ -2127,7 +2128,7 @@ class wf_crm_admin_form {
               $custom_types = wf_crm_custom_types_map_array();
               $new['type'] = $custom_types[$fieldConfigs['html_type']]['type'];
             }
-            wf_crm_admin_form::insertComponent($new, $enabled, $node->webform_civicrm);
+            wf_crm_admin_form::insertComponent($new, $enabled, $node->webform_civicrm, $node);
           }
         }
       }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -492,7 +492,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $this->existing_contacts[$c] = $this->crmValues[$fid];
         }
         // Or else see if enough info was entered to create a contact - use 0 as a placeholder for unknown cid
-        elseif (wf_crm_name_field_exists($this->crmValues, $c, $contact['contact'][1]['contact_type'])) {
+        elseif (wf_crm_name_field_exists($this->crmValues, $c, $contact['contact'][1]['contact_type'], $this->node)) {
           $this->existing_contacts[$c] = 0;
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
An "existing contact" field has an `allow_create` flag telling it whether a contact can be created. This considers whether the contact has a name/email field on the form. Now it also considers whether those fields are disabled.

Comments
----------------------------------------
This does not address an existing bug that the `allow_create` flag is not auto-updated when enabling/disabling/deleting a webform component from the webform ui. You must go to the civicrm tab and resave for changes to take effect :(