### PR TITLE
Revert "Use entity functions to save custom data"

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -662,6 +662,130 @@ abstract class wf_crm_webform_base {
   }
 
   /**
+   * Save custom data for an entity
+   *
+   * @param $entity
+   *   Array of values
+   * @param $entity_id
+   *   Numeric id of entity
+   * @param $entity_type
+   *   Type of crm entity, e.g. "Contact"
+   * @param $known
+   *   Is this a known record (as opposed to a contact matched via dedupe rules)?
+   *   We only allow saving blank fields for known contacts.
+   * @param $contact_index
+   *   Contact's index
+   */
+  protected function saveCustomData($entity, $entity_id, $entity_type, $known = TRUE, $contact_index = 1) {
+    $existing = FALSE;
+    $params = array('entityID' => $entity_id);
+    $createMultiValues = array();
+
+    foreach ($entity as $table => $values) {
+      if (substr($table, 0, 2) == 'cg' && is_array($values)) {
+        if ($existing === FALSE) {
+          $existing = $this->getCustomData($entity_id, $entity_type, FALSE);
+        }
+        $existing += array($table => array());
+        $insert = 0;
+
+        foreach ($values as $valuesIndex => $custom) {
+          // Match to id of existing record (id will be 0 for non-multi-value custom sets, which is fine)
+          if ($id = each($existing[$table])) {
+            $suf = $id['key'];
+          }
+          // Create new record(s) using negative numbers
+          else {
+            $suf = --$insert;
+          }
+
+          $multivaluesCreateMode = NULL;
+
+          // Handle 'Create mode' for multivalues custom fields of Contact entity.
+          if ($entity_type === 'Contact') {
+            $createModeKey = 'civicrm_' . $contact_index . '_contact_' . $valuesIndex . '_' . $table . '_createmode';
+            $multivaluesCreateMode = isset($this->data['config']['create_mode'][$createModeKey]) ? (int) $this->data['config']['create_mode'][$createModeKey] : NULL;
+          }
+          $multiValueSuffix = '_' . $suf;
+
+          if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
+            // Using 'Create only' mode we don't need custom value's suffix
+            // so the value can be added as new instead of updated.
+            $multiValueSuffix = '';
+          }
+
+          $customGroupParams = array();
+
+          foreach ($custom as $k => $v) {
+            // Only save if this is not blank or data already exists and record is known
+            if ($v !== '' || ($suf >= 0 && $known)) {
+              $customGroupParams[$k . $multiValueSuffix] = $v;
+            }
+          }
+
+          if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
+            $createMultiValues[] = $customGroupParams;
+          }
+          else {
+            $params = array_merge($params, $customGroupParams);
+          }
+        }
+      }
+    }
+
+    if (count($params) > 1) {
+      // Update existing values.
+      $this->saveCustomValues($entity_id, $params);
+    }
+
+    if (!empty($createMultiValues)) {
+      // Add new values.
+      foreach ($createMultiValues as $multiValuesSet) {
+        $this->saveCustomValues($entity_id, array_merge($multiValuesSet, array('entityID' => $entity_id)), TRUE);
+      }
+    }
+  }
+
+  /**
+   * Saves a set of custom values for specific entity Id.
+   *
+   * @param int $entity_id
+   * @param array $params
+   * @param bool $skipEmpty
+   */
+  protected function saveCustomValues($entity_id, array $params, $skipEmpty = FALSE) {
+    if ($skipEmpty) {
+      // Remove empty values from $params array. Useful to not save empty values
+      // with 'Create only' mode.
+      foreach ($params as $key => $value) {
+        $checkValue = str_replace(CRM_Core_DAO::VALUE_SEPARATOR, '', $value);
+        if (empty($checkValue)) {
+          unset($params[$key]);
+        }
+      }
+    }
+
+    $result = CRM_Core_BAO_CustomValueTable::setValues($params);
+
+    // Prevent wholesale failure by saving each param individually if there was an error while trying to save them all at once
+    if (!empty($result['is_error'])) {
+      $bt = debug_backtrace();
+      array_shift($params);
+      foreach ($params as $k => $v) {
+        $single_param = array('entityID' => $entity_id, $k => $v);
+        $result = CRM_Core_BAO_CustomValueTable::setValues($single_param);
+        if (!empty($result['is_error'])) {
+          $file = explode('/', $bt[0]['file']);
+          \Drupal::logger('webform_civicrm')->error(
+            'The CiviCRM "CustomValueTable::setValues" function returned the error: "%msg" when called by line !line of !file with the following parameters: "!params"',
+            ['%msg' => $result['error_message'], '!line' => $bt[0]['line'], '!file' => array_pop($file), '!params' => print_r($single_param, TRUE)]
+          );
+        }
+      }
+    }
+  }
+
+  /**
    * @param string $fid
    * @param mixed $default
    * @param bool $strict

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -217,6 +217,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
       $this->saveCurrentEmployer($contact, $cid);
 
+      $this->saveCustomData($contact, $cid, 'Contact', !empty($this->existing_contacts[$c]), $c);
+
       $this->fillHiddenContactFields($cid, $c);
 
       $this->saveContactLocation($contact, $cid, $c);
@@ -269,7 +271,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (isset($this->data['grant']['number_of_grant'])) {
         $this->processGrants();
       }
-      // Save contribution line-items
+      // Save contribution custom data & line-items
       if (!empty($this->ent['contribution'][1]['id'])) {
         $this->processContribution();
       }
@@ -1065,7 +1067,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           if (empty($params['campaign_id']) || empty($this->all_fields['participant_campaign_id'])) {
             unset($params['campaign_id']);
           }
-
+          // Reformat custom data from nested arrays
+          $custom = array();
+          foreach ($this->data['participant'][$n] as $key => $vals) {
+            if (substr($key, 0, 2) == 'cg' && isset($vals[$e])) {
+              $custom[$key][1] = $vals[$e];
+            }
+          }
           // Loop through event ids to support multi-valued form elements
           $this->events = (array) $params['event_id'];
           foreach ($this->events as $i => $id_and_type) {
@@ -1116,6 +1124,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               // When registering contact 1, store id to apply to other contacts
               if ($c == 1) {
                 $registered_by_id[$e][$i] = $result['id'];
+              }
+              if ($custom) {
+                $this->saveCustomData($custom, $result['id'], 'Participant');
               }
             }
           }
@@ -1315,13 +1326,14 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           unset($params['status_id']);
         }
         $result = wf_civicrm_api('case', 'create', $params);
-
         // Final processing if save was successful
         if (!empty($result['id'])) {
           // handle case tags
           $this->handleEntityTags('case', $result['id'], $n, $params);
           // Store id
           $this->ent['case'][$n]['id'] = $result['id'];
+          // Save custom field data
+          $this->saveCustomData($data, $result['id'], 'Case', FALSE);
           // Save case roles
           foreach ($params as $param => $val) {
             if ($val && strpos($param, 'role_') === 0) {
@@ -1429,7 +1441,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $this->handleEntityTags('activity', $result['id'], $n, $params);
           // Store id
           $this->ent['activity'][$n]['id'] = $result['id'];
-          // Save attachments
+          // Save custom data & attachments
+          $this->saveCustomData($data, $result['id'], 'Activity', FALSE);
           if (isset($data['activityupload'])) {
             $this->processAttachments('activity', $n, $result['id'], empty($params['id']));
           }
@@ -1537,7 +1550,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         if (!empty($result['id'])) {
           // Store id
           $this->ent['grant'][$n]['id'] = $result['id'];
-          // Save attachments
+          // Save custom data & attachments
+          $this->saveCustomData($data, $result['id'], 'Grant', FALSE);
           if (isset($data['grantupload'])) {
             $this->processAttachments('grant', $n, $result['id'], empty($params['id']));
           }
@@ -2112,6 +2126,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   private function processContribution() {
     $contribution = $this->data['contribution'][1]['contribution'][1];
     $id = $this->ent['contribution'][1]['id'];
+    // Save custom data
+    $this->saveCustomData($this->data['contribution'][1], $id, 'Contribution', FALSE);
     // Save soft credits
     if (!empty($contribution['soft'])) {
       // Get total amount from total amount after line item calculation
@@ -2279,7 +2295,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
   private function fillDataFromSubmission() {
     foreach ($this->enabled as $field_key => $fid) {
       $val = (array) $this->submissionValue($fid);
-      $customValue = NULL;
       // If value is null then it was hidden by a webform conditional rule - skip it
       if ($val !== NULL && $val !== array(NULL)) {
         list( , $c, $ent, $n, $table, $name) = explode('_', $field_key, 6);
@@ -2315,16 +2330,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           if (!empty($this->data[$ent][$c][$table][$n][$name]) && is_array($this->data[$ent][$c][$table][$n][$name])) {
             $val = array_unique(array_merge($val, $this->data[$ent][$c][$table][$n][$name]));
           }
-          // We need to handle items being de-selected too and provide an array to pass to Entity.create API
-          // Extract a list of available items
-          $exposedOptions = $this->getExposedOptions($field_key);
-          $customValue = [];
-          foreach ($exposedOptions as $itemName => $itemLabel) {
-            if (in_array($itemName, $val)) {
-              $customValue[] = $itemName;
-            }
-          }
-
           // Implode data that will be stored as a string
           if ($table !== 'other' && $name !== 'event_id' && $name !== 'relationship_type_id' && $table !== 'contact' && $dataType != 'ContactReference' && strpos($name, 'tag') !== 0) {
             $val = CRM_Utils_Array::implodePadded($val);
@@ -2385,13 +2390,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $date = wf_crm_aval($this->data, "$ent:$c:$table:$n:$name", date('Ymd'));
           $val = $date . str_replace(':', '', $val);
         }
-
         // Only known contacts are allowed to empty a field
         if (($val !== '' && $val !== NULL && $val !== array()) || !empty($this->existing_contacts[$c])) {
           $this->data[$ent][$c][$table][$n][$name] = $val;
-          if (substr($name, 0, 6) === 'custom') {
-            $this->data[$ent][$c][$ent][$n][$name] = $customValue ?? $val;
-          }
         }
       }
     }


### PR DESCRIPTION
Reverts colemanw/webform_civicrm#348 for the 8.x branch.
2 bugs were found in the [7.x version of this PR](https://github.com/colemanw/webform_civicrm/pull/342) which probably affect 8.x as well:

1. Custom data was [not being saved for any contact reference fields](https://www.drupal.org/project/webform_civicrm/issues/3171420).
2. Multi-record custom groups (e.g. the kind that displays as tabs on the contact summary screen) were not being saved.