### PR TITLE
D8 - Make email receipt independent of the contribution page

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1082,6 +1082,66 @@ class wf_crm_admin_form {
         $this->form['contribution']['sets']['lineitem'][$fs][$fid] = $this->addItem($fid, $field);
       }
     }
+
+    // Receipt
+    $n = wf_crm_aval($this->data, "receipt:number_number_of_receipt", 0);
+    $this->form['contribution']['sets']["receipt_1_number_of_receipt"] = [
+      '#type' => 'select',
+      '#title' => t('Enable Receipt?'),
+      '#default_value' => $n,
+      '#options' => [t('No'), t('Yes')],
+      '#prefix' => '<div class="number-of">',
+      '#suffix' => '</div>',
+      '#description' => t('Enable this section if you want an electronic receipt to be sent automatically to the contributor\'s email address.'),
+    ];
+    $this->addAjaxItem("contribution:sets", "receipt_1_number_of_receipt", "receipt");
+    if ($n) {
+      $fs = "contribution_sets_receipt_{$n}_fieldset";
+      $this->form['contribution']['sets']['receipt'][$fs] = [
+        '#type' => 'fieldset',
+        '#title' => t('Receipt'),
+        '#attributes' => ['id' => $fs, 'class' => ['web-civi-checkbox-set']],
+        'js_select' => $this->addToggle($fs),
+      ];
+      $emailFields = [
+        'receipt_1_number_of_receipt_receipt_from_name' => [
+          '#type' => 'textfield',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_receipt_from_name", ''),
+          '#title' => t('Receipt From Name'),
+          '#description' => t('Enter the FROM name to be used in receipt emails.'),
+        ],
+        'receipt_1_number_of_receipt_receipt_from_email' => [
+          '#type' => 'textfield',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_receipt_from_email", ''),
+          '#title' => t('Receipt From Email'),
+          '#required' => TRUE,
+          '#description' => t('Enter the FROM email address to be used in receipt emails.'),
+        ],
+        'receipt_1_number_of_receipt_receipt_text' => [
+          '#type' => 'textarea',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_receipt_text", ''),
+          '#title' => t('Receipt Text'),
+          '#prefix' => '<div class="auto-width">',
+          '#suffix' => '</div>',
+          '#description' => t('Enter a message you want included at the beginning of emailed receipts. NOTE: The text entered here will be used for both TEXT and HTML versions of receipt emails so we do not recommend including HTML tags / formatting here.'),
+        ],
+        'receipt_1_number_of_receipt_cc_receipt' => [
+          '#type' => 'textfield',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_cc_receipt", ''),
+          '#title' => t('CC Receipt To'),
+          '#description' => t('If you want member(s) of your organization to receive a carbon copy of each emailed receipt, enter one or more email addresses here. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).'),
+        ],
+        'receipt_1_number_of_receipt_bcc_receipt' => [
+          '#type' => 'textfield',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_bcc_receipt", ''),
+          '#title' => t('BCC Receipt To'),
+          '#description' => t('If you want member(s) of your organization to receive a BLIND carbon copy of each emailed receipt, enter one or more email addresses here. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).'),
+        ],
+      ];
+      foreach ($emailFields as $k => $fld) {
+        $this->form['contribution']['sets']['receipt'][$fs][$k] = $fld;
+      }
+    }
   }
 
   /**
@@ -1536,7 +1596,7 @@ class wf_crm_admin_form {
           $this->data[$ent][$c][$key] = $val;
         }
         // Standalone entities keep their own count independent of contacts
-        elseif ($ent == 'grant' || $ent == 'activity' || $ent == 'case' || $ent == 'lineitem') {
+        elseif ($ent == 'grant' || $ent == 'activity' || $ent == 'case' || $ent == 'lineitem' || $ent == 'receipt') {
           $this->data[$ent]["number_$key"] = $val;
         }
       }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -285,10 +285,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 //      webform_submission_send_mail($this->node, $this->submission);
       $this->submitIPNPayment();
     }
+    $isEmailReceipt = wf_crm_aval($this->data, "receipt:number_number_of_receipt", FALSE);
     // Send receipt
     if (empty($this->submission->isDraft())
       && !empty($this->ent['contribution'][1]['id'])
-      && !empty($this->contribution_page['is_email_receipt'])
+      && !empty($isEmailReceipt)
       && (!$this->contributionIsIncomplete || $this->contributionIsPayLater)
     ) {
       $this->sendReceipt();
@@ -299,6 +300,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Send receipt
    */
   private function sendReceipt() {
+    $receipt = wf_crm_aval($this->data, "receipt", []);
     // tax integration
     if (!is_null($this->tax_rate)) {
       $template = CRM_Core_Smarty::singleton();
@@ -311,6 +313,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params = array_merge($this->contribution_page, array('id' => $this->ent['contribution'][1]['id']));
     $params['payment_processor_id'] = $this->data['contribution'][1]['contribution'][1]['payment_processor_id'];
     unset($params['payment_processor']);
+    //Assign receipt values set on the webform config page.
+    $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
+    foreach ($receiptValues as $val) {
+      $params[$val] = $receipt["number_number_of_receipt_{$val}"] ?? '';
+    }
     wf_civicrm_api('contribution', 'sendconfirmation', $params);
   }
 

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -7,6 +7,7 @@
 
 use Drupal\webform_civicrm\Utils;
 use Drupal\node\Entity\Node;
+use Drupal\webform\Entity\Webform;
 
 /**
  * Implements hook_requirements().
@@ -141,4 +142,36 @@ function webform_civicrm_schema() {
     'primary key' => array('sid'),
   );
   return $schema;
+}
+
+/**
+ * Update receipt setting as per the value set in the contribution page.
+ */
+function webform_civicrm_update_8001() {
+  \Drupal::service('civicrm')->initialize();
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $contribution = wf_crm_aval($config, "webform_civicrm:settings:data:contribution:1:contribution:1", []);
+    if (!empty($contribution['contribution_page_id'])) {
+      $contribution_page = current(wf_crm_apivalues('ContributionPage', 'get', [
+        'return' => ["bcc_receipt", "cc_receipt", "receipt_text", "receipt_from_name", "receipt_from_email", "is_email_receipt"],
+        'id' => $contribution['contribution_page_id'],
+      ]));
+      if (!empty($contribution_page['is_email_receipt'])) {
+        $settings = &$config['webform_civicrm']['settings'];
+        $settings['receipt_1_number_of_receipt'] = $settings['data']['receipt']['number_number_of_receipt'] = 1;
+        $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
+        foreach ($receiptValues as $val) {
+          $settings["receipt_1_number_of_receipt_{$val}"] = $settings['data']['receipt']["number_number_of_receipt_{$val}"] =  $contribution_page[$val] ?? '';
+        }
+        $handler->setConfiguration($config);
+        $webform->save();
+      }
+    }
+  }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add Email Receipt config on the webform instead of fetching it from the contribution page.

D7 or D8?
----------------------------------------
D8

Before
----------------------------------------
Sending Email receipt is dependent on the contribution page selected on the webform.

After
----------------------------------------
New email receipt config added.

![Screenshot 2020-10-11 at 7 06 17 PM](https://user-images.githubusercontent.com/5929648/95680131-ef523500-0bf4-11eb-8a3d-d76d0d61b0ce.jpg)

- If enabled, contribution receipt will be sent to the donor.
- CC and BCC can be set from the webform.
- Upgrade code added to update the existing webforms to have the email fields default to the contribution page selected.

Comments
----------------------------------------
ping @KarinG 

Currently, this requires an additional civicrm patch - https://github.com/civicrm/civicrm-core/commit/b83493e9e454233b5a13e2e95db923c4e8973da6 due to a bug in civi core which uses cc and bcc from the contribution page even if it is overridden in the sendconfirmation api params.

