### PR TITLE
D7 : Get Membership type of current domain only

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -580,8 +580,7 @@ abstract class wf_crm_webform_base {
     static $status_types;
     static $membership_types;
     if (!isset($membership_types)) {
-      $domainId = CRM_Core_Config::domainID();
-      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => $domainId, 'return' => 'id']));
+      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => 'current_domain', 'return' => 'id']));
     }
     $existing = wf_crm_apivalues('membership', 'get', [
       'contact_id' => $cid,

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -580,7 +580,8 @@ abstract class wf_crm_webform_base {
     static $status_types;
     static $membership_types;
     if (!isset($membership_types)) {
-      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'return' => 'id']));
+      $domainId = CRM_Core_Config::domainID();
+      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => $domainId, 'return' => 'id']));
     }
     $existing = wf_crm_apivalues('membership', 'get', [
       'contact_id' => $cid,


### PR DESCRIPTION
Overview
----------------------------------------
Restrict Membership type to Current domain, when we have multisite setup, and each domain have their own membership type. and webform is configured for membership signup/renew. 

When form is submitted, System is trying to get all Membership record for a contact, for that, it first get all membership type and then find the membership record using these membership type. Now problem is that, when we get membership type, it fetches all domain membership types, and pass it to membership get api. Membership Get api throw Error.

e.g 
` MESSAGE    The CiviCRM "membership get" API returned the error: "'1' is not a valid option for field membership_type_id" when called by function "findMemberships" on line 599 of wf_crm_webform_base.inc with parameters: "Array ( [contact_id] => 6752 [membership_type_id] => Array ( [IN] => Array ( [0] => 1 [1] => 2 [2] => 3 [3] => 5 [4] => 7 [5] => 9 [6] => 10 [7] => 11 [8] => 15 [9] => 16 [10] => 17 [11] => 18 [12] => 19 [13] => 20 [14] => 21 [15] => 22 [16] => 23 [17] => 30 [18] => 31 [19] => 32 [20] => 33 [21] => 34 [22] => 36 [23] => 37 [24] => 38 [25] => 39 [26] => 40 [27] => 42 [28] => 43 [29] => 44 [30] => 45 [31] => 46 [32] => 48 [33] => 49 [34] => 51 [35] => 52 [36] => 53 [37] => 54 [38] => 55 [39] => 56 [40] => 57 [41] => 58 [42] => 59 [43] => 60 [44] => 61 [45] => 62 [46] => 64 [47] => 65 [48] => 66 [49] => 67 [50] => 68 [51] => 69 ) ) [options] => Array ( [limit] => 0 ) [check_permissions] => [version] => 3 ) " `

To avoid such error, we can pass domain id in membership type api to get current domain membership type only.


D7 or D8?
----------------------------------------
Issue Exist in D7 and D8

Before
----------------------------------------
API return all membership types across different domain, and we get API Exception in next call

After
----------------------------------------
Only get Membership type of current domain only.
