### PR TITLE
Return if entity variable is NULL.

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -525,6 +525,10 @@ function wf_crm_array2str($arr) {
  *   Result of API call
  */
 function wf_civicrm_api($entity, $operation, $params) {
+  if (is_null($entity)) {
+    return;
+  }
+
   $params += array(
     'check_permissions' => FALSE,
     'version' => 3

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -525,8 +525,8 @@ function wf_crm_array2str($arr) {
  *   Result of API call
  */
 function wf_civicrm_api($entity, $operation, $params) {
-  if (is_null($entity)) {
-    return;
+  if (!$entity) {
+    return [];
   }
 
   $params += array(


### PR DESCRIPTION
Overview
----------------------------------------
Circa 5.24 CiviCRM Core added var type declarations to some core functions including `civicrm_api()` so the signature changed from `civicrm_api($entity, $action, $params)` to` civicrm_api(string $entity, string $action, array $params)`

Before
----------------------------------------
Fatal Error when trying to Add Element on Build tab

```
TypeError: Argument 1 passed to civicrm_api() must be of the type string, null given, called in /var/www/drupal/web/modules/contrib/webform_civicrm/includes/utils.inc on line 532 in civicrm_api() (line 21 of /var/www/drupal/vendor/civicrm/civicrm-core/api/api.php)
#0 /var/www/drupal/web/modules/contrib/webform_civicrm/includes/utils.inc(532): civicrm_api(NULL, 'getoptions', Array)
```

After
----------------------------------------
Happy dance!

