### PR TITLE
Fix saving #form_key when editing civicrm_contact webform element

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -34,7 +34,7 @@ class CivicrmContact extends WebformElementBase {
   public function getDefaultProperties() {
     return [
         'name' => '',
-        'form_key' => NULL,
+        'form_key' => '',
         'pid' => 0,
         'weight' => 0,
         'value' => '',


### PR DESCRIPTION
With Webform 8.x-5.11, if you edit the automatically added 'Existing Contact' element and save it (without any changes), the '#form_key' will get set to 0 (removing it's correct value, which is needed for that element to operate correctly).

This patch makes it so that saving will maintain the correct value. However, it doesn't fix elements where the #form_key has already gotten cleared out to 0.