### PR TITLE
Fix Custom Groups Missing for Contact Subtypes.

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -281,7 +281,7 @@ class wf_crm_admin_form {
         continue;
       }
       if (!empty($set['sub_types'])) {
-        if (!$subTypeIsUserSelect && !array_intersect($c['contact'][1]['contact_sub_type'], $set['sub_types'])) {
+        if (!$subTypeIsUserSelect && !array_intersect($c['contact'][1]['contact_sub_type'], array_map('strtolower', $set['sub_types']))) {
           continue;
         }
         $pos = &$this->form['contact_' . $n]['contact_subtype_wrapper']['contact_custom_wrapper'];


### PR DESCRIPTION
Overview
----------------------------------------
@bmango reported that Custom Fields defined on a Contact Subtype did not pop up in the Settings -> CiviCRM configuration screen.

D7 or D8?
----------------------------------------
D8 - but potentially useful for D7

Before
----------------------------------------
Select Client and no Custom Set would pop up :-(

After
----------------------------------------
Select Client and Custom Set pops up :-)
![image](https://user-images.githubusercontent.com/5340555/89111076-d405c500-d40e-11ea-9d4e-c75bebb8873f.png)

Technical Details
----------------------------------------
@jamie-tillman figured out that the array structure was different in https://github.com/colemanw/webform_civicrm/pull/322 

After digging in today I arrived at the conclusion that the array structure in D7/D8 is the same... Turns out it wasn't the array structure that was the issue -> it was the lower/uppercase difference that caused the `array_intersect` to failL Friend vs friend e.g.

Solution: make the `array_intersect` match regardless of whether the API returns Friend or friend, Client or client, Student or student!

Comments
----------------------------------------
