### PR TITLE
Tooltip refactor

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -310,7 +310,7 @@ function wf_crm_contact_component_form_help(&$form) {
     if (is_array($form[$element])) {
       wf_crm_contact_component_form_help($form[$element]);
       if (method_exists('wf_crm_admin_help', "contact_component_$element")) {
-        wf_crm_admin_help::addHelp($form[$element], "contact_component_$element");
+        wf_crm_admin_help::addHelpDescription($form[$element], "contact_component_$element");
       }
     }
   }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -204,14 +204,6 @@ class wf_crm_admin_form {
     $this->form['nid'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable CiviCRM Processing'),
-      // '#description' => t('Create anything from a simple newsletter signup, to a complex multi-step registration system.
-      //   </p><strong> Getting Started:
-      //   </strong><ul>
-      //   <li>Enable fields for one or more contacts.</li>
-      //   <li>Arrange and configure those fields on the "Webform" tab.</li>
-      //   <li>Click the blue help icons to learn more.</li>
-      //   <li>Read the instructions: <a href="https://docs.civicrm.org/webform-civicrm/en/latest/" target="_blank">Click here!</a></li>
-      //   </ul>'),
       '#default_value' => $has_handler->count(),
     );
     $this->help($this->form['nid'], 'intro');
@@ -255,7 +247,6 @@ class wf_crm_admin_form {
       '#type' => 'textfield',
       '#title' => t('Label'),
       '#default_value' => wf_crm_contact_label($n, $this->data, 'plain'),
-      '#description' => t('Labels help you keep track of the role of each contact on the form. For example, you might label Contact 1 "Parent", Contact 2 "Spouse" and Contact 3 "Child".') . '<br /><br />' . t('Labels do not have to be shown to the end-user. By default they will be the title of each contact\'s fieldset, but you may rename (or remove) fieldsets without affecting this label..'),
       '#suffix' => '</div>',
     );
     $this->help($this->form['contact_' . $n][$n . '_webform_label'], 'webform_label', t('Contact Label'));
@@ -405,11 +396,6 @@ class wf_crm_admin_form {
           '#prefix' => '<div class="number-of">',
           '#suffix' => '</div>',
           '#default_value' => wf_crm_aval($this->data['contact'][$n], 'matching_rule', 'Unsupervised', TRUE),
-          // '#description' => t('This determines how an <em>unknown</em> contact will be handled when the webform is submitted. <br /><ul>
-          //    <li>Select the "Default Unsupervised" rule for the same duplicate matching used by CiviCRM event registration &amp contribution forms</li>
-          //    <li>Select a specific rule to customize how matching is performed</li>
-          //    <li>Or select "- None -" to always create a new contact</li>
-          //    </ul>Note: Matching rules are only used if the contact is not already selected via "Existing Contact" field.'),
         ];
         $rule_field =& $this->form['contact_' . $n]['contact_subtype_wrapper']["contact_{$n}_settings_matching_rule"];
         // Reset to default if selected rule doesn't exist or isn't valid for this contact type

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -204,16 +204,17 @@ class wf_crm_admin_form {
     $this->form['nid'] = array(
       '#type' => 'checkbox',
       '#title' => t('Enable CiviCRM Processing'),
-      '#description' => t('Create anything from a simple newsletter signup, to a complex multi-step registration system.
-        </p><strong> Getting Started:
-        </strong><ul>
-        <li>Enable fields for one or more contacts.</li>
-        <li>Arrange and configure those fields on the "Webform" tab.</li>
-        <li>Click the blue help icons to learn more.</li>
-        <li>Read the instructions: <a href="https://docs.civicrm.org/webform-civicrm/en/latest/" target="_blank">Click here!</a></li>
-        </ul>'),
+      // '#description' => t('Create anything from a simple newsletter signup, to a complex multi-step registration system.
+      //   </p><strong> Getting Started:
+      //   </strong><ul>
+      //   <li>Enable fields for one or more contacts.</li>
+      //   <li>Arrange and configure those fields on the "Webform" tab.</li>
+      //   <li>Click the blue help icons to learn more.</li>
+      //   <li>Read the instructions: <a href="https://docs.civicrm.org/webform-civicrm/en/latest/" target="_blank">Click here!</a></li>
+      //   </ul>'),
       '#default_value' => $has_handler->count(),
     );
+    $this->help($this->form['nid'], 'intro');
     $this->form['number_of_contacts'] = array(
       '#type' => 'select',
       '#title' => t('Number of Contacts'),
@@ -257,10 +258,7 @@ class wf_crm_admin_form {
       '#description' => t('Labels help you keep track of the role of each contact on the form. For example, you might label Contact 1 "Parent", Contact 2 "Spouse" and Contact 3 "Child".') . '<br /><br />' . t('Labels do not have to be shown to the end-user. By default they will be the title of each contact\'s fieldset, but you may rename (or remove) fieldsets without affecting this label..'),
       '#suffix' => '</div>',
     );
-    /*
-     * @todo remove private function help()
-     $this->help($this->form['contact_' . $n][$n . '_webform_label'], 'webform_label', t('Contact Label'));
-     */
+    $this->help($this->form['contact_' . $n][$n . '_webform_label'], 'webform_label', t('Contact Label'));
     $this->addAjaxItem('contact_' . $n, $n . '_contact_type', 'contact_subtype_wrapper', 'contact-subtype-wrapper');
 
     // Contact sub-type
@@ -407,17 +405,18 @@ class wf_crm_admin_form {
           '#prefix' => '<div class="number-of">',
           '#suffix' => '</div>',
           '#default_value' => wf_crm_aval($this->data['contact'][$n], 'matching_rule', 'Unsupervised', TRUE),
-          '#description' => t('This determines how an <em>unknown</em> contact will be handled when the webform is submitted. <br /><ul>
-             <li>Select the "Default Unsupervised" rule for the same duplicate matching used by CiviCRM event registration &amp contribution forms</li>
-             <li>Select a specific rule to customize how matching is performed</li>
-             <li>Or select "- None -" to always create a new contact</li>
-             </ul>Note: Matching rules are only used if the contact is not already selected via "Existing Contact" field.'),
+          // '#description' => t('This determines how an <em>unknown</em> contact will be handled when the webform is submitted. <br /><ul>
+          //    <li>Select the "Default Unsupervised" rule for the same duplicate matching used by CiviCRM event registration &amp contribution forms</li>
+          //    <li>Select a specific rule to customize how matching is performed</li>
+          //    <li>Or select "- None -" to always create a new contact</li>
+          //    </ul>Note: Matching rules are only used if the contact is not already selected via "Existing Contact" field.'),
         ];
         $rule_field =& $this->form['contact_' . $n]['contact_subtype_wrapper']["contact_{$n}_settings_matching_rule"];
         // Reset to default if selected rule doesn't exist or isn't valid for this contact type
         if (!array_key_exists($rule_field['#default_value'], $rule_field['#options'])) {
           $rule_field['#default_value'] = $this->form_state['input']["contact_{$n}_settings_matching_rule"] = 'Unsupervised';
         }
+        $this->help($rule_field, 'matching_rule');
       }
     }
   }

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1901,7 +1901,7 @@ class wf_crm_admin_form {
   }
 
   private function help(&$field, $topic, $title = NULL) {
-    \wf_crm_admin_help::addHelp($field, $topic, $title);
+    \wf_crm_admin_help::addHelpDescription($field, $topic, $title);
   }
 
   /**

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -13,6 +13,19 @@ use Drupal\webform_civicrm\Utils;
  */
 class wf_crm_admin_help {
 
+  public static function intro() {
+    return '<p>' .
+      t('Create anything from a simple newsletter signup, to a complex multi-step registration system.') .
+      '</p><strong>' .
+      t('Getting Started:') .
+      '</strong><ul>' .
+      '<li>' . t('Enable fields for one or more contacts.') . '</li>' .
+      '<li>' . t('Arrange and configure those fields on the "Webform" tab.') . '</li>' .
+      '<li>' . t('Click the blue help icons to learn more.') . '</li>' .
+      '<li><a href="https://docs.civicrm.org/sysadmin/en/latest/integration/drupal/webform/" target="_blank">' . t('Read the instructions.') . '</a></li>' .
+      '</ul>';
+  }
+
   public static function contact_existing() {
     return '<p>' .
       t('Gives many options for how this contact can be autofilled or selected. From the Webform tab you can edit this field to configure:') .'</p><ul>' .
@@ -65,6 +78,18 @@ class wf_crm_admin_help {
     self::contact_contact_id();
   }
 
+  public static function matching_rule() {
+    return '<p>' .
+      t('This determines how an <em>unknown</em> contact will be handled when the webform is submitted.') .
+      '</p><ul>' .
+      '<li>' . t('Select the "Default Unsupervised" rule for the same duplicate matching used by CiviCRM event registration &amp contribution forms.') . '</li>' .
+      '<li>' . t('Select a specific rule to customize how matching is performed.') . '</li>' .
+      '<li>' . t('Or select "- None -" to always create a new contact.') . '</li>' .
+      '</ul><p>' .
+      t('Note: Matching rules are only used if the contact is not already selected via "Existing Contact" field.') .
+      '</p>';
+  }
+
   public static function address_street_address() {
     return '<p>' .
       t('Single field for whole address line: Street Name, Number and Number Suffix. Don\'t use together with the separate fields.') .
@@ -100,8 +125,16 @@ class wf_crm_admin_help {
 
   public static function contribution_contribution_page_id() {
     return '<p>' .
-      t("It is recommended to <a !link>create a new contribution page</a> solely for webform use. When configuring the page, most options will be irrelevant (such as profiles, premiums, widgets, recurring, etc.). Only the following need to be configured:",
-        array('!link' => 'target="_blank" href="' . Url::fromUri('internal:/civicrm/admin/contribute/add', array('query' => array('reset' => 1, 'action' => 'add')))->toString() . '"')) .
+      t('It is recommended to <a href=":link">create a new contribution page</a> 
+      solely for webform use. When configuring the page, most options will be 
+      irrelevant (such as profiles, premiums, widgets, recurring, etc.). Only 
+      the following need to be configured:',
+      array(
+        ':link' => Url::fromUri(
+            'internal:/civicrm/admin/contribute/add', 
+            array('query' => array('reset' => 1, 'action' => 'add'))
+          )->toString()
+      )) .
       '</p><ul>' .
       '<li>' . t('Title: Displayed on the webform.') . '</li>' .
       '<li>' . t('Financial Type: Controls overall contribution type.') . '</li>' .
@@ -255,8 +288,14 @@ class wf_crm_admin_help {
 
   public static function reg_options_title_display() {
     return '<p>' .
-      t('Controls how events are displayed. Date formats can be further configured in <a !link>CiviCRM Date Settings</a>',
-        array('!link' => 'target="_blank" href="' . Url::fromUri('internal:/civicrm/admin/setting/date', array('query' => array('reset' => 1)))->toString() . '"')
+      t('Controls how events are displayed. Date formats can be further configured in 
+        <a href=":link">CiviCRM Date Settings</a>',
+        array(
+          ':link' => Url::fromUri(
+              'internal:/civicrm/admin/setting/date', 
+              array('query' => array('reset' => 1))
+            )->toString()
+        )
       ) .
       '</p><p>' .
       t('Note: End-date will automatically be omitted if it is the same as the start-date.') .
@@ -299,6 +338,14 @@ class wf_crm_admin_help {
       t('Click the + button to select more than one option.') .
       '</p><p>' .
       t('You may set options here and/or add this element to the webform ("User Select"). Options chosen here will be applied automatically and will not appear on the form.') .
+      '</p>';
+  }
+
+  public static function webform_label() {
+    return '<p>' .
+      t('Labels help you keep track of the role of each contact on the form. For example, you might label Contact 1 "Parent", Contact 2 "Spouse" and Contact 3 "Child".') .
+      '</p><p>' .
+      t("Labels do not have to be shown to the end-user. By default they will be the title of each contact's fieldset, but you may rename (or remove) fieldsets without affecting this label.") .
       '</p>';
   }
 

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -207,6 +207,34 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function reg_options_validate() {
+    return '<p>' .
+      t('Will not allow the form to be submitted if user registers for an event that is ended or full.') .
+      '</p>';
+  }
+
+  public static function reg_options_block_form() {
+    return '<p>' .
+      t('Hide webform if all the events for the form are full or ended.') .
+      '</p>';
+  }
+
+  public static function reg_options_disable_unregister() {
+    return '<p>' .
+      t('If this is selected, on "User Select mode", participants will not be unregistered from unchecked events.') .
+      '</p>';
+  }
+
+  public static function reg_options_allow_url_load() {
+    return '<p>' .
+      t('Allow events in "User Select" mode to be auto-filled from URL.') .
+      '</p>'.'<br /><p>'.t('Example for "Register all":') .
+      '<br /><code>' . Url::fromUri("internal:/node", array('absolute' => TRUE))->toString() . '/{node.nid}?event1={event1.event_id},{event2.event_id}</code></p><br />'.
+      t('Example for "Register separately":') .
+      '<br /><code>' . Url::fromUri("internal:/node", array('absolute' => TRUE))->toString() .
+      '/{node.nid}?c1event1={event1.event_id},{event2.event_id}&amp;c2event1={event3.event_id}</code></p>';
+  }
+
   public static function reg_options_show_past_events() {
     return '<p>' .
       t('To also display events that have ended, choose an option for how far in the past to search.') .
@@ -503,5 +531,4 @@ function wf_crm_admin_help($topic) {
   elseif (strpos($topic, 'fieldset_') === 0) {
     return wf_crm_admin_help::fieldset($topic);
   }
-  //exit();
 }

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -1,5 +1,6 @@
 <?php
 use Drupal\Core\Url;
+use Drupal\webform_civicrm\Utils;
 
 /**
  * @file
@@ -288,7 +289,7 @@ class wf_crm_admin_help {
   }
 
   public static function activity_assignee_contact_id() {
-    civicrm_initialize();
+    \Drupal::service('civicrm')->initialize();
     print '<p>';
     if (wf_crm_get_civi_setting('activity_assignee_notification')) {
       print t('A copy of this activity will be emailed to the assignee.');
@@ -421,7 +422,7 @@ class wf_crm_admin_help {
     if (!is_numeric($id)) {
       return;
     }
-    civicrm_initialize();
+    \Drupal::service('civicrm')->initialize();
     $help = '';
     \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/utils');
     $info = wf_civicrm_api('custom_field', 'getsingle', array('id' => $id));
@@ -439,13 +440,14 @@ class wf_crm_admin_help {
    */
   public static function fieldset($param) {
     list( , $set) = explode('_', $param);
-    civicrm_initialize();
+    \Drupal::service('civicrm')->initialize();
     $help = '';
     \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/utils');
-    $sets = wf_crm_get_fields('sets');
+    $sets = Utils::wf_crm_get_fields('sets');
     if (!empty($sets[$set]['help_text'])) {
       $help .= '<p>' . $sets[$set]['help_text'] . '</p>';
     }
+    return $help;
   }
 
   /**

--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -1,4 +1,5 @@
 <?php
+use Drupal\Core\Url;
 
 /**
  * @file
@@ -12,7 +13,7 @@
 class wf_crm_admin_help {
 
   public static function contact_existing() {
-    print '<p>' .
+    return '<p>' .
       t('Gives many options for how this contact can be autofilled or selected. From the Webform tab you can edit this field to configure:') .'</p><ul>' .
       '<li>' . t('Widget: Determine whether to expose this field to the form as an autocomplete or select element, or hide it and pick the contact automatically.') . '</li>' .
       '<li>' . t('Default Value: Select a contact based on the current user, relationships, or other options.') . '</li>' .
@@ -22,7 +23,7 @@ class wf_crm_admin_help {
   }
 
   public static function contact_employer_id() {
-    print '<p>' .
+    return '<p>' .
       t('Choose a webform contact of type "Organization" to be the employer for this individual.') .
       '</p><p>' .
       t('Use the "Existing Contact" field for that organization to enable autocomplete or selection of employers.') .
@@ -32,19 +33,19 @@ class wf_crm_admin_help {
   }
 
   public static function contact_image_URL() {
-    print '<p>' .
+    return '<p>' .
       t('Allows an image to be associated with a contact. This image will appear in CiviCRM, but the file is stored in Drupal. If the webform submission or entire webform were to be deleted, the image would be lost.') .
       '</p>';
   }
 
   public static function contact_contact_id() {
-    print '<p>' .
+    return '<p>' .
       t('This read-only field can be used to as a token to generate links, for example to include an email link back to this form to update their info.') .
       '</p>';
   }
 
   public static function contact_user_id() {
-    print '<p>' .
+    return '<p>' .
       t("This read-only field will load the contact's drupal user id. Works even for anonymous users following a checksum.") .
       '</p>';
   }
@@ -54,7 +55,7 @@ class wf_crm_admin_help {
   }
 
   public static function contact_source() {
-    print '<p>' .
+    return '<p>' .
       t('This field will override the "Source Label" in "Additional Options".') .
       '</p>';
   }
@@ -64,31 +65,31 @@ class wf_crm_admin_help {
   }
 
   public static function address_street_address() {
-    print '<p>' .
+    return '<p>' .
       t('Single field for whole address line: Street Name, Number and Number Suffix. Don\'t use together with the separate fields.') .
       '</p>';
   }
 
   public static function address_street_name() {
-    print '<p>' .
+    return '<p>' .
       t('Use together with Street Number and Street Number Suffix as an alternative for Street Address.') .
       '</p>';
   }
 
   public static function address_street_number() {
-    print '<p>' .
+    return '<p>' .
       t('Use together with Street Name and Street Number Suffix as an alternative for Street Address.') .
       '</p>';
   }
 
   public static function address_street_unit() {
-    print '<p>' .
+    return '<p>' .
       t('Use together with Street Name and Street Number as an alternative for Street Address.') .
       '</p>';
   }
 
   public static function address_master_id() {
-    print '<p>' .
+    return '<p>' .
       t('When selected, will hide fields for this address and use those of the other contact.') .
       '</p><p>' .
       t('Tip: In many use-cases it is desirable to show this field as a single checkbox. You can configure that by editing the field and removing all but one option (the one this contact is allowed to share) and re-labelling it something like "Same as my address".') .
@@ -97,9 +98,9 @@ class wf_crm_admin_help {
 
 
   public static function contribution_contribution_page_id() {
-    print '<p>' .
+    return '<p>' .
       t("It is recommended to <a !link>create a new contribution page</a> solely for webform use. When configuring the page, most options will be irrelevant (such as profiles, premiums, widgets, recurring, etc.). Only the following need to be configured:",
-        array('!link' => 'target="_blank" href="' . url('civicrm/admin/contribute/add', array('query' => array('reset' => 1, 'action' => 'add'))) . '"')) .
+        array('!link' => 'target="_blank" href="' . Url::fromUri('internal:/civicrm/admin/contribute/add', array('query' => array('reset' => 1, 'action' => 'add')))->toString() . '"')) .
       '</p><ul>' .
       '<li>' . t('Title: Displayed on the webform.') . '</li>' .
       '<li>' . t('Financial Type: Controls overall contribution type.') . '</li>' .
@@ -111,7 +112,7 @@ class wf_crm_admin_help {
   }
 
   public static function contribution_payment_processor_id() {
-    print '<p>' .
+    return '<p>' .
       t('Supported payment processors enabled on the contribution page are available here. "Pay Later" option allows the user to purchase events/memberships without entering a credit card.') .
       '</p><p>' .
       t("Note that only on-site credit card processors are currently supported on Webforms. Services that redirect to an external website, such as Paypal Standard, are not supported. Recurring payments are not supported.") .
@@ -119,35 +120,35 @@ class wf_crm_admin_help {
   }
 
   public static function contribution_total_amount() {
-    print '<p>' .
+    return '<p>' .
       t('This amount will be in addition to any paid events and memberships.') .
       '</p>';
     self::fee();
   }
 
   public static function contribution_frequency_unit() {
-    print '<p>' .
+    return '<p>' .
       t('Frequency of Installments. ') .
       t('Set the frequency for the installments - options are: day, week, month, year - or make this a user-select element on the webform.') .
       '</p>';
   }
 
   public static function contribution_installments() {
-    print '<p>' .
+    return '<p>' .
       t('Number of Installments. ') .
       t('Create a webform element that allows the Number of Installments to be specified: for example - total amount is paid in 10 installments. For a Contribution of unspecified duration/commitment use installments = 0.') .
       '</p>';
   }
 
   public static function contribution_frequency_interval() {
-    print '<p>' .
+    return '<p>' .
       t('Interval of Installments. ') .
       t('Create a webform elements that allows the Interval of Installments to be specified: for example - every second (month).') .
       '</p>';
   }
 
   public static function participant_fee_amount() {
-    print '<p>' .
+    return '<p>' .
       t('Price for this event. If multiple events or participants are registered with this field, the amount will be multiplied per-person, per-event.') .
       '</p><p>' .
       t('Note that any event prices you have configured in CiviCRM are not imported into the Webform - you will need to reconfigure them here.') .
@@ -156,7 +157,7 @@ class wf_crm_admin_help {
   }
 
   public static function fee() {
-    print '<p>' .
+    return '<p>' .
       t('Once added to the webform, this field can be configured in a number of ways by changing its settings.') .
       '</p><strong>' .
       t('Possible Widgets:') .
@@ -170,7 +171,7 @@ class wf_crm_admin_help {
   }
 
   public static function participant_reg_type() {
-    print '<p>' .
+    return '<p>' .
       t('Registering as a group will set Contact 1 as the primary registrant. Registering participants separately gives finer control over which contacts register for what events.') .
       '</p><p>' .
       t('With only one contact on the form, there is no difference between these two options.') .
@@ -178,7 +179,7 @@ class wf_crm_admin_help {
   }
 
   public static function participant_event_id() {
-    print '<p>' .
+    return '<p>' .
       t('Events can be selected here without giving the user a choice, or this field can be added to the form ("User Select").') .
       '</p><p>' .
       t('Click the + button to choose multiple events.') .
@@ -190,7 +191,7 @@ class wf_crm_admin_help {
   }
 
   public static function participant_status_id() {
-    print '<ul><li>' .
+    return '<ul><li>' .
       t('In "Automatic" mode, status will be set to "Registered" (or "Pending" if the user chooses to "Pay Later" for events with a fee). The user will be able to cancel registration by re-visiting the form and de-selecting any events they are registered for.') .
       '</li><li>' .
       t('If a status is selected here, events will be autofilled only if the participant has that status.') .
@@ -200,61 +201,33 @@ class wf_crm_admin_help {
   }
 
   public static function reg_options_show_remaining() {
-    print '<p>' .
+    return '<p>' .
       t('Display a message at the top of the form for each event with a registration limit or past end date.') .
       '</p>';
   }
 
-  public static function reg_options_validate() {
-    print '<p>' .
-      t('Will not allow the form to be submitted if user registers for an event that is ended or full.') .
-      '</p>';
-  }
-
-  public static function reg_options_block_form() {
-    print '<p>' .
-      t('Hide webform if all the events for the form are full or ended.') .
-      '</p>';
-  }
-
-  public static function reg_options_disable_unregister() {
-    print '<p>' .
-      t('If this is selected, on "User Select mode", participants will not be unregistered from unchecked events.') .
-      '</p>';
-  }
-
-  public static function reg_options_allow_url_load() {
-    print '<p>' .
-      t('Allow events in "User Select" mode to be auto-filled from URL.') .
-      '</p>'.'<br /><p>'.t('Example for "Register all":') .
-      '<br /><code>' . url("node", array('absolute' => TRUE)) . '/{node.nid}?event1={event1.event_id},{event2.event_id}</code></p><br />'.
-      t('Example for "Register separately":') .
-      '<br /><code>' . url("node", array('absolute' => TRUE)) .
-      '/{node.nid}?c1event1={event1.event_id},{event2.event_id}&amp;c2event1={event3.event_id}</code></p>';
-  }
-
   public static function reg_options_show_past_events() {
-    print '<p>' .
+    return '<p>' .
       t('To also display events that have ended, choose an option for how far in the past to search.') .
       '</p>';
   }
 
   public static function reg_options_show_future_events() {
-    print '<p>' .
+    return '<p>' .
       t('To also display events in the future, choose an option for how far in the future to search.') .
       '</p>';
   }
 
   public static function reg_options_show_public_events() {
-    print '<p>' .
+    return '<p>' .
       t('Choose whether to display events marked as Public, Private or all.') .
       '</p>';
   }
 
   public static function reg_options_title_display() {
-    print '<p>' .
+    return '<p>' .
       t('Controls how events are displayed. Date formats can be further configured in <a !link>CiviCRM Date Settings</a>',
-        array('!link' => 'target="_blank" href="' . url('civicrm/admin/setting/date', array('query' => array('reset' => 1))) . '"')
+        array('!link' => 'target="_blank" href="' . Url::fromUri('internal:/civicrm/admin/setting/date', array('query' => array('reset' => 1)))->toString() . '"')
       ) .
       '</p><p>' .
       t('Note: End-date will automatically be omitted if it is the same as the start-date.') .
@@ -262,19 +235,19 @@ class wf_crm_admin_help {
   }
 
   public static function membership_membership_type_id() {
-    print '<p>' .
+    return '<p>' .
       t('Fee will be calculated automatically based on selected membership type and number of terms chosen. A contribution page must be enabled to collect fees.') .
       '</p>';
   }
 
   public static function membership_status_id() {
-    print '<p>' .
+    return '<p>' .
       t('If number of terms is enabled, status can be calculated automatically based on new/renewal status and payment.') .
       '</p>';
   }
 
   public static function membership_num_terms() {
-    print '<p>' .
+    return '<p>' .
       t('Membership dates will be filled automatically by selecting terms. This can be overridden by entering dates manually.') .
       '</p><p>' .
       t('Note: Number of terms is required to calculate membership fees for paid memberships.') .
@@ -284,7 +257,7 @@ class wf_crm_admin_help {
   }
 
   public static function membership_fee_amount() {
-    print '<p>' .
+    return '<p>' .
       t('Price for this membership per term. If this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .
       '</p><p>' .
       t('Note that if this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .
@@ -293,7 +266,7 @@ class wf_crm_admin_help {
   }
 
   public static function multiselect_options() {
-    print '<p>' .
+    return '<p>' .
       t('Click the + button to select more than one option.') .
       '</p><p>' .
       t('You may set options here and/or add this element to the webform ("User Select"). Options chosen here will be applied automatically and will not appear on the form.') .
@@ -301,14 +274,14 @@ class wf_crm_admin_help {
   }
 
   public static function activity_target_contact_id() {
-    print '<p>' .
+    return '<p>' .
       t('Which contacts should be tagged as part of this activity?') .
       '</p>';
     self::contact_reference();
   }
 
   public static function activity_source_contact_id() {
-    print '<p>' .
+    return '<p>' .
       t('Choose "automatic" to have this activity attributed to the current user (or contact 1 if the user is anonymous).') .
       '</p>';
     self::contact_reference();
@@ -328,13 +301,13 @@ class wf_crm_admin_help {
   }
 
   public static function activity_duration() {
-    print '<p>' .
+    return '<p>' .
       t('Total time spent on this activity (in minutes).') .
       '</p>';
   }
 
   public static function existing_activity_status() {
-    print '<p>' .
+    return '<p>' .
       t('If a matching activity of the chosen type already exists for Contact 1, it will be autofilled and updated.') .
       '</p><p>' .
       t('Note: an activity can also be autofilled by passing "activity1", etc. in the url.') .
@@ -342,7 +315,7 @@ class wf_crm_admin_help {
   }
 
   public static function existing_case_status() {
-    print '<p>' .
+    return '<p>' .
       t('If a matching case of the chosen type already exists for the client, it will be autofilled and updated.') .
       '</p><p>' .
       t('Note: a case can also be autofilled by passing "case1", etc. in the url.') .
@@ -350,7 +323,7 @@ class wf_crm_admin_help {
   }
 
   public static function duplicate_case_status() {
-    print '<p>' .
+    return '<p>' .
       t('Choosing this option means a new case will always be created even when an existing case has been selected. If an existing case has been selected the data for this case will NOT be updated.') .
       '</p><p>' .
       t('Useful if you want to pre-fill a form with existing case data, allow the user to make updates and then create a new case with their updates.') .
@@ -360,7 +333,7 @@ class wf_crm_admin_help {
   }
 
   public static function existing_grant_status() {
-    print '<p>' .
+    return '<p>' .
       t('If a matching grant of the chosen type already exists for the applicant, it will be autofilled and updated.') .
       '</p><p>' .
       t('Note: a grant can also be autofilled by passing "grant1", etc. in the url.') .
@@ -368,7 +341,7 @@ class wf_crm_admin_help {
   }
 
   public static function file_on_case() {
-    print '<p>' .
+    return '<p>' .
       t('Add this activity to either a specific case from this webform, or an already existing case based on matching criteria.') .
       '</p><p>' .
       t('These options will not open a new case; configure the "Cases" section to do so.') .
@@ -376,13 +349,13 @@ class wf_crm_admin_help {
   }
 
   public static function case_medium_id() {
-    print '<p>' .
+    return '<p>' .
       t('Medium for activities added to cases from this webform.') .
       '</p>';
   }
 
   public static function contact_reference() {
-    print '<p>' .
+    return '<p>' .
       t('This is a contact reference field. Webform gives you a great deal of flexibility about how this field is displayed:') .
       '</p><ul>' .
       '<li>' . t('First choose a contact on this webform as the target for this field (or add a new contact to the form for that purpose).') . '</li>' .
@@ -394,7 +367,7 @@ class wf_crm_admin_help {
   }
 
   public static function fieldset_relationship() {
-    print '<p>' .
+    return '<p>' .
       t('Relationships are created from higher-number contacts to lower-number contacts.') .
       '</p><p>' .
       t("Example: to create a relationship between Contact 3 and Contact 4, go to Contact 4's tab and select Number of Relationships: 3. This will give you the option to create relationships between Contact 4 and Contacts 1, 2, and 3, respectively.") .
@@ -402,7 +375,7 @@ class wf_crm_admin_help {
   }
 
   public static function contact_creation() {
-    print '<p>' .
+    return '<p>' .
       t('CiviCRM requires at minimum a name or email address to create a new contact.') .
       '</p><p>' .
       t("Webform contacts that do not have these fields can be used for selection of existing contacts but not creating new ones.") .
@@ -410,7 +383,7 @@ class wf_crm_admin_help {
   }
 
   public static function contact_component_widget() {
-    print '<ul>
+    return '<ul>
       <li>' . t('Autocomplete will suggest names of contacts as the user types. Good for large numbers of contacts.') . '</li>
       <li>' . t('A select list will show all possible contacts in a dropdown menu. Good for small lists - use filters.') . '</li>
       <li>' . t('A static element will select a contact automatically without giving the user a choice. Use in conjunction with a default value setting or a cid passed in the url.') . '</li>
@@ -419,7 +392,7 @@ class wf_crm_admin_help {
   }
 
   public static function contact_component_hide_fields() {
-    print '<p>' .
+    return '<p>' .
       t('When an existing contact is selected or prepopulated, which fields should the user not be allowed to edit?') .
       '</p><p>' .
       t("This is useful for preventing changes to existing data.") .
@@ -427,13 +400,13 @@ class wf_crm_admin_help {
   }
 
   public static function dynamic_custom() {
-    print '<p>' .
+    return '<p>' .
       t("This will add all fields from this custom group, and automatically update the webform whenever this group's custom fields are added, edited, or deleted in CiviCRM.") .
       '</p>';
   }
 
   public static function multivalue_fieldset_create_mode() {
-      print '<p>' .
+    return '<p>' .
         t("Create/ Edit Mode (Default): Pre-populate the existing entry (if any) in order to allow user modifying it. If there isn't any existing entry, any value entered into the fieldset will be created as a new entry.") .
         '<br><br>' .
         t("Create Only Mode: Any value entered into the fieldset will be created as a new entry without overwriting any existing record.") .
@@ -449,14 +422,16 @@ class wf_crm_admin_help {
       return;
     }
     civicrm_initialize();
+    $help = '';
     \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/utils');
     $info = wf_civicrm_api('custom_field', 'getsingle', array('id' => $id));
     if (!empty($info['help_pre'])) {
-      print '<p>' . $info['help_pre'] . '</p>';
+      $help .= '<p>' . $info['help_pre'] . '</p>';
     }
     if (!empty($info['help_post'])) {
-      print '<p>' . $info['help_post'] . '</p>';
+      $help .= '<p>' . $info['help_post'] . '</p>';
     }
+    return $help;
   }
 
   /**
@@ -465,10 +440,11 @@ class wf_crm_admin_help {
   public static function fieldset($param) {
     list( , $set) = explode('_', $param);
     civicrm_initialize();
+    $help = '';
     \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/utils');
     $sets = wf_crm_get_fields('sets');
     if (!empty($sets[$set]['help_text'])) {
-      print '<p>' . $sets[$set]['help_text'] . '</p>';
+      $help .= '<p>' . $sets[$set]['help_text'] . '</p>';
     }
   }
 
@@ -504,6 +480,11 @@ class wf_crm_admin_help {
   public static function helpIcon($topic, $title) {
     return '<span class="crm-container"><a class="helpicon" href="#' . $topic . '" title="' . $title .'">&nbsp;</a></span>';
   }
+
+  public static function addHelpDescription(&$field, $topic) {
+    $helpText = wf_crm_admin_help($topic);
+    if ($helpText) $field['#description'] = $helpText;
+  }
 }
 
 /**
@@ -512,13 +493,13 @@ class wf_crm_admin_help {
  */
 function wf_crm_admin_help($topic) {
   if (method_exists('wf_crm_admin_help', $topic)) {
-    wf_crm_admin_help::$topic();
+    return wf_crm_admin_help::$topic();
   }
   elseif (strpos($topic, 'custom_') === 0) {
-    wf_crm_admin_help::custom($topic);
+    return wf_crm_admin_help::custom($topic);
   }
   elseif (strpos($topic, 'fieldset_') === 0) {
-    wf_crm_admin_help::fieldset($topic);
+    return wf_crm_admin_help::fieldset($topic);
   }
-  exit();
+  //exit();
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is a an attempt to comprehensively incorporate old "civi-based" helptext into the admin form as Drupal #description array elements.  I found that the fieldsets that were dynamically build did not lend themselves to hardcoded #description elements, so I modified the old functions to return their values instead of printing them.  It seems to have taken effect globally, even on dynamically created fields and custom fields.

D7 or D8?
----------------------------------------
D8

Before
----------------------------------------
Previously, the fields all had relatively useless help icons:

![image](https://user-images.githubusercontent.com/52583757/88719842-e7085480-d0f1-11ea-8f61-2b3ea4c2a184.png)

After
----------------------------------------
Now, the old helptext shows on mouseover:

![image](https://user-images.githubusercontent.com/52583757/88719983-259e0f00-d0f2-11ea-9e97-0807b175847a.png)

Technical Details
----------------------------------------
The main changes were the addition of a new `addHelpDescription()` method to the `wf_crm_admin_help` module and changing all of its "helptext" functions to return their text instead of directly printing it.  I was then able to make a single change in `wf_crm_admin_form` to switch over to using `addHelpDescription()` instead of `addHelp()`

Comments
----------------------------------------
There are a few tooltips with URLs in them in `<code>` elements.  These tend to overflow the tooltip container.  I'm hoping a solution can be found to correct that.  I was unable to figure it out.

There appears to be a potentially significant amount of dead code in this module that should be removed.  For example, I'm not sure what parts of `includes/contact_component.inc` are used, but parts of it appear to be reimplemented in `src/Plugin/WebformElement/CivicrmContact.php`

An analysis for dead code would probably help with future refactoring work, as it's very confusing to me as a newcomer to the module.

Due to this confusion, I've tried to make the smallest amount of code changes possible in this first attempt at refactoring these tooltips.  I think a cleaner approach could be identified once some clean-up and refactoring has been done.