### PR TITLE
Trim whitespace from user input

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2340,6 +2340,10 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
         else {
           $val = is_array($val) ? reset($val) : $val;
+          // Trim whitespace from user input
+          if (is_string($val)) {
+            $val = trim($val);
+          }
         }
         if ($component['type'] == 'autocomplete' && is_string($val) && strlen($val)) {
           $options = wf_crm_field_options($component, '', $this->data);


### PR DESCRIPTION
Overview
----------------------------------------
Make sure user input (first name, last name, etc. etc.) do not contain leading or trailing whitespace.

D7 or D8?
----------------------------------------
Needs port to D8

Before
----------------------------------------
Untrimmed strings from webform saved as-is

After
----------------------------------------
All user input trimmed

Comments
----------------------------------------
This might be over-aggressive but I can't think of any legitimate cases for whitepace at the beginning or end of a string in the db.