### PR TITLE
CATL-1034: Allow updating case type of an existing case

### DIFF
--- a/includes/wf_crm_admin_help.inc
+++ b/includes/wf_crm_admin_help.inc
@@ -372,6 +372,18 @@ class wf_crm_admin_help {
       '</p>';
   }
 
+  public static function case_case_type_id() {
+    print '<p>' .
+      t('You can select the case type for your case here, or configure this to be "User Select".') .
+      '</p><p>' .
+      t('When "User Select" is chosen a new Drupal field component will be added where you can configure the behaviour of this field in more detail.') .
+      '<p></p>' .
+      t('Also note that setting this field will update the case type of any cases which are autoloaded by the form. ').
+      t('This may have undesirable consequences in some situations where, for example, certain custom fields no longer exist on ').
+      t('the new case type and could lead to data being inaccessible within the CiviCase user interface after the case type has changed.').
+      '</p>';
+  }
+
   public static function existing_case_status() {
     print '<p>' .
       t('If a matching case of the chosen type already exists for the client, it will be autofilled and updated.') .

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1278,7 +1278,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         else {
           $params['id'] = $this->ent['case'][$n]['id'];
           // These params aren't allowed in update mode
-          unset($params['creator_id'], $params['case_type_id']);
+          unset($params['creator_id']);
         }
         // Allow "automatic" status to pass-thru
         if (empty($params['status_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Updating case type for an existing case is not possible using webform civicrm. As part of this PR we are making it possible to be able to update case types for a case using webform.

D7 or D8?
----------------------------------------
This PR is for D7

Before
----------------------------------------
![CATL-1034-before](https://user-images.githubusercontent.com/7393885/89532891-23cdfd00-d810-11ea-8bec-d825c405fd4f.gif)


After
----------------------------------------
![CATL-1034-after](https://user-images.githubusercontent.com/7393885/89532859-1a449500-d810-11ea-9124-9b267b09f14c.gif)

Also added help text:
![image](https://user-images.githubusercontent.com/7393885/91038775-f8794980-e628-11ea-8bef-c03c9060d705.png)


Technical Details
----------------------------------------
1. In function `processCases` the field `case_type_id` was unset when the case is updated, because of which it doesn't update case type in CiviCRM.
Removed the key to prevent it from getting unset.
2. Added help text for **case type** field using `public static function case_case_type_id()`

Comments
----------------------------------------