### PR TITLE
Fix type for time -> webform_time

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -424,7 +424,7 @@ class Fields implements FieldsInterface {
       );
       $fields['activity_activity_date_time_timepart'] = array(
         'name' => t('Activity # Time'),
-        'type' => 'time',
+        'type' => 'webform_time',
         'value' => 'now',
       );
       $fields['activity_duration'] = array(
@@ -959,7 +959,7 @@ class Fields implements FieldsInterface {
               $fields[$id]['name'] .= ' - ' . t('date');
               $fields[$id . '_timepart'] = array(
                 'name' => $dao->label . ' - ' . t('time'),
-                'type' => 'time',
+                'type' => 'webform_time',
                 'extra' => array('hourformat' => $dao->time_format == 1 ? '12-hour' : '24-hour'),
               );
             }


### PR DESCRIPTION
Overview
----------------------------------------
time is not a correct type to use when creating a webform element.

Before -> when adding element Activity Time to the form
----------------------------------------
`'type' => 'time',
`
results in unknown type [time] -> the element can not be configured via the GUI and does not appear on the Form

![image](https://user-images.githubusercontent.com/5340555/81433104-45d8b600-9121-11ea-861d-6de6c5d43260.png)

After
----------------------------------------
`'type' => 'webform_time',
`
All good!

![image](https://user-images.githubusercontent.com/5340555/81433218-71f43700-9121-11ea-9ec3-56aa48cb08e3.png)

Comments
----------------------------------------
I scanned Fields.php for other `'type' => 'time'` and found one more so editing that here as well.