### PR TITLE
[WIP] - CATL-1562: Add start date to case role and record related case activity

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1298,12 +1298,31 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             if ($val && strpos($param, 'role_') === 0) {
               foreach ((array) $params['client_id'] as $client) {
                 foreach ((array) $val as $contactB) {
-                  wf_civicrm_api('relationship', 'create', [
+                  $parameters = [
                     'relationship_type_id' => substr($param, 5),
                     'contact_id_a' => $client,
                     'contact_id_b' => $contactB,
                     'case_id' => $result['id'],
-                  ]);
+                    'is_active' => TRUE,
+                  ];
+                  // Add case role if active case role does not exist.
+                  if (empty($relationship['count'])) {
+                    $parameters['start_date'] = 'now';
+                    $parameters['end_date'] = '';
+                    $relationship = wf_civicrm_api('relationship', 'create', $parameters);
+                    if (empty($relationship['is_error'])) {
+                      // Record 'Assign Case Role' Activity.
+                      $relationship_types = wf_crm_get_relationship_types();
+                      $relationship_type = $relationship_types[$parameters['relationship_type_id']]['label_a_b'];
+                      $contact_name = wf_crm_display_name($contactB);
+                      wf_civicrm_api('Activity', 'create', [
+                        'case_id' => $result['id'],
+                        'status_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_status_id', 'Completed'),
+                        'activity_type_id' => CRM_Core_PseudoConstant::getKey('CRM_Activity_BAO_Activity', 'activity_type_id', 'Assign Case Role'),
+                        'subject' => "{$contact_name} added as {$relationship_type}",
+                      ]);
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
Overview
----------------------------------------
Currently when trying to add the case role to a case using webform
1. **Start date** is not recorded with the case role.
2. **Case role activity** is not recorded in CiviCRM against the case.
As part of this PR, we are trying to sort both points mentioned above.

Before
----------------------------------------
![screenshot(5)](https://user-images.githubusercontent.com/7393885/88921828-ce807180-d28c-11ea-8c0b-0c44e06cc346.png)

![image](https://user-images.githubusercontent.com/7393885/88921989-11dae000-d28d-11ea-8320-111c3ef0cde3.png)

After
----------------------------------------
![screenshot(6)](https://user-images.githubusercontent.com/7393885/88921859-d93b0680-d28c-11ea-9d06-72912d7a6865.png)

![screenshot(7)](https://user-images.githubusercontent.com/7393885/88922157-5c5c5c80-d28d-11ea-9835-51743abb300f.png)


Technical Details
----------------------------------------
In `private function processCases()` the code to add case role already exists. Just modified it to do the following:
1. Add case role only if an active case role doesn't exist.
2. Add start date to the case role.
3. Also record related case role activity for the 'Assign Case Role' type.