### PR TITLE
#3108512 Fix primary address when shared

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -816,6 +816,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
                 'id' => wf_crm_aval($existing, "$i:id"),
                 'mc' => $params['master_id'],
                 'loc' => $params['location_type_id'],
+                'pri' => $params['location_type_id'] == $is_primary_address_location_type,
               );
               continue;
             }
@@ -1251,7 +1252,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $params['master_id'] = $params['id'];
             $params['id'] = $addr['id'];
             $params['contact_id'] = $cid;
-            $params['is_primary'] = $i == 1;
+            $params['is_primary'] = $addr['pri'];
             wf_civicrm_api('address', 'create', $params);
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
This PR addresses the issue described by user maynardsmith in https://www.drupal.org/project/webform_civicrm/issues/3108512 and replaces the patch provided there.

To reproduce a simplified version (compared to the original issue description) of the issue:
- Create a webform with 2 contacts and a contribution
- Contact 1: address 1 (primary): home: shared from contact 2
- Contact 2: address 1 (primary): home:
- Basic contribution page using Test Processor

Before
----------------------------------------
Contact 1 has a billing address and home address is shared from Contact 2 - the Billing address is Primary.

After
----------------------------------------
Contact 1 has a billing address and home address is shared from Contact 2 - the Home address is Primary.

Comments
----------------------------------------
Note that if the first address is not shared, then it is created as primary.  This change means the behaviour of creating the first configured address as primary is consistent regardless of whether the address is shared.
