### PR TITLE
Verify a contact is created when the Webform is submitted

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -488,7 +488,7 @@ class CivicrmContact extends WebformElementBase {
     $cid = wf_crm_aval($element, '#default_value', '');
     $contactComponent = \Drupal::service('webform_civicrm.contact_component');
     if ($element['#type'] == 'hidden') {
-      if (!$component['#show_hidden_contact']) {
+      if (!isset($component['#show_hidden_contact']) || !$component['#show_hidden_contact']) {
         return;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Extends the test to submit the webform and verify the contact over the CiviCRM API

Before
----------------------------------------
Form loaded with a notice, didn't test submit

After
----------------------------------------
Form loads, no notices, and submitted!
