### PR TITLE
D8 : Do not change Membership type for Inherited membership record

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -579,6 +579,8 @@ abstract class wf_crm_webform_base {
       'contact_id' => $cid,
       // Limit to only enabled membership types
       'membership_type_id' => array('IN' => $membership_types),
+      // skip membership through Inheritance.
+      'owner_membership_id' => ['IS NULL' => 1],
     ));
     if (!$existing) {
       return array();


### PR DESCRIPTION
Overview
----------------------------------------
Do not change Membership Type for Inherited Membership Record.

Steps to Recreate Issue

1. Assume you as individual have Inherited Membership record from your employer. ( you don't have other membership record).
2. Now, As individual signup for any membership type (excluding existing Inherited membership type, just to avoid confusion), when signup is completed, your existing Inherited Membership type get changed to New Membership type. If you click on View membership in Backend, you will see Error Message. 


D7 or D8?
----------------------------------------
This issue exist in D7 and D8 version of this module.

Before
----------------------------------------
Inherited Membership Type changes to other Membership record.

After
----------------------------------------
Inherited Membership Type record get skipped, Either New Membership is created or other membership record (which are not from  Inheritance) type get changed.
