### PR TITLE
D7: make Contact selectable for Contributions

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -1052,6 +1052,13 @@ function wf_crm_get_fields($var = 'fields') {
         ],
         'weight' => 9999,
       ];
+      $fields['contribution_contact_id'] = [
+        'name' => t('Contact'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'data_type' => 'ContactReference',
+        'weight' => 9998,
+      ];
       $fields['contribution_total_amount'] = [
         'name' => t('Contribution Amount'),
         'weight' => 9991,

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2011,7 +2011,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
     $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
     $params['skipRecentView'] = $params['skipLineItem'] = 1;
-    $params['contact_id'] = $this->ent['contact'][1]['id'];
+    $params['contact_id'] = $this->data['contribution'][1]['contribution'][1]['contact_id'];
     $params['total_amount'] = round($this->totalContribution, 2);
 
     // Most payment processors expect this (normally be set by contribution page processConfirm)

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1754,6 +1754,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
     if ($cid) {
       $address['contact_id'] = $email['contact_id'] = $this->ent['contact'][1]['id'] = $cid;
+      $this->data['contribution'][1]['contribution'][1]['contact_id'] = $cid;
       wf_civicrm_api('address', 'create', $address);
       wf_civicrm_api('email', 'create', $email);
     }


### PR DESCRIPTION
Overview
----------------------------------------
In `webform_civicrm` when creating a Contribution, it's assigned to **Contact 1** by default.  
There are some use cases where we need to create several Contacts in the same webform or having conditional contacts creation (Individual or Organization in the same webform selectable by the user, for instance) and we don't want to assign the new Contribution (one off and/or recurring) to **Contact 1**.

This PR adds the possibility to select to which contact the contribution will be assigned, or selectable by the User as well, that could be manual assigned, or use in different scenarios (using webform_conditional to assing the contribution to Contact X depending on criteria)  

![webform_civicrm](https://user-images.githubusercontent.com/2589799/93922462-4493d880-fd12-11ea-91d1-b92c599fe09f.png)


D7 or D8?
----------------------------------------
Drupal 7

Before
----------------------------------------
The Contribution is always assigned to **Contact 1**

After
----------------------------------------
The Contribution can be assigned to any Contact available in the webform, even *selectable by user*, adding more webforms' use cases 

Technical Details
----------------------------------------
This PR adds `contribution_contact_id` field as part of the Contribution fields

Comments
----------------------------------------
I'm adding this to `7.x-5.x` branch because it's the version we are still using in Drupal 7. I won't be ready to port this to Drupal 8 at the moment
