### PR TITLE
membership_activity_fix

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1189,7 +1189,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if (!empty($params['id'])) {
           $membership = $result['values'][$result['id']];
           $actParams = [
-            'source_record_id' => $result['id'],
+            'source_contact_id' => $cid,
             'activity_type_id' => 'Membership Renewal',
             'target_id' => $cid,
           ];


### PR DESCRIPTION
Overview
----------------------------------------
Error in Drupal log on Membership Renewal form. I believe this is a long time bug -> $result['id'] is a membership id, not a contact id.

D7
----------------------------------------
This is D7 - will need a port.

Before
----------------------------------------
`The CiviCRM "Activity create" API returned the error: "source_contact_id is not a valid integer" when called by function "preSave" on line 203 of wf_crm_webform_postprocess.inc with parameters: "Array ( [source_record_id] => 1032 [activity_type_id] => Membership Renewal [target_id] => 600 [subject] => Associate - Status: Current [check_permissions] => [version] => 3 ) "`

After
----------------------------------------
Should work now!

Technical Details
----------------------------------------

Comments
----------------------------------------
Client is currently testing/verifying this fix.