### PR TITLE
case subject

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1287,7 +1287,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $params['status_id'] = current(array_keys($options));
           }
           if (empty($params['subject'])) {
-            $params['subject'] = Html::escape($this->node->title);
+            $params['subject'] = Html::escape($this->node->get('title'));
           }
           // Automatic creator_id - default to current user or contact 1
           if (empty($data['case'][1]['creator_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Bug reported by @gibsonoliver

D7 or D8?
----------------------------------------
D8 only

Before
----------------------------------------
if no Subject configured to appear on the webform when creating a case:

Error: Cannot access protected property Drupal\webform\Entity\Webform::$title in wf_crm_webform_postprocess->processCases() (line 1290 of /home/vsiallianceorg/public_html/web/modules/contrib/webform_civicrm/includes/wf_crm_webform_postprocess.inc)

After
----------------------------------------
No error!

Comments
----------------------------------------
Olly can you please test/confirm this fixes things for you?