### PR TITLE
D7 - [WIP] Add new setting to respect existing membership_type on updates

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1185,6 +1185,12 @@ class wf_crm_admin_form {
       '#default_value' => $this->settings['new_contact_source'],
       '#description' => t('Optional "source" label for any new contact/participant/membership created by this webform.'),
     ];
+    $this->form['options']['existing_membership_type'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Keep Existing Membership Type'),
+      '#default_value' => !empty($this->settings['existing_membership_type']),
+      '#description' => t('If enabled, when the webform includes a Membership, the Membership Type will be respected in order to update it (if User already has it, if not it will created).'),
+    ];
   }
 
   /**

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1123,18 +1123,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
 
       // Search for existing membership to renew - must belong to same domain and organization
-      // But not necessarily the same membership type to allow for upsell
+      // Depending on existing_membership_type setting allow update different membership type for upsell or not
       if (!empty($params['num_terms'])) {
         $type = $types[$params['membership_type_id']];
         foreach ($existing as $mem) {
           $existing_type = $types[$mem['membership_type_id']];
           if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
-            $params['id'] = $mem['id'];
+            if (empty($this->settings['existing_membership_type'])) {
+              $params['id'] = $mem['id'];
+            }
             // If we have an exact match, look no further
             if ($mem['membership_type_id'] == $params['membership_type_id']) {
               $is_active = $mem['is_active'];
               $membershipStatus = $mem['status'];
               $membershipEndDate = $mem['end_date'];
+              $params['id'] = $mem['id'];
               break;
             }
           }

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -107,6 +107,13 @@ function webform_civicrm_schema() {
         'default' => '',
         'description' => 'Source label for newly created contacts',
       ],
+      'existing_membership_type' => [
+        'description' => 'Update the Membership based on existing membership types.',
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
     ],
     'primary key' => ['nid'],
   ];
@@ -831,4 +838,18 @@ function webform_civicrm_update_7403() {
     'default' => 0,
   ];
   db_add_field('webform_civicrm_forms', 'create_new_relationship', $field);
+}
+
+/**
+ * Add field to respect membership_type or not on existing Membership updates.
+ */
+function webform_civicrm_update_7404() {
+  $field = [
+    'description' => 'Update the Membership based on existing membership types.',
+    'type' => 'int',
+    'size' => 'tiny',
+    'not null' => TRUE,
+    'default' => 0,
+  ];
+  db_add_field('webform_civicrm_forms', 'existing_membership_type', $field);
 }


### PR DESCRIPTION
Overview
----------------------------------------
Following the discussion threads on [#64](https://github.com/colemanw/webform_civicrm/pull/64) and [#199](https://github.com/colemanw/webform_civicrm/pull/199), `CiviCRM` core and `webform_civicrm` don't allow to create and update in a public form (Drupal Webforms or Contribution Pages) two or more Memberships with different types belonging to same organization for a single contact separately.

The arguments raised by @KarinG in [#199](https://github.com/colemanw/webform_civicrm/pull/199) are correct, **but** are not taking into consideration that this can be achieved from the CiviCRM backend itself.. there's no limitation for an user in Civi to create 2 different memberships of different membership_types belonging to same Org, for a contact. And because of that we have loads of Organizations using the CiviCRM in that way.

But we have the limitation on public forms to follow that rule. And this is excluding a lot of use cases from different ORGs to have for instance: 2 different Webforms to create 2 different `membership_types`, the default behaviour nowadays for the second webform will update the first membership that the User has, regardless the `membership_type`, instead of expecting behaviour which would be to create the second membership.
So this **[WIP] PR** is similar than the one @jaapjansma submitted in [#199](https://github.com/colemanw/webform_civicrm/pull/199) to fill the gap of this.

Still in **[WIP]** state so we can reopen this discussion about this topic.

D7 or D8?
----------------------------------------
D7

Before
----------------------------------------
If the User filling the webform, exists and has a membership, the webform will update that membership (the latest one in case of having many), regardless the `membership_type` defined for the membership in the `webfrom_civicrm`

After
----------------------------------------
If the User filling the webform, exists and has a membership, the webform will update only an existing membership of the same `membership_type`. If it doesn't exists webform_civicrm will create it.

Technical Details
----------------------------------------
It add s a new `webform_civicrm` setting, by default disabled, so the normal behaviour it's not affected at all, as it is right now.

Comments
----------------------------------------
Comments and ideas welcome :)
