### PR TITLE
Issue#3174133: Allow static widget to use values other than default value

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -549,8 +549,6 @@ function _webform_render_civicrm_contact($component, $value = NULL, $filter = TR
 function wf_crm_fill_contact_value($node, $component, &$element, $ids = NULL) {
   $cid = wf_crm_aval($element, '#default_value', '');
   if ($element['#type'] == 'hidden') {
-    // User may not change this value for hidden fields
-    $element['#value'] = $cid;
     if (!$component['extra']['show_hidden_contact']) {
       return;
     }


### PR DESCRIPTION
Overview
----------------------------------------
Currently if you add two contacts to the webform with configuration below:
1. Contact A: Individual (Widget: Autocomplete)
2. Contact B: Employer of contact A (Widget: Static)

With above configuration the below will happen:
1. Change contact A to another individual contact.
2. Contact B will change as per the contact chosen in step 1
3. Save the webform
4. See the submission, you will notice the contact B is still not changed even though it loaded fine in step 2.

This PR fixes that.

D7 or D8?
----------------------------------------
The PR is for D7.

Before
----------------------------------------
![CATL-1711-before](https://user-images.githubusercontent.com/7393885/95185997-179df600-07e7-11eb-8917-8a94e905598c.gif)

After
----------------------------------------
![CATL-1711-after](https://user-images.githubusercontent.com/7393885/95185903-f6d5a080-07e6-11eb-830c-a6c042ed7055.gif)


Technical Details
----------------------------------------
In `function wf_crm_fill_contact_value` the code sets the value for `$element['#value']` because of which webform skips this element and doesn't fetch it's value from `$form_state['input']` because of which the value for existing contact element remains unchanged when the `static` widget is used.
Removing that code as part of this PR.
