### PR TITLE
Fixed the issue #3129204 of multiple display of existing contact

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -1,7 +1,7 @@
 (function ($, D, drupalSettings) {
   D.behaviors.webform_civicrm_contact = {
     attach: function (context) {
-      $('[data-civicrm-contact]', context).each(function (i, el) {
+      $('[data-civicrm-contact]', context).once('webform_civicrm_contact').each(function (i, el) {
         var toHide = []
         var field = $(el)
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));


### PR DESCRIPTION
Fixed for the Issue  - https://www.drupal.org/project/webform_civicrm/issues/3129204
Steps to reproduce this issue :
 1) In the webform, Add the CiviCRM's field from Settings > CiviCRM > Select fields ( e.g. Existing Contact, First Name, Last Name, Job Title )
 2) Add one non-CiviCRM field of type 'File'
 3) Edit the 'Existing Contact' field and set the 'Default Value' as Current User
 4) Now Issue is, When we upload any file from 'File' field then Existing contact name get displaying 
      multiple times and keeps on adding if we upload multiple files.

There was  ajax request which is triggering at file upload was actually breaking the 'Existing Contact' field display and each time keep on adding the 'Existing Contact' display.

Solution  - 
I  added  once() so as the to restrict the ajax request execute only once for the Existing Contact.