### PR TITLE
When updating a Case with multiple contacts, unset contact ID fields to avoid API error

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1268,6 +1268,18 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $params['id'] = $this->ent['case'][$n]['id'];
           // These params aren't allowed in update mode
           unset($params['creator_id']);
+
+          // If orig_contact_id is missing and there's more than one Contact
+          // on the Case, set orig_contact_id to the current ID. Otherwise
+          // we get a Case.create error "Case is linked with more than one 
+          // contact id".
+          if (empty($params['orig_contact_id']) && !empty($params['id'])) {
+            $caseContactCount = wf_civicrm_api('CaseContact', 'getcount', ['case_id' => $params['id']]);
+            if ($caseContactCount > 1 && !empty($params['client_id'])) {
+              $params['orig_contact_id'] = current((array) $params['client_id']);
+            }
+          }
+
         }
         // Allow "automatic" status to pass-thru
         if (empty($params['status_id'])) {


### PR DESCRIPTION
When updating a Case, unset contact_id and client_id if specified and
there's more than one Contact on the Case. Otherwise we get a Case.create
error "Case is linked with more than one contact id".

Overview
----------------------------------------
The webform post-processing code would previously fail with an API error when updating a Case with multiple Contacts attached. This change prevents that error from occurring.

D7 or D8?
----------------------------------------
D7. I don't currently have a D8 Civi installation for testing.

Before
----------------------------------------
The webform would appear to submit correctly from the user's perspective, but the custom fields would not update. In the Drupal log I would find this message:
`The CiviCRM "case create" API returned the error: "Case is linked with more than one contact id. Provide the required params orig_contact_id to be replaced" when called by function "postSave" on line 219 of wf_crm_webform_postprocess.inc with parameters: "Array ( [client_id] => Array ( [0] => 34231 ) [medium_id] => 9 [id] => 20342 [check_permissions] => [version] => 3 ) "`

After
----------------------------------------
The custom fields are updated correctly and there are no errors in the Drupal log.

Technical Details
----------------------------------------
If a webform were designed to update the Contacts on a Case - where there were already multiple Contacts on that Case - I expect this change would prevent such a webform from doing its job. However, I believe that webform would also fail without this change (due to the error described above).

If there's only one Contact on the Case, no fields are unset, so it should not break any functionality which currently works.

Comments
----------------------------------------
I'll apply this change to our production server tonight. It has been tested locally but will see more intensive testing over the course of the next week.

I wasn't sure about the correct procedure for updating this old fork of the repository. If I shouldn't have created the extra branch for this commit or if there are any other issues, let me know and I can try again.
