### PR TITLE
WIP - Decouple list of payment processors from contribution page

### DIFF
--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -75,6 +75,38 @@ function wf_crm_field_options($field, $context, $data) {
     elseif ($table == 'membership' && $name == 'num_terms') {
       $ret = drupal_map_assoc(range(1, 9));
     }
+    elseif ($table === 'contribution' && $name === 'payment_processor_id') {
+      // For the config form we display a list of all active (live) payment processors
+      // Saving will map the IDs to live or test.
+      // For the frontend we display the selected payment processors (with correct ID for live or test)
+      $params = wf_crm_aval($data, "$ent:$c:$table:$n", []);
+      if ($context === 'config_form') {
+        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'], 'is_active' => 1]);
+        $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
+        foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
+          $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
+        }
+        return $ret;
+      }
+      else {
+        $selectedPaymentProcessors = wf_crm_aval($params, "payment_processor_id", []);
+        if (in_array(0, $selectedPaymentProcessors)) {
+          $ret[0] = $field['exposed_empty_option'];
+        }
+        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', []);
+        $testPaymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => 1], 'name');
+        foreach ($selectedPaymentProcessors as $paymentProcessorID) {
+          if (array_key_exists((int) $paymentProcessorID, $paymentProcessors)) {
+            if (!empty($params['is_test'])) {
+              $paymentProcessorName = $paymentProcessors[$paymentProcessorID]['name'];
+              $paymentProcessorID = array_search($paymentProcessorName, $testPaymentProcessors);
+            }
+            $ret[$paymentProcessorID] = $paymentProcessors[$paymentProcessorID]['title'] ?? $paymentProcessors[$paymentProcessorID]['name'];
+          }
+        }
+        return $ret;
+      }
+    }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
       $params = ['field' => $name, 'context' => 'create'];
@@ -106,14 +138,17 @@ function wf_crm_field_options($field, $context, $data) {
       }
     }
     // Remove options that were set behind the scenes on the admin form
-    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])) {
+    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])
+      && "{$table}_{$name}" !== 'contribution_payment_processor_id') {
       foreach (wf_crm_aval($data, "$ent:$c:$table:$n:$name", []) as $key => $val) {
         unset($ret[$key]);
       }
     }
   }
   if (!empty($field['exposed_empty_option'])) {
-    $ret = [0 => $field['exposed_empty_option']] + $ret;
+    if ($context === 'config_form' || ($context !== 'config_form' && "{$table}_{$name}" !== 'contribution_payment_processor_id')) {
+      $ret = [0 => $field['exposed_empty_option']] + $ret;
+    }
   }
   return $ret;
 }
@@ -1060,10 +1095,26 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Payment Processor'),
         'type' => 'select',
         'expose_list' => TRUE,
-        'extra' => ['aslist' => 0],
+        'extra' => [
+          'aslist' => 0,
+          'civicrm_live_options' => TRUE,
+          'required' => TRUE
+        ],
         'exposed_empty_option' => t('Pay Later'),
         'value_callback' => TRUE,
         'weight' => 9995,
+        'admin' => [
+          'disable_user_select' => TRUE,
+          'multiple' => TRUE,
+        ]
+      ];
+      $fields['contribution_is_test'] = [
+        'name' => t('Payment Processor Mode'),
+        'type' => 'select',
+        'expose_list' => TRUE,
+        'value' => 0,
+        'weight' => 9996,
+        'disable_user_select' => TRUE,
       ];
       $fields['contribution_note'] = [
         'name' => t('Contribution Note'),
@@ -1088,14 +1139,6 @@ function wf_crm_get_fields($var = 'fields') {
         'name' => t('Honoree Type'),
         'type' => 'select',
         'expose_list' => TRUE,
-      ];
-      $fields['contribution_is_test'] = [
-        'name' => t('Payment Processor Mode'),
-        'type' => 'select',
-        'expose_list' => TRUE,
-        'extra' => ['civicrm_live_options' => 1],
-        'value' => 0,
-        'weight' => 9997,
       ];
       $fields['contribution_source'] = [
         'name' => t('Contribution Source'),

--- a/includes/utils.inc
+++ b/includes/utils.inc
@@ -80,32 +80,12 @@ function wf_crm_field_options($field, $context, $data) {
       // Saving will map the IDs to live or test.
       // For the frontend we display the selected payment processors (with correct ID for live or test)
       $params = wf_crm_aval($data, "$ent:$c:$table:$n", []);
-      if ($context === 'config_form') {
-        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'], 'is_active' => 1]);
-        $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
-        foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
-          $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
-        }
-        return $ret;
+      $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'] ?? 0, 'is_active' => 1]);
+      $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
+      foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
+        $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
       }
-      else {
-        $selectedPaymentProcessors = wf_crm_aval($params, "payment_processor_id", []);
-        if (in_array(0, $selectedPaymentProcessors)) {
-          $ret[0] = $field['exposed_empty_option'];
-        }
-        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', []);
-        $testPaymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => 1], 'name');
-        foreach ($selectedPaymentProcessors as $paymentProcessorID) {
-          if (array_key_exists((int) $paymentProcessorID, $paymentProcessors)) {
-            if (!empty($params['is_test'])) {
-              $paymentProcessorName = $paymentProcessors[$paymentProcessorID]['name'];
-              $paymentProcessorID = array_search($paymentProcessorName, $testPaymentProcessors);
-            }
-            $ret[$paymentProcessorID] = $paymentProcessors[$paymentProcessorID]['title'] ?? $paymentProcessors[$paymentProcessorID]['name'];
-          }
-        }
-        return $ret;
-      }
+      return $ret;
     }
     // Aside from the above special cases, most lists can be fetched from api.getoptions
     else {
@@ -138,17 +118,14 @@ function wf_crm_field_options($field, $context, $data) {
       }
     }
     // Remove options that were set behind the scenes on the admin form
-    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])
-      && "{$table}_{$name}" !== 'contribution_payment_processor_id') {
+    if ($context != 'config_form' && !empty($field['extra']['multiple']) && !empty($field['expose_list'])) {
       foreach (wf_crm_aval($data, "$ent:$c:$table:$n:$name", []) as $key => $val) {
         unset($ret[$key]);
       }
     }
   }
   if (!empty($field['exposed_empty_option'])) {
-    if ($context === 'config_form' || ($context !== 'config_form' && "{$table}_{$name}" !== 'contribution_payment_processor_id')) {
-      $ret = [0 => $field['exposed_empty_option']] + $ret;
-    }
+    $ret = [0 => $field['exposed_empty_option']] + $ret;
   }
   return $ret;
 }
@@ -1103,18 +1080,13 @@ function wf_crm_get_fields($var = 'fields') {
         'exposed_empty_option' => t('Pay Later'),
         'value_callback' => TRUE,
         'weight' => 9995,
-        'admin' => [
-          'disable_user_select' => TRUE,
-          'multiple' => TRUE,
-        ]
       ];
       $fields['contribution_is_test'] = [
         'name' => t('Payment Processor Mode'),
-        'type' => 'select',
+        'type' => 'hidden',
         'expose_list' => TRUE,
         'value' => 0,
         'weight' => 9996,
-        'disable_user_select' => TRUE,
       ];
       $fields['contribution_note'] = [
         'name' => t('Contribution Note'),

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -54,10 +54,6 @@ class wf_crm_admin_form {
     // Merge in existing fields
     $existing = array_keys(wf_crm_enabled_fields($this->node, NULL, TRUE));
     $this->settings += array_fill_keys($existing, 'create_civicrm_webform_element');
-    unset(
-      $this->settings['civicrm_1_contribution_1_contribution_payment_processor_id'],
-      $this->settings['civicrm_1_contribution_1_contribution_is_test']
-    );
 
     // Sort fields by set
     foreach ($this->fields as $fid => $field) {
@@ -1004,7 +1000,6 @@ class wf_crm_admin_form {
     $this->form['contribution'] = [
       '#type' => 'fieldset',
       '#title' => t('Contribution'),
-
       '#group' => 'webform_civicrm',
       '#description' => t('In order to process live transactions for events, memberships, or contributions, select a contribution page and its billing fields will be included on the webform.'),
       '#attributes' => ['class' => ['civi-icon-contribution']],
@@ -1316,8 +1311,7 @@ class wf_crm_admin_form {
       if (!empty($field['extra']['required'])) {
         $item['#attributes']['class'][] = 'required';
       }
-
-      if (($field['type'] != 'hidden') && (empty($field['admin']['disable_user_select']))) {
+      if ($field['type'] != 'hidden') {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
       $options += wf_crm_field_options($field, 'config_form', $this->data);
@@ -1548,6 +1542,9 @@ class wf_crm_admin_form {
           (!empty($val) || (in_array($name, ['num_terms', 'is_active', 'is_test', 'payment_processor_id'])))) {
           // Don't add data for non-existent contacts
           if (!in_array($ent, ['contact', 'participant', 'membership']) || isset($this->data['contact'][$c])) {
+            if ($name == 'payment_processor_id' && !empty($val) && is_numeric($val)) {
+              $val = $this->getPaymentProcessorValue($val);
+            }
             $this->data[$ent][$c][$table][$n][$name] = $val;
           }
         }
@@ -1675,9 +1672,7 @@ class wf_crm_admin_form {
 
           if (!isset($enabled[$key])) {
             $val = (array) $val;
-            if (in_array('create_civicrm_webform_element', $val, TRUE)
-                || (!empty($val[0]) && $field['type'] == 'hidden')
-                || ((count($val) > 1) && (!empty($field['admin']['disable_user_select'])))) {
+            if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
               // Restore disabled component
               if (isset($disabled[$key])) {
                 webform_component_update($disabled[$key]);
@@ -1833,8 +1828,7 @@ class wf_crm_admin_form {
       }
       else {
         $field = wf_crm_get_field($key);
-        if ((!empty($val[0]) && $field['type'] == 'hidden')
-          ) {
+        if ($field['type'] == 'hidden' && (!empty($val[0]) || $field['name'] == 'Payment Processor Mode')) {
           unset($fields[$key]);
         }
       }
@@ -2021,6 +2015,18 @@ class wf_crm_admin_form {
    */
   public static function get_default_contact_cs($fid, $options) {
     return wf_crm_get_civi_setting('checksum_timeout', 7);
+  }
+
+  /**
+   * Ensure processor option is set as per is_test flag.
+   */
+  protected function getPaymentProcessorValue($val) {
+    $params = [
+      'is_test' => $this->settings['civicrm_1_contribution_1_contribution_is_test'] ?? 0,
+      'is_active' => 1,
+      'name' => CRM_Financial_BAO_PaymentProcessor::getPaymentProcessorName($val),
+    ];
+    return key(wf_crm_apivalues('PaymentProcessor', 'get', $params));
   }
 
   /**

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -54,6 +54,10 @@ class wf_crm_admin_form {
     // Merge in existing fields
     $existing = array_keys(wf_crm_enabled_fields($this->node, NULL, TRUE));
     $this->settings += array_fill_keys($existing, 'create_civicrm_webform_element');
+    unset(
+      $this->settings['civicrm_1_contribution_1_contribution_payment_processor_id'],
+      $this->settings['civicrm_1_contribution_1_contribution_is_test']
+    );
 
     // Sort fields by set
     foreach ($this->fields as $fid => $field) {
@@ -1000,6 +1004,7 @@ class wf_crm_admin_form {
     $this->form['contribution'] = [
       '#type' => 'fieldset',
       '#title' => t('Contribution'),
+
       '#group' => 'webform_civicrm',
       '#description' => t('In order to process live transactions for events, memberships, or contributions, select a contribution page and its billing fields will be included on the webform.'),
       '#attributes' => ['class' => ['civi-icon-contribution']],
@@ -1311,7 +1316,8 @@ class wf_crm_admin_form {
       if (!empty($field['extra']['required'])) {
         $item['#attributes']['class'][] = 'required';
       }
-      if ($field['type'] != 'hidden') {
+
+      if (($field['type'] != 'hidden') && (empty($field['admin']['disable_user_select']))) {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
       $options += wf_crm_field_options($field, 'config_form', $this->data);
@@ -1669,7 +1675,9 @@ class wf_crm_admin_form {
 
           if (!isset($enabled[$key])) {
             $val = (array) $val;
-            if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
+            if (in_array('create_civicrm_webform_element', $val, TRUE)
+                || (!empty($val[0]) && $field['type'] == 'hidden')
+                || ((count($val) > 1) && (!empty($field['admin']['disable_user_select'])))) {
               // Restore disabled component
               if (isset($disabled[$key])) {
                 webform_component_update($disabled[$key]);
@@ -1825,7 +1833,8 @@ class wf_crm_admin_form {
       }
       else {
         $field = wf_crm_get_field($key);
-        if (!empty($val[0]) && $field['type'] == 'hidden') {
+        if ((!empty($val[0]) && $field['type'] == 'hidden')
+          ) {
           unset($fields[$key]);
         }
       }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -951,22 +951,4 @@ abstract class wf_crm_webform_base {
     return CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
   }
 
-  /**
-   * Historically webform_civicrm was configured with the live payment processor ID and the is_test flag.
-   * But this is not how CiviCRM expects it to work and this can cause problems where payments use the live processor
-   *   instead of test.  So we "fix" the processor ID here to be the correct one for live/test.
-   * An "improved" fix would involve changing the configuration saved by the user but this avoids that.
-   *
-   * @throws \CiviCRM_API3_Exception
-   */
-  protected function fixPaymentProcessorID() {
-    // Check for is_test and payment_processor_id (pay later = 0 is set to '' here. is_test has no meaning for pay later).
-    if (!empty($this->data['contribution'][1]['contribution'][1]['is_test'])
-        && !empty($this->data['contribution'][1]['contribution'][1]['payment_processor_id'])) {
-      $paymentProcessor = \Civi\Payment\System::singleton()->getById($this->data['contribution'][1]['contribution'][1]['payment_processor_id']);
-      $paymentProcessor = \Civi\Payment\System::singleton()->getByName($paymentProcessor->getPaymentProcessor()['name'], TRUE);
-      $this->data['contribution'][1]['contribution'][1]['payment_processor_id'] = $paymentProcessor->getPaymentProcessor()['id'];
-    }
-  }
-
 }

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -45,7 +45,6 @@ abstract class wf_crm_webform_base {
   function __get($name) {
     switch ($name) {
       case 'payment_processor':
-        $this->fixPaymentProcessorID();
         $payment_processor_id = wf_crm_aval($this->data, 'contribution:1:contribution:1:payment_processor_id');
         if ($payment_processor_id && !$this->_payment_processor) {
           $this->_payment_processor = wf_civicrm_api('payment_processor', 'getsingle', ['id' => $payment_processor_id]);

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -43,7 +43,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $this->node = $node;
     $this->settings = $node->webform_civicrm;
     $this->data = $this->settings['data'];
-    $this->fixPaymentProcessorID();
     $this->enabled = wf_crm_enabled_fields($node);
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -213,9 +213,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       }
       else {
         $js_vars['paymentProcessor'] = $this->getData($fid);
-        if (is_array($js_vars['paymentProcessor'])) {
-          $js_vars['paymentProcessor'] = reset($js_vars['paymentProcessor']);
-        }
       }
     }
     if ($js_vars) {

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -21,7 +21,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     $this->node = $form['#node'];
     $this->settings = $this->node->webform_civicrm;
     $this->data = $this->settings['data'];
-    $this->fixPaymentProcessorID();
     $this->ent['contact'] = [];
     $this->all_fields = wf_crm_get_fields();
     $this->all_sets = wf_crm_get_fields('sets');
@@ -214,6 +213,9 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
       }
       else {
         $js_vars['paymentProcessor'] = $this->getData($fid);
+        if (is_array($js_vars['paymentProcessor'])) {
+          $js_vars['paymentProcessor'] = reset($js_vars['paymentProcessor']);
+        }
       }
     }
     if ($js_vars) {


### PR DESCRIPTION
Overview
----------------------------------------
Continuation of https://github.com/colemanw/webform_civicrm/pull/343. Decouple list of payment processors from contribution page

D7 or D8?
----------------------------------------
D7 for now. D8 port needed.

Before
----------------------------------------
Payment processor list depends on the contribution pages.

After
----------------------------------------
- All Payment processor are listed on the contribution tab.
- User-select removed from Payment processor mode so admins have to select either live or test.
- `fixPaymentProcessorID` removed. Payment Processor id is now decided at the backend based on test/live selected on the config page.

@mattwire Can you skim through the second commit pls https://github.com/colemanw/webform_civicrm/commit/6e3153e60b0638eb57f74e9be25267cad79ecd67? I've removed few lines that I felt as not required based on our final discussion. Have tested this with different scenarios and all seem to work fine for me. 

Comments
----------------------------------------
@KarinG This fixes the requirement for 1 & 2, i.e, 

>1. add - User Select - to Payment Processor Mode (and then taking into account the setting for Mode -> only present Live (or Test) processors on the form.
>2. remove - User Select - from the Payment Processor Mode -> so that Admins have to pick Live or Test -> default should be Live.


