### PR TITLE
Fix autoload of event from URL

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -531,6 +531,9 @@ abstract class wf_crm_webform_base {
       return $exposed;
     }
 
+    if ($field && $field['#type'] == 'civicrm_options') {
+      return $field['#options'] ?? [];
+    }
     if ($field && $field['#type'] == 'select') {
       // Fetch static options
       if (empty($field['#extra']['civicrm_live_options'])) {
@@ -555,7 +558,7 @@ abstract class wf_crm_webform_base {
    */
   protected function getComponent($field_key) {
     if ($field_key && isset($this->enabled[$field_key])) {
-      $elements = $this->node->getElementsDecoded();
+      $elements = $this->node->getElementsDecodedAndFlattened();
       return $elements[$this->enabled[$field_key]];
     }
     return NULL;


### PR DESCRIPTION
Overview
----------------------------------------
Fix autoload of event from URL params.

D7 or D8?
----------------------------------------
D8WFC

Before
----------------------------------------
If the below setting is enabled on the event tab for the contact, the event cannot be loaded from the URL params eg c1event1=<event_id>

![image](https://user-images.githubusercontent.com/5929648/91845588-05281e00-ec77-11ea-8566-29052f8301be.png)

To replicate -

- Enable the above setting from `Event` tab -> `Registration option` section on the civicrm setting page.
- Try to load event id from the URL
- Event is not loaded on the field.

After
----------------------------------------
Event loaded from the URL Eg - `...?c1event1=2`

Technical Details
----------------------------------------
Handling for d8 element civicrm_options.

