### PR TITLE
D9 rector check/fixes.

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -20,7 +20,7 @@ function _webform_edit_civicrm_contact($component) {
   $form = array();
   $node = node_load($component['nid']);
   if (empty($node->webform_civicrm) && node_is_page($node)) {
-    drupal_set_message(t('CiviCRM processing is not enabled for this webform.'), 'error');
+    \Drupal::messenger()->addError(t('CiviCRM processing is not enabled for this webform.'));
     return $form;
   }
   list($contact_types, $sub_types) = wf_crm_get_contact_types();
@@ -595,12 +595,9 @@ function wf_crm_contact_search($node, $component, $params, $contacts, $str = NUL
         l(t('Edit component'), "node/{$node->nid}/webform/components/{$component['cid']}")
       );
       if (wf_crm_admin_access($node) && node_is_page($node)) {
-        drupal_set_message(
-          '<strong>' . t('Maximum contacts exceeded, list truncated.') .'</strong><br>' .
-          t('The field "@field" cannot show more than !limit contacts because it is a select list. Recommend switching to autocomplete widget in <a !link>component settings</a>.',
-            array('!limit' => $limit, '@field' => $component['name'], '!link' => 'href="' . url("node/{$node->nid}/webform/components/{$component['cid']}") . '"')),
-          'warning'
-        );
+        \Drupal::messenger()->addWarning('<strong>' . t('Maximum contacts exceeded, list truncated.') .'</strong><br>' .
+        t('The field "@field" cannot show more than !limit contacts because it is a select list. Recommend switching to autocomplete widget in <a !link>component settings</a>.',
+          array('!limit' => $limit, '@field' => $component['name'], '!link' => 'href="' . url("node/{$node->nid}/webform/components/{$component['cid']}") . '"')));
       }
     }
   }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\webform\Entity\Webform;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Form\FormStateInterface;
@@ -1222,7 +1224,7 @@ class wf_crm_admin_form {
 
     /** @var \Drupal\webform\WebformAccessRulesManagerInterface $access_rules_manager */
     $access_rules_manager = \Drupal::service('webform.access_rules_manager');
-    $anonymous_access = $access_rules_manager->checkWebformAccess('create', new \Drupal\Core\Session\AnonymousUserSession(), $webform);
+    $anonymous_access = $access_rules_manager->checkWebformAccess('create', new AnonymousUserSession(), $webform);
     // If anonymous users don't have access to the form, no need for a warning.
     if (!$anonymous_access->isAllowed()) {
       return;
@@ -1242,12 +1244,12 @@ class wf_crm_admin_form {
           ->fields(array('submit_limit' => $submit_limit, 'submit_interval' => $submit_interval))
           ->execute();
       }
-      drupal_set_message(t('Per-user submission limit has been updated. You may revisit these options any time on the <em>Form Settings</em> tab of this webform.'));
+      \Drupal::messenger()->addStatus(t('Per-user submission limit has been updated. You may revisit these options any time on the <em>Form Settings</em> tab of this webform.'));
     }
     // Handle ajax submission from "webform_tracking_mode" mini-form below
     if (!empty($_POST['webform_tracking_mode']) && $_POST['webform_tracking_mode'] == 'strict') {
       variable_set('webform_tracking_mode', 'strict');
-      drupal_set_message(t('Webform anonymous user tracking has been updated to use the strict method. You may revisit this option any time on the global <a :link>Webform Settings</a> page.',
+      \Drupal::messenger()->addStatus(t('Webform anonymous user tracking has been updated to use the strict method. You may revisit this option any time on the global <a :link>Webform Settings</a> page.',
         array(':link' => 'href="/admin/config/content/webform" target="_blank"')
       ));
     }
@@ -1653,14 +1655,14 @@ class wf_crm_admin_form {
       }
       if ($deleted == 1) {
         $p = array('%name' => $field['#title']);
-        drupal_set_message($button === 'edit-delete' ? t('Deleted field: %name', $p) : t('Disabled field: %name', $p));
+        \Drupal::messenger()->addStatus($button === 'edit-delete' ? t('Deleted field: %name', $p) : t('Disabled field: %name', $p));
       }
       else {
         $p = array(':num' => $deleted);
-        drupal_set_message($button === 'edit-delete' ? t('Deleted :num fields.', $p) : t('Disabled :num fields.', $p));
+        \Drupal::messenger()->addStatus($button === 'edit-delete' ? t('Deleted :num fields.', $p) : t('Disabled :num fields.', $p));
       }
       if ($button === 'edit-disable') {
-        drupal_set_message(t('Disabled fields will still be processed as normal Webform fields, but they will not be autofilled from or saved to the CiviCRM database.'));
+        \Drupal::messenger()->addStatus(t('Disabled fields will still be processed as normal Webform fields, but they will not be autofilled from or saved to the CiviCRM database.'));
       }
       else {
         // Remove empty fieldsets for deleted contacts
@@ -1707,7 +1709,7 @@ class wf_crm_admin_form {
               if (isset($disabled[$key])) {
                 webform_component_update($disabled[$key]);
                 $enabled[$key] = $disabled[$key]['cid'];
-                drupal_set_message(t('Re-enabled field: %name', array('%name' => $disabled[$key]['name'])));
+                \Drupal::messenger()->addStatus(t('Re-enabled field: %name', array('%name' => $disabled[$key]['name'])));
               }
               // Create new component
               else {
@@ -2177,7 +2179,7 @@ class wf_crm_admin_form {
     $sets = Utils::wf_crm_get_fields('sets');
     // @todo Start using webform_civicrm_forms to track enabled webforms.
     /** @var \Drupal\webform\WebformInterface[] $webforms */
-    $webforms = \Drupal\webform\Entity\Webform::loadMultiple();
+    $webforms = Webform::loadMultiple();
     foreach ($webforms as $webform) {
       $handler_collection = $webform->getHandlers('webform_civicrm');
 

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -162,7 +162,7 @@ function webform_civicrm_update_6100() {
  */
 function webform_civicrm_update_6101() {
   civicrm_initialize();
-  $db = db_query('SELECT * FROM {webform_civicrm_submissions} WHERE contact_id <> :contact_id AND activity_id <> :activity_id', array(':contact_id' => 0, ':activity_id' => 0));
+  $db = \Drupal::database()->query('SELECT * FROM {webform_civicrm_submissions} WHERE contact_id <> :contact_id AND activity_id <> :activity_id', array(':contact_id' => 0, ':activity_id' => 0));
   $sql = 'INSERT INTO civicrm_activity_target (activity_id, target_contact_id) VALUES (%1,%2)';
   $n = 1;
   $c = 0;
@@ -244,7 +244,7 @@ function webform_civicrm_update_6200() {
   $match['civicrm_state_province'] = 'civicrm_1_contact_1_address_state_province';
 
   // Collect entity data
-  $db = db_query("SELECT form_key, nid FROM {webform_component} WHERE form_key LIKE 'civicrm_%%' AND type <> 'fieldset'");
+  $db = \Drupal::database()->query("SELECT form_key, nid FROM {webform_component} WHERE form_key LIKE 'civicrm_%%' AND type <> 'fieldset'");
   foreach ($db as $row) {
     if (array_key_exists($row->form_key, $match)) {
       $update[$row->form_key] = $match[$row->form_key];
@@ -270,7 +270,7 @@ function webform_civicrm_update_6200() {
   }
 
   // Populate entity data
-  $db = db_query("SELECT * FROM {webform_civicrm_forms}");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($db as $row) {
     $data = array(
       'contact' => array(
@@ -340,14 +340,14 @@ function webform_civicrm_update_6203() {
   module_load_include('inc', 'webform', 'includes/webform.components');
 
   // First get rid of redundant fields
-  $db = db_query("SELECT c1.* FROM {webform_component} c1, {webform_component} c2 WHERE c1.nid = c2.nid AND c1.form_key LIKE 'civicrm_%%_contact_%%_address_state_province' AND c2.form_key = CONCAT(c1.form_key, '_id')");
+  $db = \Drupal::database()->query("SELECT c1.* FROM {webform_component} c1, {webform_component} c2 WHERE c1.nid = c2.nid AND c1.form_key LIKE 'civicrm_%%_contact_%%_address_state_province' AND c2.form_key = CONCAT(c1.form_key, '_id')");
   foreach ($db as $item) {
     webform_component_delete($item, (array) $item);
   }
 
   // Update state_province fields
   $submitted = array();
-  $db = db_query("SELECT * FROM {webform_component} WHERE form_key LIKE 'civicrm_%%_contact_%%_address_state_province%%'");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_component} WHERE form_key LIKE 'civicrm_%%_contact_%%_address_state_province%%'");
   foreach ($db as $item) {
     if (substr($item->form_key, -3) == '_id') {
       $submitted[] = '(nid = ' . $item->nid . ' AND cid = ' . $item->cid . ')';
@@ -369,10 +369,10 @@ function webform_civicrm_update_6203() {
     $where = implode(' OR ', $submitted);
     civicrm_initialize();
     module_load_include('inc', 'webform_civicrm', 'includes/utils');
-    $db = db_query('SELECT DISTINCT data FROM {webform_submitted_data} WHERE ' . $where);
+    $db = \Drupal::database()->query('SELECT DISTINCT data FROM {webform_submitted_data} WHERE ' . $where);
     foreach ($db as $row) {
       if ($row->data && is_numeric($row->data)) {
-        db_query('UPDATE {webform_submitted_data} SET data = \'' . wf_crm_state_abbr($row->data) . '\' WHERE data = ' . $row->data . ' AND (' . $where . ')');
+        \Drupal::database()->query('UPDATE {webform_submitted_data} SET data = \'' . wf_crm_state_abbr($row->data) . '\' WHERE data = ' . $row->data . ' AND (' . $where . ')');
       }
     }
   }
@@ -386,7 +386,7 @@ function webform_civicrm_update_6203() {
 function webform_civicrm_update_6204() {
   module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
-  $db = db_query("SELECT * FROM {webform_civicrm_forms}");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($db as $form) {
     $data = unserialize($form->data);
     if (isset($data['event_type'])) {
@@ -410,7 +410,7 @@ function webform_civicrm_update_6205() {
   civicrm_initialize();
   module_load_include('inc', 'webform_civicrm', 'includes/utils');
   module_load_include('inc', 'webform', 'includes/webform.components');
-  $db = db_query("SELECT * FROM {webform_component} WHERE form_key LIKE 'civicrm_%%_other_tags' OR form_key LIKE 'civicrm_%%_other_group%%'");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_component} WHERE form_key LIKE 'civicrm_%%_other_tags' OR form_key LIKE 'civicrm_%%_other_group%%'");
   $tag = $group = array();
   foreach ($db as $row) {
     if ($pieces = Utils::wf_crm_explode_key($row->form_key)) {
@@ -425,8 +425,8 @@ function webform_civicrm_update_6205() {
       ${$type}[$row->nid][$c] = (array) $row;
     }
   }
-  db_query("UPDATE {webform_component} SET form_key = REPLACE(form_key, 'other_groups', 'other_group') WHERE form_key LIKE 'civicrm_%%_other_groups'");
-  $db = db_query("SELECT * FROM {webform_civicrm_forms}");
+  \Drupal::database()->query("UPDATE {webform_component} SET form_key = REPLACE(form_key, 'other_groups', 'other_group') WHERE form_key LIKE 'civicrm_%%_other_groups'");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($db as $form) {
     $nid = $form->nid;
     $data = unserialize($form->data);
@@ -489,7 +489,7 @@ function webform_civicrm_update_7300() {
   module_load_include('inc', 'webform', 'includes/webform.components');
   civicrm_initialize();
   $fields = wf_crm_get_fields();
-  $db = db_query("SELECT * FROM {webform_civicrm_forms}");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($db as $form) {
     $form = (array) $form;
     $form['data'] = unserialize($form['data']);
@@ -676,7 +676,7 @@ function webform_civicrm_update_7300() {
   db_drop_field('webform_civicrm_forms', 'contact_matching');
 
   $msg = st('There are important changes in Webform CiviCRM 3 that require your attention. Read the upgrade instructions at http://drupal.org/node/1615380 and review your existing webforms to ensure they are working as expected. Enjoy the new contact matching features!');
-  drupal_set_message($msg, 'warning');
+  \Drupal::messenger()->addWarning($msg);
   return $msg;
 }
 
@@ -686,7 +686,7 @@ function webform_civicrm_update_7300() {
 function webform_civicrm_update_7301() {
   module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
-  $db = db_query("SELECT * FROM {webform_civicrm_forms}");
+  $db = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($db as $form) {
     $data = unserialize($form->data);
     if (!empty($data['case'][1])) {
@@ -741,11 +741,11 @@ function webform_civicrm_update_7401(&$batch) {
     );
     db_add_field('webform_civicrm_submissions', 'civicrm_data', $field);
     $batch['progress'] = $batch['current_sid'] = 0;
-    $batch['max'] = db_query('SELECT COUNT(sid) FROM {webform_civicrm_submissions}')->fetchField();
+    $batch['max'] = \Drupal::database()->query('SELECT COUNT(sid) FROM {webform_civicrm_submissions}')->fetchField();
   }
 
   // Process the next group of submissions.
-  $result = db_query("SELECT * FROM {webform_civicrm_submissions} WHERE sid > {$batch['current_sid']} ORDER BY sid LIMIT 500");
+  $result = \Drupal::database()->query("SELECT * FROM {webform_civicrm_submissions} WHERE sid > {$batch['current_sid']} ORDER BY sid LIMIT 500");
   foreach ($result as $row) {
     $data = array();
     if ($row->activity_id) {
@@ -780,7 +780,7 @@ function webform_civicrm_update_7402() {
   civicrm_initialize();
   module_load_include('inc', 'webform', 'includes/webform.components');
   module_load_include('inc', 'webform_civicrm', 'includes/utils');
-  $forms = db_query("SELECT * FROM {webform_civicrm_forms}");
+  $forms = \Drupal::database()->query("SELECT * FROM {webform_civicrm_forms}");
   foreach ($forms as $form) {
     $data = $orig = unserialize($form->data);
     if (isset($data['activity'][1]['activity'][1])) {
@@ -801,7 +801,7 @@ function webform_civicrm_update_7402() {
       }
       // Create hidden field for activity subject to replace the removed "default subject" setting
       $fid = 'civicrm_1_activity_1_activity_subject';
-      if (!(db_query("SELECT nid FROM {webform_component} WHERE form_key = '$fid' AND nid = {$form->nid}")->fetchField())) {
+      if (!(\Drupal::database()->query("SELECT nid FROM {webform_component} WHERE form_key = '$fid' AND nid = {$form->nid}")->fetchField())) {
         $component = array(
           'form_key' => $fid,
           'nid' => $form->nid,

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\webform\Entity\Webform;
 /**
  * @file
  * Webform CiviCRM Integration Module:
@@ -464,7 +465,7 @@ function webform_civicrm_civicrm_buildForm($formName, $form) {
     if ($fid) {
       // @todo Start using webform_civicrm_forms to track enabled webforms.
       /** @var \Drupal\webform\WebformInterface[] $webforms */
-      $webforms = \Drupal\webform\Entity\Webform::loadMultiple();
+      $webforms = Webform::loadMultiple();
       foreach ($webforms as $webform) {
         $handler_collection = $webform->getHandlers('webform_civicrm');
 


### PR DESCRIPTION
Overview
----------------------------------------
Today was work on getting your module ready for D9 day - supported by many smart Drupal folks on slack

After
----------------------------------------
I ran https://Drupal.org/project/rector where possible. Had some issues with autoloading -> so ended up having a couple of passes using specific --autoload-file option

`$ vendor/bin/rector process web/modules/contrib/webform_civicrm --dry-run`

For example:
`$ vendor/bin/rector process web/modules/contrib/webform_civicrm/includes/contact_component.inc --autoload-file web/modules/contrib/webform_civicrm/includes/wf_crm_admin_help.inc`

Technical Details
----------------------------------------
I could not examine/get through all code/files in the 8.x-5.x project. Some were consistently producing: Call to undefined function module_load_include()

ToDo list:
web/modules/contrib/webform_civicrm/includes/wf_crm_admin_component.inc
web/modules/contrib/webform_civicrm/includes/wf_crm_webform_ajax.inc
web/modules/contrib/webform_civicrm/includes/wf_crm_webform_base.inc
web/modules/contrib/webform_civicrm/includes/wf_crm_webform_postprocess.inc
web/modules/contrib/webform_civicrm/includes/wf_crm_webform_preprocess.inc
web/modules/contrib/webform_civicrm/src/Controller/AjaxController.php
web/modules/contrib/webform_civicrm/src/Plugin/WebformHandler/CivicrmWebformHandler.php

Tools to look at:
Matt's drupal-check
Upgrade status module
