### PR TITLE
Autocomplete Element filter cannot be configured with smart groups

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -338,7 +338,10 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#multiple' => TRUE,
     '#title' => t('Groups'),
-    '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_apivalues('group', 'get', [], 'title'),
+    '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_apivalues('group', 'get', [
+        'is_active' => 1,
+        'options' => ['sort' => 'title'],
+      ], 'title'),
     '#default_value' => $component['extra']['filters']['group'],
     '#description' => t('Listed contacts must be members of at least one of the selected groups (leave blank to not filter by group).'),
   ];

--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -338,7 +338,7 @@ function _webform_edit_civicrm_contact($component) {
     '#type' => 'select',
     '#multiple' => TRUE,
     '#title' => t('Groups'),
-    '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_apivalues('group_contact', 'getoptions', ['field' => 'group_id']),
+    '#options' => ['' => '- ' . t('None') . ' -'] + wf_crm_apivalues('group', 'get', [], 'title'),
     '#default_value' => $component['extra']['filters']['group'],
     '#description' => t('Listed contacts must be members of at least one of the selected groups (leave blank to not filter by group).'),
   ];


### PR DESCRIPTION
Overview
----------------------------------------
Webform_civicrm has a special element type "Existing Contact". It can be used to lookup existing contacts in CiviCRM and use them in the form. It is possible to restrict the list of contacts by requiring that they have to belong to a certain group. However, in the list with groups, the smart groups are not shown.

More information at https://www.drupal.org/project/webform_civicrm/issues/3177748

D7
----------------------------------------

Before
----------------------------------------
![webform_smartgroup](https://user-images.githubusercontent.com/14834891/96465998-ee8b5580-1229-11eb-908b-5fb27e2af705.png)
(1) The smart groups are not shown.

After
----------------------------------------
(1) The smart groups are shown.

Technical Details
----------------------------------------
The filter does work with smart groups
