### PR TITLE
Fix for Missing options for Contact Type, Relationship types etc.. on build Edit field section

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -50,13 +50,23 @@ class CivicrmSelectOptions extends FormElement {
     }
   }
 
-  protected static function getFieldOptions($form_key) {
+  protected static function getFieldOptions($form_key, $webform_id = NULL) {
     \Drupal::getContainer()->get('civicrm')->initialize();
     $field_options = \Drupal::service('webform_civicrm.field_options');
-    return $field_options->get(['form_key' => $form_key], 'create', []);
+    $data = [];
+    if (!empty($webform_id)) {
+      $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_id);
+      $handler_collection = $webform->getHandlers('webform_civicrm');
+      $handler = $handler_collection->get('webform_civicrm');
+      $settings = $handler->getConfiguration()['settings'];
+      $data = $settings['data'];
+    }
+    return $field_options->get(['form_key' => $form_key], 'create', $data);
   }
 
   public static function processSelectOptions(&$element, FormStateInterface $form_state, &$complete_form) {
+    $build_info = $form_state->getBuildInfo();
+    $webform_id = !empty($build_info['args'][0]) ? $build_info['args'][0]->id() : NULL;
     $element['#tree'] = TRUE;
     // Add validate callback that extracts the associative array of options.
     $element += ['#element_validate' => []];
@@ -109,7 +119,7 @@ class CivicrmSelectOptions extends FormElement {
 
     $current_options = $element['#default_value'];
     $weight = 0;
-    $field_options = static::getFieldOptions($element['#form_key']);
+    $field_options = static::getFieldOptions($element['#form_key'], $webform_id);
 
     // Sort the field options by the current options.
     if (!$element['#live_options']) {
@@ -183,7 +193,9 @@ class CivicrmSelectOptions extends FormElement {
    */
   public static function validateSelectOptions(&$element, FormStateInterface $form_state, &$complete_form) {
     if ($element['#live_options']) {
-      $options_value = self::getFieldOptions($element['#form_key']);
+      $build_info = $form_state->getBuildInfo();
+      $webform_id = !empty($build_info['args'][0]) ? $build_info['args'][0]->id() : NULL;
+      $options_value = self::getFieldOptions($element['#form_key'], $webform_id);
     }
     else {
       $raw_values = $form_state->getValue($element['options']['#parents']);

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -199,7 +199,18 @@ class CivicrmOptions extends WebformElementBase {
   protected function getFieldOptions($element) {
     \Drupal::getContainer()->get('civicrm')->initialize();
     $field_options = \Drupal::service('webform_civicrm.field_options');
-    return $field_options->get(['form_key' => $element['#form_key']], 'create', []);
+    $data = [];
+    if (!empty($this->webform) && is_object($this->webform)) {
+      $webform_id = $this->webform->get('id');
+      if (!empty($webform_id)) {
+        $webform = \Drupal::entityTypeManager()->getStorage('webform')->load($webform_id);
+        $handler_collection = $webform->getHandlers('webform_civicrm');
+        $handler = $handler_collection->get('webform_civicrm');
+        $settings = $handler->getConfiguration()['settings'];
+        $data = $settings['data'];
+      }
+    }
+    return $field_options->get(['form_key' => $element['#form_key']], 'create', $data);
   }
 
   /**

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -105,6 +105,14 @@ class CivicrmSelect extends WebformElementBase {
       '#prefix' => '<div id="webform-civicrm-options-wrapper">',
       '#suffix' => '</div>',
     ];
+    // M.H added this, provide empty option for CiviCRM Select
+    $form['options']['empty_option'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Empty option label'),
+      '#description' => $this->t('The label to show for the initial option denoting no selection in a select element.'),
+      '#default_value' => $element_properties['empty_option'],
+    ];
+    // end added
 
     if ($element_properties['civicrm_live_options']) {
       $live_options_description = t('You cannot control the presentation of live options. They will be loaded from the CiviCRM database every time the form is displayed.');


### PR DESCRIPTION
Fix for Missing options for Contact Type, Relationship types etc.. on build Edit field section
Overview
----------------------------------------
When CiviCRM Webform field like Contact Sub Type, Relationship Types are exposed as `User Select` option, then under build tab ->  edit field -> field Options for these field missing. Modified any setting in Edit mode, loose all options by default available in view mode.

Before
----------------------------------------
https://www.drupal.org/project/webform_civicrm/issues/3152999
https://www.drupal.org/project/webform_civicrm/issues/3153274


After
----------------------------------------
Options are available.
