### PR TITLE
Fix custom group fieldsets to not get recreated after adding additional CiviCRM Core fields.

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1996,8 +1996,8 @@ class wf_crm_admin_form {
       $field['value'] = $settings[$field['form_key']];
     }
     // Create fieldsets for multivalued entities
-    if ($ent !== 'contribution' &&
-      ($ent !== 'participant' || wf_crm_aval($settings['data'], 'participant_reg_type') === 'separate')
+    if (empty($enabled[$field['form_key']]) && ($ent !== 'contribution' &&
+      ($ent !== 'participant' || wf_crm_aval($settings['data'], 'participant_reg_type') === 'separate'))
     ) {
        $fieldset_key = self::addFieldset($c, $field, $enabled, $settings, $ent, $create_fieldsets);
        $field['parent'] = $fieldset_key;


### PR DESCRIPTION
Overview
----------------------------------------
fix fieldsets which are recreated on the webform

Before
----------------------------------------
To reproduce -

- Add 1 contact + enable some custom fields on the webform.
- This creates a fieldset for the custom set too. Move the fields to main contact fieldset and delete the custom fieldset. Webform should look something like -

![image](https://user-images.githubusercontent.com/5929648/76830445-448abb80-684b-11ea-90e6-9df0e6a086a9.png)

- Now, add one more field from the civicrm setting page. Eg job title, nickname, etc. After saving the webform, the previous custom fieldset is recreated on the webform.

![image](https://user-images.githubusercontent.com/5929648/76830588-89aeed80-684b-11ea-933c-07d1f92e1d9e.png)

This is irritating when more no. of custom fieldsets are present on the webform and all of them are recreated after any field is added from the civicrm settings page. 

After
----------------------------------------
no fieldsets are added if custom field is already present on the page.

