### PR TITLE
[WIP] - Decouple list of payment processors from contribution page.

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -75,6 +75,38 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table === 'contribution' && $name === 'payment_processor_id') {
+      // For the config form we display a list of all active (live) payment processors
+      // Saving will map the IDs to live or test.
+      // For the frontend we display the selected payment processors (with correct ID for live or test)
+      $params = wf_crm_aval($data, "$ent:$c:$table:$n", []);
+      if ($context === 'config_form') {
+        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'], 'is_active' => 1]);
+        $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
+        foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
+          $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
+        }
+        return $ret;
+      }
+      else {
+        $selectedPaymentProcessors = wf_crm_aval($params, "payment_processor_id", []);
+        if (in_array(0, $selectedPaymentProcessors)) {
+          $ret[0] = $field['exposed_empty_option'];
+        }
+        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', []);
+        $testPaymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => 1], 'name');
+        foreach ($selectedPaymentProcessors as $paymentProcessorID) {
+          if (array_key_exists((int) $paymentProcessorID, $paymentProcessors)) {
+            if (!empty($params['is_test'])) {
+              $paymentProcessorName = $paymentProcessors[$paymentProcessorID]['name'];
+              $paymentProcessorID = array_search($paymentProcessorName, $testPaymentProcessors);
+            }
+            $ret[$paymentProcessorID] = $paymentProcessors[$paymentProcessorID]['title'] ?? $paymentProcessors[$paymentProcessorID]['name'];
+          }
+        }
+        return $ret;
+      }
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = ['field' => $name, 'context' => 'create'];
@@ -106,14 +138,17 @@ function wf_crm_field_options($field, $context, $data) {
       }
     }
     // Remove options that were set behind the scenes on the admin form
-    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])) {
+    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])
+      && "{$table}_{$name}" !== 'contribution_payment_processor_id') {
       foreach (wf_crm_aval($data, "$ent:$c:$table:$n:$name", []) as $key => $val) {
         unset($ret[$key]);
       }
     }
   }
   if (!empty($field['exposed_empty_option'])) {
-    $ret = [0 => $field['exposed_empty_option']] + $ret;
+    if ($context === 'config_form' || ($context !== 'config_form' && "{$table}_{$name}" !== 'contribution_payment_processor_id')) {
+      $ret = [0 => $field['exposed_empty_option']] + $ret;
+    }
   }
   return $ret;
 }
@@ -1057,10 +1092,26 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Payment Processor'),
         'type' => 'select',
         'expose_list' => TRUE,
-        'extra' => ['aslist' => 0],
+        'extra' => [
+          'aslist' => 0,
+          'civicrm_live_options' => TRUE,
+          'required' => TRUE
+        ],
         'exposed_empty_option' => t('Pay Later'),
         'value_callback' => TRUE,
         'weight' => 9995,
+        'admin' => [
+          'disable_user_select' => TRUE,
+          'multiple' => TRUE,
+        ]
+      ];
+      $fields['contribution_is_test'] = [
+        'name' => t('Payment Processor Mode'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'weight' => 9996,
+        'disable_user_select' => TRUE,
       ];
       $fields['contribution_note'] = [
         'name' => t('Contribution Note'),
@@ -1085,14 +1136,6 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Honoree Type'),
         'type' => 'select',
         'expose_list' => TRUE,
-      ];
-      $fields['contribution_is_test'] = [
-        'name' => t('Payment Processor Mode'),
-        'type' => 'select',
-        'expose_list' => TRUE,
-        'extra' => ['civicrm_live_options' => 1],
-        'value' => 0,
-        'weight' => 9997,
       ];
       $fields['contribution_source'] = [
         'name' => t('Contribution Source'),

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -54,6 +54,10 @@ class wf_crm_admin_form {
     // Merge in existing fields
     $existing = array_keys(wf_crm_enabled_fields($this->node, NULL, TRUE));
     $this->settings += array_fill_keys($existing, 'create_civicrm_webform_element');
+    unset(
+      $this->settings['civicrm_1_contribution_1_contribution_payment_processor_id'],
+      $this->settings['civicrm_1_contribution_1_contribution_is_test']
+    );
 
     // Sort fields by set
     foreach ($this->fields as $fid => $field) {
@@ -1000,6 +1004,7 @@ class wf_crm_admin_form {
     $this->form['contribution'] = [
       '#type' => 'fieldset',
       '#title' => t('Contribution'),
+
       '#group' => 'webform_civicrm',
       '#description' => t('In order to process live transactions for events, memberships, or contributions, select a contribution page and its billing fields will be included on the webform.'),
       '#attributes' => ['class' => ['civi-icon-contribution']],
@@ -1311,7 +1316,8 @@ class wf_crm_admin_form {
       if (!empty($field['extra']['required'])) {
         $item['#attributes']['class'][] = 'required';
       }
-      if ($field['type'] != 'hidden') {
+
+      if (($field['type'] != 'hidden') && (empty($field['admin']['disable_user_select']))) {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
       $options += wf_crm_field_options($field, 'config_form', $this->data);
@@ -1669,7 +1675,9 @@ class wf_crm_admin_form {
 
           if (!isset($enabled[$key])) {
             $val = (array) $val;
-            if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
+            if (in_array('create_civicrm_webform_element', $val, TRUE)
+                || (!empty($val[0]) && $field['type'] == 'hidden')
+                || ((count($val) > 1) && (!empty($field['admin']['disable_user_select'])))) {
               // Restore disabled component
               if (isset($disabled[$key])) {
                 webform_component_update($disabled[$key]);
@@ -1825,7 +1833,8 @@ class wf_crm_admin_form {
       }
       else {
         $field = wf_crm_get_field($key);
-        if (!empty($val[0]) && $field['type'] == 'hidden') {
+        if ((!empty($val[0]) && $field['type'] == 'hidden')
+          ) {
           unset($fields[$key]);
         }
       }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -949,22 +949,4 @@ abstract class wf_crm_webform_base {
     return CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
   }
 
-  /**
-   * Historically webform_civicrm was configured with the live payment processor ID and the is_test flag.
-   * But this is not how CiviCRM expects it to work and this can cause problems where payments use the live processor
-   *   instead of test.  So we "fix" the processor ID here to be the correct one for live/test.
-   * An "improved" fix would involve changing the configuration saved by the user but this avoids that.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  protected function fixPaymentProcessorID() {
-    // Check for is_test and payment_processor_id (pay later = 0 is set to '' here. is_test has no meaning for pay later).
-    if (!empty($this->data['contribution'][1]['contribution'][1]['is_test'])
-        && !empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id'])) {
-      $paymentProcessor = \Civi\Payment\System::singleton()->getById($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
-      $paymentProcessor = \Civi\Payment\System::singleton()->getByName($paymentProcessor->getPaymentProcessor()['name'], TRUE);
-      $this->data['contribution'][1]['contribution'][1]['payment_processor_id'] = $paymentProcessor->getPaymentProcessor()['id'];
-    }
-  }
-
 }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -43,7 +43,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $this->node = $node;
     $this->settings = $node->webform_civicrm;
     $this->data = $this->settings['data'];
-    $this->fixPaymentProcessorID();
     $this->enabled = wf_crm_enabled_fields($node);
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -21,7 +21,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     $this->node = $form['#node'];
     $this->settings = $this->node->webform_civicrm;
     $this->data = $this->settings['data'];
-    $this->fixPaymentProcessorID();
     $this->ent['contact'] = [];
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');
@@ -214,6 +213,9 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       }
       else {
         $js_vars['paymentProcessor'] = $this->getData($fid);
+        if (is_array($js_vars['paymentProcessor'])) {
+          $js_vars['paymentProcessor'] = reset($js_vars['paymentProcessor']);
+        }
       }
     }
     if ($js_vars) {


### PR DESCRIPTION
Overview
----------------------------------------
Allow to select any active processor. Remove user_select on mode (live/test) and make sure that webform_civicrm always sends the correct (live or test) payment processor ID to CiviCRM.

This is work in progress per our discussion @KarinG.  `webform_civicrm` only actually uses about 4 parameters from a contribution_page and removing that dependency would allow for some pretty cool stuff like currency selection on the form etc.

D7 or D8?
----------------------------------------
D7, will port once finalised/agreed.

Before
----------------------------------------
Payment processor selection dependent on contribution page.

After
----------------------------------------
Payment processor selection not dependent on contribution page.

Technical Details
----------------------------------------
There are some specific complexities and issues here that we need some discussion on:
1. Test/Live processors. We *should* be passing the correct ID for the live/test processor when submitting the webform. However for multiple processors this isn't currently possible because the IDs are saved in the admin screen.
- Proposal: Remove "User select" for "Test mode/Live mode" and require it to be one or the other on the admin screen.

2. "User select" and multiple selections. These seem complex to implement at the moment and I'm trying to add some metadata to allow that. But it would be good to get some thoughts from the webform experts :-).
Using the (simpler) example of currency which is not in this PR:
a) You may select a single currency. This is easy and works with the admin UI we have.
b) You may select multiple currencies. This requires that a multiselect *without* "user select" is shown in the admin UI. Then a multi-select showing only the selected options is displayed on the form. I don't see a need to expose an "any" option in the admin UI though we could.
- You'll see in this PR I've added `'disable_user_select' => TRUE, 'multiple' => TRUE,` as admin metadata and that may be the right thing to do but I'd like agreement/alternatives. You'll also see it requires tweaks at various points in the code to make it work.

