### PR TITLE
Replace old D7 functions and deprecated node_load (for D9 readiness)

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -8,6 +8,8 @@
 use Drupal\Component\Utility\Html;
 use Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact;
 use Drupal\webform_civicrm\Utils;
+use Drupal\node\Entity\Node;
+
 
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
 module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_admin_help');
@@ -18,7 +20,7 @@ module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_admin_help');
 function _webform_edit_civicrm_contact($component) {
   civicrm_initialize();
   $form = array();
-  $node = node_load($component['nid']);
+  $node = Node::load($component['nid']);
   if (empty($node->webform_civicrm) && node_is_page($node)) {
     \Drupal::messenger()->addError(t('CiviCRM processing is not enabled for this webform.'));
     return $form;
@@ -319,7 +321,7 @@ function wf_crm_contact_component_form_help(&$form) {
  * Implements _webform_render_component().
  */
 function _webform_render_civicrm_contact($component, $value = NULL, $filter = TRUE) {
-  $node = isset($component['nid']) ? node_load($component['nid']) : NULL;
+  $node = isset($component['nid']) ? Node::load($component['nid']) : NULL;
   civicrm_initialize();
   list(, $c, ) = explode('_', $component['form_key'], 3);
   $hide_fields = array_filter($component['extra']['hide_fields']);

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -10,7 +10,6 @@ use Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact;
 use Drupal\webform_civicrm\Utils;
 use Drupal\node\Entity\Node;
 
-
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
 module_load_include('inc', 'webform_civicrm', 'includes/wf_crm_admin_help');
 

--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -11,7 +11,7 @@ use Drupal\webform_civicrm\Utils;
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
 // FIXME: Temporary workaround for https://www.drupal.org/node/2389537
-variable_set('webform_table', TRUE);
+\Drupal::state()->set('webform_table', TRUE);
 
 class wf_crm_admin_component {
   private $form;

--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\Html;
 use Drupal\webform_civicrm\Utils;
+use Drupal\node\Entity\Node;
 
 module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
@@ -26,7 +27,7 @@ class wf_crm_admin_component {
     civicrm_initialize();
     $this->form = &$form;
     $this->form_state = &$form_state;
-    $this->node = node_load($form['nid']['#value']);
+    $this->node = Node::load($form['nid']['#value']);
     $this->data = wf_crm_aval($this->node, 'webform_civicrm:data');
     $this->component = wf_crm_aval($this->node, 'webform:components:' . $this->form['cid']['#value']);
   }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -220,11 +220,10 @@ class wf_crm_admin_form {
       '#suffix' => '<div>' . t('You have Javascript disabled. You will need to click this button after changing any option to see the result.') . '</div></div>',
     );
     $this->form['webform_civicrm'] = array('#type' => 'vertical_tabs');
-    // Display intro help to virgins
     /*
-     * @todo evaluate this; use \Drupal::state(). also inline JS is not allowed in D8.
-    if (!variable_get('webform_civicrm_help_seen')) {
-      variable_set('webform_civicrm_help_seen', TRUE);
+     * @todo evaluate this; inline JS is not allowed in D8.
+    if (!\Drupal::state()->get('webform_civicrm_help_seen')) {
+      \Drupal::state()->set('webform_civicrm_help_seen', TRUE);
       drupal_add_js('cj(function() {CRM.help("' . t('Welcome to Webform-CiviCRM') . '", {}, "' . url('webform-civicrm/help/intro') . '");});', array('type' => 'inline', 'scope' => 'footer'));
     }
     */
@@ -1254,7 +1253,7 @@ class wf_crm_admin_form {
     }
     // Handle ajax submission from "webform_tracking_mode" mini-form below
     if (!empty($_POST['webform_tracking_mode']) && $_POST['webform_tracking_mode'] == 'strict') {
-      variable_set('webform_tracking_mode', 'strict');
+      \Drupal::state()->set('webform_tracking_mode', 'strict');
       \Drupal::messenger()->addStatus(t('Webform anonymous user tracking has been updated to use the strict method. You may revisit this option any time on the global <a :link>Webform Settings</a> page.',
         array(':link' => 'href="/admin/config/content/webform" target="_blank"')
       ));
@@ -1281,7 +1280,7 @@ class wf_crm_admin_form {
       );
     }
     // Mini-form to conveniently update global cookie setting
-    elseif (variable_get('webform_tracking_mode', 'cookie') == 'cookie') {
+    elseif (\Drupal::state()->get('webform_tracking_mode', 'cookie') == 'cookie') {
       $this->form['contribution']['sets']['webform_tracking_mode'] = array(
         '#markup' => '<div class="messages warning">' .
           t('Per-user submission limit is enabled for this form, however the webform anonymous user tracking method is configured to use cookies only, which is not secure enough to prevent Credit Card abuse.') .

--- a/includes/wf_crm_webform_ajax.inc
+++ b/includes/wf_crm_webform_ajax.inc
@@ -193,7 +193,7 @@ class wf_crm_webform_ajax extends wf_crm_webform_base {
       return FALSE;
     }
     /* TODO figure out what this means in Drupal 8
-    if (variable_get('webform_submission_access_control', 1)) {
+    if (\Drupal::state()->get('webform_submission_access_control', 1)) {
       $allowed_roles = array();
       foreach ($node->webform['roles'] as $rid) {
         $allowed_roles[$rid] = isset($user->roles[$rid]) ? TRUE : FALSE;

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\webform_civicrm\Utils;
+use Drupal\node\Entity\Node;
 
 /**
  * Implements hook_requirements().
@@ -445,7 +446,7 @@ function webform_civicrm_update_6205() {
       }
     }
     if (!empty($tag[$nid]) || !empty($group[$nid])) {
-      $node = node_load($nid);
+      $node = Node::load($nid);
       $both = wf_crm_aval($tag, $nid, array()) + wf_crm_aval($group, $nid, array());
       foreach ($both as $c => $val) {
         $data['contact'][$c]['number_of_other'] = 1;
@@ -494,7 +495,7 @@ function webform_civicrm_update_7300() {
     $form = (array) $form;
     $form['data'] = unserialize($form['data']);
     $data = &$form['data'];
-    $node = node_load($form['nid']);
+    $node = Node::load($form['nid']);
     $enabled = wf_crm_enabled_fields($node);
     // Add existing contact field
     $field = $fields['contact_existing'];

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -11,6 +11,7 @@ use Drupal\webform\Entity\Webform;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\webform_civicrm\Utils;
+use Drupal\node\Entity\Node;
 
 /**
  * The versions of CiviCRM and WebForm. Min is >=.  Max is <. FALSE = no MAX
@@ -651,7 +652,7 @@ function wf_crm_contact_clone($form, $form_state) {
   form_load_include($form_state, 'inc', 'webform_civicrm', 'includes/utils');
   $fid = $form['form_key']['#default_value'];
   list(, $old) = Utils::wf_crm_explode_key($fid);
-  $node = node_load($form['nid']['#value']);
+  $node = Node::load($form['nid']['#value']);
   $settings = $node->webform_civicrm;
   $new = count($settings['data']['contact']) + 1;
   // Clone contact

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -29,10 +29,10 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = array(
+    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
       'preprocess' => FALSE,
       'minified' => FALSE
-    );
+    ];
   }
 }
 
@@ -226,11 +226,11 @@ function webform_civicrm_node_view($node, $view_mode, $langcode) {
  * @return array
  */
 function webform_civicrm_theme() {
-  return array(
-    'webform_civicrm_contact' => array(
+  return [
+    'webform_civicrm_contact' => [
       'base hook' => 'input',
-    ),
-  );
+    ],
+  ];
   /*
   $theme = array(
     'webform_civicrm_options_table' => array(

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -29,10 +29,10 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
+    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = array(
       'preprocess' => FALSE,
       'minified' => FALSE
-    ];
+    );
   }
 }
 
@@ -226,11 +226,11 @@ function webform_civicrm_node_view($node, $view_mode, $langcode) {
  * @return array
  */
 function webform_civicrm_theme() {
-  return [
-    'webform_civicrm_contact' => [
+  return array(
+    'webform_civicrm_contact' => array(
       'base hook' => 'input',
-    ],
-  ];
+    ),
+  );
   /*
   $theme = array(
     'webform_civicrm_options_table' => array(
@@ -791,7 +791,7 @@ function _webform_civicrm_isWebformSubmission($tokenType, $webformData) {
   return (
     $tokenType === 'submission' &&
     !empty($webformData['webform-submission']) &&
-    webform_variable_get('webform_token_access')
+    \Drupal::state()->get('webform_token_access')
   );
 }
 


### PR DESCRIPTION
**Overview**
----------------------------------------
Replaces PR-> https://github.com/colemanw/webform_civicrm/pull/308/files

Small iterative step re: code cleanup and towards D9
My strategy will continue to be small iterations as I believe that's the safest way fwd.
Replace deprecated node_load - no refactoring

**Before**
----------------------------------------

- Rector would choke on D7 functions -> like `variable_set` and `variable_get` even when unreachable
- `node_load()`

**After**
----------------------------------------
- replaced all `variable_set` and `variable_get` with D8 `\Drupal::state()->set` and `\Drupal::state()->get`
- `use Drupal\node\Entity\Node;` and `Node::load()`

**Technical Details**
----------------------------------------
Straight up replacement - not attempting to port the actual functionality. Since webforms are no longer nodes in D8 - much of this can be refactored - but this is just a drop-in replacement

Used: https://www.drupal.org/docs/8/converting-drupal-7-modules-to-drupal-8/step-5-how-to-upgrade-d7-variables-to-d8s-state
