### PR TITLE
RSE-1204: Fix civicrm file field show/hide behavior

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -96,16 +96,11 @@ var wfCivi = (function ($, D) {
     var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
     if (container.length > 0) {
       if ($('.file', container).length > 0) {
-        if ($('.file', container).is(':visible')) {
-          $('.file', container).hide();
-          info.icon = $('.file a', container).attr('href');
-        }
-        else {
-          return;
-        }
+        $('.file', container).hide();
+        info.icon = $('.file a', container).attr('href');
       }
       else {
-        $(':visible', container).hide();
+        $(container).children().hide();
         container.append('<input type="submit" class="form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Change') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
       }
       container.prepend('<span class="civicrm-file-icon"><img alt="' + Drupal.t('File') + '" src="' + info.icon + '" /> ' + (info.name ? ('<a href="'+ info.file_url+ '" target="_blank">'+info.name +'</a>') : '') + '</span>');
@@ -115,7 +110,7 @@ var wfCivi = (function ($, D) {
   pub.clearFileField = function(field) {
     var container = $('div.webform-component[class*="--' + field.replace(/_/g, '-') + '"] div.civicrm-enabled');
     $('.civicrm-remove-file, .civicrm-file-icon', container).remove();
-    $('input[type=file], input[type=submit]', container).show();
+    $(container).children().show();
   };
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes broken show/hide behavior for civicrm files in webforms. It was working fine if field was initially visible, but has an issue if field is initially hidden (e.g. when conditional fields are used).
Issue is reproducable with bartik and with custom theme.

Before
----------------------------------------
![before](https://user-images.githubusercontent.com/39520000/86010945-c4b4e580-ba24-11ea-98b8-6a95dd38ef8f.gif)

After
----------------------------------------
![after](https://user-images.githubusercontent.com/39520000/86446622-dba55180-bd1c-11ea-9cc0-5833a8aec016.gif)

Technical Details
----------------------------------------
Previously only visible field was hidden, now we will hide it anyway.