### PR TITLE
Fix issues with civicrm_option widget.

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -74,6 +74,14 @@ class CivicrmOptions extends WebformElementBase {
       '#default_value' => $element_properties['extra']['aslist'],
       '#parents' => ['properties', 'extra', 'aslist'],
     ];
+    $form['extra']['multiple'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Multiple'),
+      '#description' => $this->t('Check this option if multiple options can be selected for the input field.'),
+      '#access' => TRUE,
+      '#default_value' => $element_properties['extra']['multiple'],
+      '#parents' => ['properties', 'extra', 'multiple'],
+    ];
 
     // Options.
     $form['options'] = [
@@ -82,6 +90,12 @@ class CivicrmOptions extends WebformElementBase {
       '#open' => TRUE,
       '#prefix' => '<div id="webform-civicrm-options-wrapper">',
       '#suffix' => '</div>',
+    ];
+    $form['options']['empty_option'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Empty option label'),
+      '#description' => $this->t('The label to show for the initial option denoting no selection in a select element.'),
+      '#default_value' => $element_properties['empty_option'],
     ];
 
     if ($element_properties['civicrm_live_options']) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix multiple and empty option label for civicrm option widget.

Before
----------------------------------------
1.  No UI input to select empty option label if civicrm option is displayed as listbox. So if civicrm custom field is displayed as select element, the first option is selected by default.

![image](https://user-images.githubusercontent.com/5929648/77638117-ac907e80-6f7c-11ea-9d1a-be0e8aa7476c.png)

2. https://www.drupal.org/project/webform_civicrm/issues/3116288 No option to display civicrm option widget to display as checkboxes.
 

After
----------------------------------------
1.  Empty option label is added on the form.

![image](https://user-images.githubusercontent.com/5929648/77638253-db0e5980-6f7c-11ea-85cc-eee03b50ef8b.png)

If value is entered in the above field, the same is selected on the webform display -

![image](https://user-images.githubusercontent.com/5929648/77638656-85867c80-6f7d-11ea-8591-aee3c1cbc682.png)

2. Multiple checkbox is now displayed on the component form which is selected by default. If listbox option is disabled for the checkbox custom field, the input field is rendered as checkbox on the webform

![image](https://user-images.githubusercontent.com/5929648/77638812-c1214680-6f7d-11ea-8a20-6a6a9a05457c.png)



