### PR TITLE
Error IPN redirect after upgrade to 7.x-5.0

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1946,6 +1946,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $paymentProcessor->setCancelUrl($this->getIpnRedirectUrl('cancel'));
     }
 
+    // Required by (at least) 'Paypal - Website Payments Standard' and 'Redsys'
+    $params['webform_redirect_cancel'] = $this->getIpnRedirectUrl('cancel');
+    $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
+
     if (method_exists($paymentProcessor, 'doTransferCheckout')) {
       //Paypal Express checkout
       if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -1042,3 +1042,21 @@ function webform_civicrm_civicrm_pre($op, $objectName, $id, &$params) {
     }
   }
 }
+
+/**
+ * Implements hook_civicrm_alterPaymentProcessorParams().
+ *
+ * Legacy handling for paypal.
+ * We use it to override the return url so that the user gets redirected to the right place from paypal.
+ *
+ * Required by (at least) 'Paypal - Website Payments Standard' and 'Redsys'
+ * 
+ */
+function webform_civicrm_civicrm_alterPaymentProcessorParams($paymentObj, $rawParams, &$cookedParams) {
+  if (!empty($rawParams['webform_redirect_cancel']) && !empty($rawParams['webform_redirect_success'])
+    && !empty($cookedParams['return']) && !empty($cookedParams['cancel_return'])
+  ) {
+    $cookedParams['return'] = $rawParams['webform_redirect_success'];
+    $cookedParams['cancel_return'] = $rawParams['webform_redirect_cancel'];
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
After upgrading Webform CiviCRM from 7.x-4.28 to 7.x-5.0 when I return from the payment processor on success or on failure, I get an error page instead of the confirmation page.

The URL of the error page is something like `https://(...)civicrm/contribute/transact?_qf_Main_display=1&cancel=1&qfKey=7b3df95cb36`(...) and the error is

`$Fatal Error Details = Array ( [message] => We can't load the requested web page. This page requires cookies to be enabled in your browser settings. Please check this setting and enable cookies (if they are not enabled). Then try again. If this error persists, contact the site administrator for assistance`

`$backTrace = #0 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Error.php(357): CRM_Core_Error::backtrace("backTrace", TRUE) #1 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Controller.php(833): CRM_Core_Error::fatal("We can't load the requested web page. This page requires cookies to be enable...") #2 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Controller.php(853): CRM_Core_Controller->invalidKeyCommon() #3 /usr/home/web/sites/all/modules/civicrm/CRM/Contribute/Form/ContributionBase.php(236): CRM_Core_Controller->invalidKeyRedirect() #4 /usr/home/web/sites/all/modules/civicrm/CRM/Contribute/Form/Contribution/Main.php(64): CRM_Contribute_Form_ContributionBase->preProcess() #5 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Form.php(590): CRM_Contribute_Form_Contribution_Main->preProcess() #6 /usr/home/web/sites/all/modules/civicrm/CRM/Core/QuickForm/Action/Display.php(92): CRM_Core_Form->buildForm() #7 /usr/home//web/sites/all/modules/civicrm/packages/HTML/QuickForm/Controller.php(203): CRM_Core_QuickForm_Action_Display->perform(Object(CRM_Contribute_Form_Contribution_Main), "display") #8 /usr/home/web/sites/all/modules/civicrm/packages/HTML/QuickForm/Page.php(103): HTML_QuickForm_Controller->handle(Object(CRM_Contribute_Form_Contribution_Main), "display") #9 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Controller.php(351): HTML_QuickForm_Page->handle("display") #10 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(284): CRM_Core_Controller->run((Array:3), NULL) #11 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(84): CRM_Core_Invoke::runItem((Array:15)) #12 /usr/home/web/sites/all/modules/civicrm/CRM/Core/Invoke.php(52): CRM_Core_Invoke::_invoke((Array:3)) #13 /usr/home/web/sites/all/modules/civicrm/drupal/civicrm.module(456): CRM_Core_Invoke::invoke((Array:3)) #14 /usr/home/web/includes/menu.inc(527): civicrm_invoke("contribute", "transact") #15 /usr/home/web/index.php(21): menu_execute_active_handler() #16 {main}
`
It happens on the two payment processors that I have activated:

Paypal Standard (CiviCRM core native) and Redsys Payment Processor

first ocurred on:

Drupal version 7.69
Webform version 7.x-4.21
Webform CiviCRM version 7.x-5.0
CiviCRM version 5.20.3


D7 or D8?
----------------------------------------
D7WFC

Before
----------------------------------------
After a cancel redirect with PayPal payment method system shows this page error:

`$Fatal Error Details = Array ( [message] => We can't load the requested web page. This page requires cookies to be enabled in your browser settings. Please check this setting and enable cookies (if they are not enabled). Then try again. If this error persists, contact the site administrator for assistance`

After
----------------------------------------
Cancel redirect works well again.

Comments
----------------------------------------
https://www.drupal.org/project/webform_civicrm/issues/3111975

Patch #2 https://www.drupal.org/project/webform_civicrm/issues/3111975#comment-13455427
Patch #4 https://www.drupal.org/project/webform_civicrm/issues/3111975#comment-13609705
