### PR TITLE
group_subscriptionnotice_fix

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -976,7 +976,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
       if ($confirmations_sent) {
-        \Drupal::messenger()->addStatus(t('A message has been sent to %email to confirm subscription to !group.', array('%email' => $email, '!group' => '<em>' . implode('</em> ' . t('and') . ' <em>', $confirmations_sent) . '</em>')));
+        \Drupal::messenger()->addStatus(t('A message has been sent to %email to confirm subscription to :group.', array('%email' => $email, ':group' => '' . implode('' . t('and') . '', $confirmations_sent) . '')));
       }
     }
     // Remove data from entity


### PR DESCRIPTION
Overview
----------------------------------------
This PR fixes the Group subscription notice displayed to the user after filling out a webform subscribing the user to a Group that has subscription 

D8
----------------------------------------
D8 only - small port fix.

Before
----------------------------------------
A message has been sent to email@example.com to confirm subscription to <<blank >> Group.

After
----------------------------------------
A message has been sent to email@example.com to confirm subscription to Our Newsletter Group.

