### PR TITLE
D8 - Decouple list of payment processors from contribution page

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1584,6 +1584,9 @@ class wf_crm_admin_form {
           (!empty($val) || (in_array($name, array('num_terms', 'is_active', 'is_test', 'payment_processor_id'))))) {
           // Don't add data for non-existent contacts
           if (!in_array($ent, array('contact', 'participant', 'membership')) || isset($this->data['contact'][$c])) {
+            if ($name == 'payment_processor_id' && !empty($val) && is_numeric($val)) {
+              $val = $this->getPaymentProcessorValue($val);
+            }
             $this->data[$ent][$c][$table][$n][$name] = $val;
           }
         }
@@ -1915,7 +1918,7 @@ class wf_crm_admin_form {
       }
       else {
         $field = wf_crm_get_field($key);
-        if (!empty($val[0]) && $field['type'] == 'hidden') {
+        if ($field['type'] == 'hidden' && (!empty($val[0]) || $field['name'] == 'Payment Processor Mode')) {
           unset($fields[$key]);
         }
       }
@@ -2108,6 +2111,28 @@ class wf_crm_admin_form {
     $pagebreak += webform_component_invoke('pagebreak', 'defaults');
     webform_component_insert($pagebreak);
     */
+  }
+
+  /**
+   * Return payment processor id as per is_test flag set on the webform.
+   *
+   * @param int $ppId.
+   *  Payment Processor ID.
+   *
+   * @return int
+   *  id of the payment processor as per is_test flag.
+   */
+  protected function getPaymentProcessorValue($ppId) {
+    $pName = wf_civicrm_api('PaymentProcessor', 'getvalue', [
+      'return' => "name",
+      'id' => $ppId,
+    ]);
+    $params = [
+      'is_test' => $this->settings['civicrm_1_contribution_1_contribution_is_test'] ?? 0,
+      'is_active' => 1,
+      'name' => $pName,
+    ];
+    return key(wf_crm_apivalues('PaymentProcessor', 'get', $params));
   }
 
   /**

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -83,6 +83,18 @@ class FieldOptions implements FieldOptionsInterface {
       elseif ($table == 'membership' && $name == 'num_terms') {
         $ret = array_combine(range(1, 9), range(1, 9));
       }
+      elseif ($table === 'contribution' && $name === 'payment_processor_id') {
+        // For the config form we display a list of all active (live) payment processors
+        // Saving will map the IDs to live or test.
+        // For the frontend we display the selected payment processors (with correct ID for live or test)
+        $params = wf_crm_aval($data, "$ent:$c:$table:$n", []);
+        $paymentProcessors = wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'] ?? 0, 'is_active' => 1]);
+        $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
+        foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
+          $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
+        }
+        return $ret;
+      }
       // Aside from the above special cases, most lists can be fetched from api.getoptions
       else {
         $params = array('field' => $name, 'context' => 'create');

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -598,11 +598,22 @@ class Fields implements FieldsInterface {
           'name' => 'Payment Processor',
           'type' => 'select',
           'expose_list' => TRUE,
-          'extra' => array('aslist' => 0),
+          'extra' => [
+            'aslist' => 0,
+            'civicrm_live_options' => TRUE,
+            'required' => TRUE
+          ],
           'exposed_empty_option' => 'Pay Later',
           // Removed due to error, when a custom element is made, revisit.
           // 'value_callback' => TRUE,
         );
+        $fields['contribution_is_test'] = [
+          'name' => t('Payment Processor Mode'),
+          'type' => 'hidden',
+          'expose_list' => TRUE,
+          'value' => 0,
+          'weight' => 9996,
+        ];
         $fields['contribution_contribution_page_id'] = array(
           'name' => ts('Contribution Page'),
           'type' => 'hidden',
@@ -638,14 +649,6 @@ class Fields implements FieldsInterface {
           'name' => t('Honoree Type'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'parent' => 'contribution_pagebreak',
-        );
-        $fields['contribution_is_test'] = array(
-          'name' => t('Payment Processor Mode'),
-          'type' => 'select',
-          'expose_list' => TRUE,
-          'extra' => array('civicrm_live_options' => 1),
-          'value' => 0,
           'parent' => 'contribution_pagebreak',
         );
         $fields['contribution_source'] = array(


### PR DESCRIPTION
Overview
----------------------------------------
D8 port of #368

D7 or D8?
----------------------------------------
D8

Before
----------------------------------------
Payment processor list depends on the contribution pages.

After
----------------------------------------
- All Payment processor are listed on the contribution tab.
- User-select removed from Payment processor mode so admins have to select either live or test.
- `fixPaymentProcessorID ` isn't available in d8wfc so the removal code isn't required here.

Comments
----------------------------------------
ping @KarinG @mattwire 