### PR TITLE
Make sure recurring amount always equals first amount; also calculate…

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1821,19 +1821,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $numInstallments = wf_crm_aval($contributionParams, 'installments', NULL, TRUE);
     // if ($installments === 0) or $installments is not defined we treat as an open-ended recur
     $contributionFirstAmount = $contributionRecurAmount = $contributionParams['total_amount'];
-    $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);;
+    $salesTaxFirstAmount = wf_crm_aval($contributionParams, 'tax_amount', NULL, TRUE);
+    $nondeductibleFirstAmount = wf_crm_aval($contributionParams, 'non_deductible_amount', NULL, TRUE);
     if ($numInstallments > 0) {
       // DRU-2862396 - we must ensure to only present 2 decimals to CiviCRM:
-      $contributionRecurAmount = floor(($contributionParams['total_amount'] / $numInstallments) * 100) / 100;
-      $contributionFirstAmount = $contributionParams['total_amount'] - $contributionRecurAmount * ($numInstallments - 1);
-      $salesTaxFirstAmount = $salesTaxFirstAmount - floor(($salesTaxFirstAmount / $numInstallments) * 100) / 100 * ($numInstallments - 1);
+      $contributionRecurAmount = round(($contributionParams['total_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+      $contributionFirstAmount = $contributionRecurAmount;
+      $salesTaxFirstAmount = round(($salesTaxFirstAmount / $numInstallments), 2, PHP_ROUND_HALF_UP);
+      $nondeductibleFirstAmount = round(($nondeductibleFirstAmount / $numInstallments), 2, PHP_ROUND_HALF_UP);
 
       // Calculate the line_items for the first contribution:
       // At this point line_items are set to the full (non-installment) amounts.
       foreach ($this->line_items as $key => $k) {
-        $this->line_items[$key]['unit_price'] = $k['unit_price'] / $numInstallments;
-        $this->line_items[$key]['line_total'] = $k['line_total'] / $numInstallments;
-        $this->line_items[$key]['tax_amount'] = $k['tax_amount'] / $numInstallments;
+        $this->line_items[$key]['unit_price'] = round(($k['unit_price'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+        $this->line_items[$key]['line_total'] = round(($k['line_total'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+        $this->line_items[$key]['tax_amount'] = round(($k['tax_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
       }
     }
 
@@ -1860,6 +1862,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     // Run the Transaction - and Create the Contribution Record - relay Recurring Series information in addition to the already existing Params [and re-key where needed]; at times two keys are required
     $contributionParams['total_amount'] = $contributionFirstAmount;
     $contributionParams['tax_amount'] = $salesTaxFirstAmount;
+    $contributionParams['non_deductible_amount'] = $nondeductibleFirstAmount;
     $additionalParams = array(
       'contribution_recur_id' => $resultRecur['id'],
       'contributionRecurID' => $resultRecur['id'],


### PR DESCRIPTION
Make sure recurring amount always equals first amount; also calculate non_deductible_amount.

Now that it has been clarified that the amount field in the civicrm_contribution_recur table contains the amount to be transacted including any sales taxes we can finish the instalment bits for webform_civicrm module -> https://github.com/civicrm/civicrm-core/pull/17311

**Overview**
----------------------------------------
Logic for recurring contributions in core really expects them to be the same amount every month. This PR ensure that this is will now be the case. Also -> `non_deductible_amount` needs to be calculated properly. The use of `PHP_ROUND_HALF_UP` was previously proposed by @omarabuhussein.


**Before**
----------------------------------------
Logic: take the total amount -> split it up over x instalments, rounded to 2 decimals -> re-calculate the first amount to be total amount minus 11 instalments. That meant that the first amount could be different from the recurring amount.

**After**
----------------------------------------
Logic: much simpler, more predictable! Works much better with the expected recurring workflows in Core. Repeattransaction e.g. -> as the amount is the same month over month. 

**Downside**
----------------------------------------
Could end up with a few pennies more or less over a full year of rounded values. This however can be avoided by thinking ahead and pricing your annual fees/instalments accordingly :-)

**Example**
----------------------------------------
Professional Membership: $129 + 5% tax = 135.45

Before this PR:
$11.37 (first instalment) + $11.28 x 11 (instalments) = $135.45

After this PR:
$11.29 x 12 (instalments) = $135.48

The benefits of this integrating much better with existing recurring contribution workflows because the recurring amount is the same month over month far outweigh the $0.03 additional sales tax. Again, orgs can think ahead and adjust their pricing accordingly if they feel that is necessary. 

Comments
----------------------------------------
Live on one of our projects!
