### PR TITLE
Replacing old D7 functions with D8 functions even when unreachable [r…

### DIFF
--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -11,7 +11,7 @@ use Drupal\webform_civicrm\Utils;
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
 // FIXME: Temporary workaround for https://www.drupal.org/node/2389537
-variable_set('webform_table', TRUE);
+\Drupal::state()->set('webform_table', TRUE);
 
 class wf_crm_admin_component {
   private $form;

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -220,11 +220,10 @@ class wf_crm_admin_form {
       '#suffix' => '<div>' . t('You have Javascript disabled. You will need to click this button after changing any option to see the result.') . '</div></div>',
     );
     $this->form['webform_civicrm'] = array('#type' => 'vertical_tabs');
-    // Display intro help to virgins
     /*
-     * @todo evaluate this; use \Drupal::state(). also inline JS is not allowed in D8.
-    if (!variable_get('webform_civicrm_help_seen')) {
-      variable_set('webform_civicrm_help_seen', TRUE);
+     * @todo evaluate this; inline JS is not allowed in D8.
+    if (!\Drupal::state()->get('webform_civicrm_help_seen')) {
+      \Drupal::state()->set('webform_civicrm_help_seen', TRUE);
       drupal_add_js('cj(function() {CRM.help("' . t('Welcome to Webform-CiviCRM') . '", {}, "' . url('webform-civicrm/help/intro') . '");});', array('type' => 'inline', 'scope' => 'footer'));
     }
     */
@@ -1254,7 +1253,7 @@ class wf_crm_admin_form {
     }
     // Handle ajax submission from "webform_tracking_mode" mini-form below
     if (!empty($_POST['webform_tracking_mode']) && $_POST['webform_tracking_mode'] == 'strict') {
-      variable_set('webform_tracking_mode', 'strict');
+      \Drupal::state()->set('webform_tracking_mode', 'strict');
       \Drupal::messenger()->addStatus(t('Webform anonymous user tracking has been updated to use the strict method. You may revisit this option any time on the global <a :link>Webform Settings</a> page.',
         array(':link' => 'href="/admin/config/content/webform" target="_blank"')
       ));
@@ -1281,7 +1280,7 @@ class wf_crm_admin_form {
       );
     }
     // Mini-form to conveniently update global cookie setting
-    elseif (variable_get('webform_tracking_mode', 'cookie') == 'cookie') {
+    elseif (\Drupal::state()->get('webform_tracking_mode', 'cookie') == 'cookie') {
       $this->form['contribution']['sets']['webform_tracking_mode'] = array(
         '#markup' => '<div class="messages warning">' .
           t('Per-user submission limit is enabled for this form, however the webform anonymous user tracking method is configured to use cookies only, which is not secure enough to prevent Credit Card abuse.') .

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -193,7 +193,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
       return FALSE;
     }
     /* TODO figure out what this means in Drupal 8
-    if (variable_get('webform_submission_access_control', 1)) {
+    if (\Drupal::state()->get('webform_submission_access_control', 1)) {
       $allowed_roles = array();
       foreach ($node->webform['roles'] as $rid) {
         $allowed_roles[$rid] = isset($user->roles[$rid]) ? TRUE : FALSE;

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -29,10 +29,10 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = array(
+    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
       'preprocess' => FALSE,
       'minified' => FALSE
-    );
+    ];
   }
 }
 
@@ -226,11 +226,11 @@ function webform_civicrm_node_view($node, $view_mode, $langcode) {
  * @return array
  */
 function webform_civicrm_theme() {
-  return array(
-    'webform_civicrm_contact' => array(
+  return [
+    'webform_civicrm_contact' => [
       'base hook' => 'input',
-    ),
-  );
+    ],
+  ];
   /*
   $theme = array(
     'webform_civicrm_options_table' => array(

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -29,10 +29,10 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
+    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = array(
       'preprocess' => FALSE,
       'minified' => FALSE
-    ];
+    );
   }
 }
 
@@ -226,11 +226,11 @@ function webform_civicrm_node_view($node, $view_mode, $langcode) {
  * @return array
  */
 function webform_civicrm_theme() {
-  return [
-    'webform_civicrm_contact' => [
+  return array(
+    'webform_civicrm_contact' => array(
       'base hook' => 'input',
-    ],
-  ];
+    ),
+  );
   /*
   $theme = array(
     'webform_civicrm_options_table' => array(
@@ -791,7 +791,7 @@ function _webform_civicrm_isWebformSubmission($tokenType, $webformData) {
   return (
     $tokenType === 'submission' &&
     !empty($webformData['webform-submission']) &&
-    webform_variable_get('webform_token_access')
+    \Drupal::state()->get('webform_token_access')
   );
 }
 


### PR DESCRIPTION
**Overview**
----------------------------------------
Small iterative step re: code cleanup and towards D9
My strategy will continue to be small iterations as I believe that's the safest way fwd. 

**Before**
----------------------------------------
Rector would choke on D7 functions -> like `variable_set` and `variable_get`
even when unreachable 

**After**
----------------------------------------
replaced all `variable_set` and `variable_get` with D8 `\Drupal::state()->set` and `\Drupal::state()->get`

**Technical Details**
----------------------------------------
Straight up replacement [for now] - not attempting to port the actual functionality.

