### PR TITLE
Trim first_name and last_name.

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -632,6 +632,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     if ($params['contact_type'] == 'Individual' && empty($params['first_name']) && empty($params['last_name'])) {
       $params['display_name'] = $params['sort_name'] = empty($params['nick_name']) ? $contact['email'][1]['email'] : $params['nick_name'];
     }
+    // Trim (to remove trailing whitespaces) first_name and last_name prior to creating a new contact
+    $params['first_name'] = trim($params['first_name']);
+    $params['last_name'] = trim($params['last_name']);
     $result = wf_civicrm_api('contact', 'create', $params);
     return wf_crm_aval($result, 'id', 0);
   }


### PR DESCRIPTION
Overview
----------------------------------------
Addresses https://civicrm.stackexchange.com/questions/35819/anyone-noticing-trailing-spaces-in-name-and-address-fields-submitted-via-profile

D7 or D8?
----------------------------------------
PR for D7 -> we should be able to cherry pick this for D8 after merge. 

Before
----------------------------------------
Contacts in database with e.g. first_name = "Just  "

After
----------------------------------------
No more trailing spaces.

Technical Details
----------------------------------------
This PR addresses the immediate issue. When we see a webform submission that contains "Just  " -> it typically also has other textfields like street_address that have trailing spaces - but that's not as critical and can be addressed later. 
