### PR TITLE
Support computed elements across multiple pages

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2470,8 +2470,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
   /**
    * Get or set a value from a webform submission
-   * During validation phase we use $this->crmValues
-   * During submission processing we use $this->submission
+   * Always use \Drupal\webform\WebformSubmissionInterface $webform_submission [more reliable according to JR]
    *
    * @param $fid
    *   Numeric webform component id
@@ -2481,34 +2480,22 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * @return array|null field value if found
    */
   protected function submissionValue($fid, $value = NULL) {
-    // In submission processing context
-    if ($this->submission) {
-      $data = $this->submission->getData();
-      if (!isset($data[$fid])) {
-        return NULL;
-      }
-      // Expects an array.
-      $field = (array) $data[$fid];
-      // During submission preprocessing this is used to alter the submission
-      if ($value !== NULL) {
-        $field = (array) $value;
-      }
-      return $field;
+    $form_object = $this->form_state->getFormObject();
+    /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
+    $webform_submission = $form_object->getEntity();
+    $data = $webform_submission->getData();
+
+    if (!isset($data[$fid])) {
+      return NULL;
     }
-    // In validation context - no need to ever change the value so just return it
-    else {
-      if (!isset($this->rawValues[$fid])) {
-        return NULL;
-      }
-      // rawValues is slightly different from submission->data in that empty values are present in arrays
-      if (is_array($this->rawValues[$fid])) {
-        $val = array_filter($this->rawValues[$fid]);
-        return $val;
-      }
-      else {
-        return (array) $this->rawValues[$fid];
-      }
+
+    // Expects an array.
+    $field = (array) $data[$fid];
+    // During submission preprocessing this is used to alter the submission
+    if ($value !== NULL) {
+      $field = (array) $value;
     }
+    return $field;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Refactors `submissionValue()` -> a more reliable way to retrieve form data between pages.

D8
----------------------------------------
D8 only

Before
----------------------------------------
Computed Twig element values don't make it onto the next page to be (in this example) included in the LineItem summary table.

![image](https://user-images.githubusercontent.com/5340555/88459234-1187b280-ce51-11ea-8234-7f8a1cf95d84.png)

After
----------------------------------------
JR assist -> It is more reliable to use the processed submission data. I did not realize this also works between pages -> but it does! Tested -> Computed Twig element value does make it into the LineItem summary table.

We've seen a couple of bug reports from people re: not retaining values across pages. I suspect this refactoring could very well help address these as well.

Comments
----------------------------------------
Could use some more testing! To reproduce: you must change the computed element value (in this example by changing the date of birth);

Technical
----------------------------------------

Form YAML for Computed Twig elements in example:

```
  age:
    '#type': computed_twig
    '#title': Age
    '#template': '{{ (''now''|date(''Y'')) - (data.civicrm_1_contact_1_contact_birth_date|date(''Y'')) }}'
    '#store': true
    '#ajax': true
  civicrm_1_participant_1_participant_fee_amount:
    '#type': computed_twig
    '#title': 'Participant Fee'
    '#template': '{% if data.age.__toString > 40 %}{{ 80 }}{% else %}{{ 99 }}{% endif %}'
    '#store': true
    '#ajax': true
    '#form_key': civicrm_1_participant_1_participant_fee_amount
    '#parent': civicrm_1_contact_1_fieldset_fieldset

```