### PR TITLE
Add a flag to identify that AJAX endpoint is being called by drupal webform

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -199,7 +199,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         'scope' => 'footer',
       );
       $currency = $this->contribution_page['currency'];
-      $contributionCallbackQuery = array('currency' => $currency, 'snippet' => 4);
+      $contributionCallbackQuery = array('currency' => $currency, 'snippet' => 4, 'is_drupal_webform' => 1);
       $contributionCallbackUrl = 'civicrm/payment/form';
       $js_vars['processor_id_key'] = 'processor_id';
       if (!empty($this->data['contribution'][1]['contribution'][1]['is_test'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Some payment processors need to do certain things differently (eg. Stripe) if they are being loaded via webform_civicrm. Currently you can't detect on the server side if the caller is a drupal webform or a civi form.
The payment block is loaded via the endpoint `civicrm/payment/form` which calls functions such as `buildForm()` on the `CRM_Core_Payment` class. This flag allows code there to detect that it is being called by a webform.

Before
----------------------------------------
Not able to identify drupal webform as caller

After
----------------------------------------
Extra flag that can be checked.

Technical Details
----------------------------------------


Comments
----------------------------------------
@colemanw @KarinG What's the deal with 8.x-5.x as this should apply to both?