### PR TITLE
D8: Issue with translations and creating groups

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -906,7 +906,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     switch ($data_type) {
       case 'group':
         $api = 'group_contact';
-        $params['method'] = t('Webform');
+        $params['method'] = substr(t('Webform'), 0, 8);
         break;
       case 'tag':
         $api = 'EntityTag';


### PR DESCRIPTION

Overview
----------------------------------------
Can't save webform with group(s) when the word webform is translated in the Drupal translation interface.

D7 or D8?
----------------------------------------
D8WFC

Before
----------------------------------------
Can't save webform with group(s).

After
----------------------------------------
Can save webform with group(s).

Technical Details
----------------------------------------
The $params['method'] gets sets to webform or its translation, in de database only 8 chars are allowed for the method field an once the word 'webform' gets translated (example) into dutch it becomes 'Webformulier' which is longer then 8 chars and an error is thrown.

Comments
----------------------------------------
Patch contains tempory fix, there could be a better solution!