### PR TITLE
Nick name is not a required field.

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1739,7 +1739,6 @@ function wf_crm_required_contact_fields($contact_type) {
       array('table' => 'email', 'name' => 'email'),
       array('table' => 'contact', 'name' => 'first_name'),
       array('table' => 'contact', 'name' => 'last_name'),
-      array('table' => 'contact', 'name' => 'nick_name'),
     );
   }
   return array(array('table' => 'contact', 'name' => $contact_type . '_name'));


### PR DESCRIPTION
nick_name is not a required field when creating new contacts -> see CiviCRM core docs:

https://docs.civicrm.org/user/en/latest/common-workflows/importing-data-into-civicrm/

![image](https://user-images.githubusercontent.com/5340555/74104540-00e9b700-4b13-11ea-9154-e2aa7052c049.png)
