### PR TITLE
Fix test payment processor ID on form submission when there are multiple processors available

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -45,6 +45,7 @@ abstract class wf_crm_webform_base {
   function __get($name) {
     switch ($name) {
       case 'payment_processor':
+        $this->fixPaymentProcessorID();
         $payment_processor_id = wf_crm_aval($this->data, 'contribution:1:contribution:1:payment_processor_id');
         if ($payment_processor_id && !$this->_payment_processor) {
           $this->_payment_processor = wf_civicrm_api('payment_processor', 'getsingle', array('id' => $payment_processor_id));

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2082,7 +2082,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $params['payment_instrument_id'] = $this->getPaymentInstrument($params['payment_processor_id']);
     }
 
-    // doPayment requries payment_processor and payment_processor_mode fields.
+    // doPayment requires payment_processor and payment_processor_mode fields.
     $params['payment_processor'] = wf_crm_aval($params, 'payment_processor_id');
 
     if (!empty($params['credit_card_number'])) {


### PR DESCRIPTION
Overview
----------------------------------------
To reproduce:
1. Configure a webform with multiple payment processors available in mode "test".
2. Submit the form - you will see that the wrong payment processor (the live ID) is selected and this causes some processors (eg. Stripe) to fail.

Before
----------------------------------------
Cannot submit payment in test mode for some payment processors.

After
----------------------------------------
Can submit payment in test mode when there are multiple payment processors on the form.

Technical Details
----------------------------------------
We introduced the function `fixPaymentProcessorID()` a while ago, but it is only triggered during the form constructor. For a webform with multiple payment processors there is no payment processor ID when the form is built, only once it is submitted.

Comments
----------------------------------------
@KarinG @eileenmcnaughton This should be a straightforward fix with limited scope for breakage?
