### PR TITLE
[WIP] D7 - Add new Membership Type action setting

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1185,6 +1185,12 @@ class wf_crm_admin_form {
       '#default_value' => $this->settings['new_contact_source'],
       '#description' => t('Optional "source" label for any new contact/participant/membership created by this webform.'),
     ];
+    $this->form['options']['existing_membership_type'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Keep Existing Membership Type'),
+      '#default_value' => !empty($this->settings['existing_membership_type']),
+      '#description' => t('If enabled, when the webform includes a Membership, the Membership Type will be respected in order to update it (if User already has it, if not it will created).'),
+    ];
   }
 
   /**

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -585,7 +585,7 @@ abstract class wf_crm_webform_base {
     static $status_types;
     static $membership_types;
     if (!isset($membership_types)) {
-      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => 'current_domain', 'return' => 'id']));
+      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'return' => 'id']));
     }
     $existing = wf_crm_apivalues('membership', 'get', [
       'contact_id' => $cid,

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1123,18 +1123,21 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       }
 
       // Search for existing membership to renew - must belong to same domain and organization
-      // But not necessarily the same membership type to allow for upsell
+      // Depending on existing_membership_type setting allow update different membership type for upsell or not
       if (!empty($params['num_terms'])) {
         $type = $types[$params['membership_type_id']];
         foreach ($existing as $mem) {
           $existing_type = $types[$mem['membership_type_id']];
           if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
-            $params['id'] = $mem['id'];
+            if (empty($this->settings['existing_membership_type'])) {
+              $params['id'] = $mem['id'];
+            }
             // If we have an exact match, look no further
             if ($mem['membership_type_id'] == $params['membership_type_id']) {
               $is_active = $mem['is_active'];
               $membershipStatus = $mem['status'];
               $membershipEndDate = $mem['end_date'];
+              $params['id'] = $mem['id'];
               break;
             }
           }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1129,22 +1129,20 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
       // Search for existing membership to renew - must belong to same domain and organization
       // Depending on membership_type_action setting allow update different membership type for upsell or not, or force new creation always
-      if (!empty($params['num_terms'])) {
-        $type = $types[$params['membership_type_id']];
-        foreach ($existing as $mem) {
-          $existing_type = $types[$mem['membership_type_id']];
-          if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
-            if (empty($this->settings['membership_type_action'])) {
-              $params['id'] = $mem['id'];
-            }
-            // If we have an exact match, look no further
-            if ($mem['membership_type_id'] == $params['membership_type_id']) {
-              $is_active = $mem['is_active'];
-              $membershipStatus = $mem['status'];
-              $membershipEndDate = $mem['end_date'];
-              $params['id'] = $mem['id'];
-              break;
-            }
+      $type = $types[$params['membership_type_id']];
+      foreach ($existing as $mem) {
+        $existing_type = $types[$mem['membership_type_id']];
+        if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
+          if (empty($this->settings['membership_type_action'])) {
+            $params['id'] = $mem['id'];
+          }
+          // If we have an exact match, look no further
+          if ($mem['membership_type_id'] == $params['membership_type_id']) {
+            $is_active = $mem['is_active'];
+            $membershipStatus = $mem['status'];
+            $membershipEndDate = $mem['end_date'];
+            $params['id'] = $mem['id'];
+            break;
           }
         }
       }

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -107,6 +107,13 @@ function webform_civicrm_schema() {
         'default' => '',
         'description' => 'Source label for newly created contacts',
       ],
+      'existing_membership_type' => [
+        'description' => 'Update the Membership based on existing membership types.',
+        'type' => 'int',
+        'size' => 'tiny',
+        'not null' => TRUE,
+        'default' => 0,
+      ],
     ],
     'primary key' => ['nid'],
   ];
@@ -831,4 +838,18 @@ function webform_civicrm_update_7403() {
     'default' => 0,
   ];
   db_add_field('webform_civicrm_forms', 'create_new_relationship', $field);
+}
+
+/**
+ * Add field to respect membership_type or not on existing Membership updates.
+ */
+function webform_civicrm_update_7404() {
+  $field = [
+    'description' => 'Update the Membership based on existing membership types.',
+    'type' => 'int',
+    'size' => 'tiny',
+    'not null' => TRUE,
+    'default' => 0,
+  ];
+  db_add_field('webform_civicrm_forms', 'existing_membership_type', $field);
 }


### PR DESCRIPTION
Overview
----------------------------------------
This is an enhanced implementation of of [#382 ](https://github.com/colemanw/webform_civicrm/pull/382) based on the suggestions of @mattwire  --> https://github.com/colemanw/webform_civicrm/pull/382#issuecomment-720423579

D7 or D8?
----------------------------------------
D7

Before
----------------------------------------
If the User filling the webform, exists and has a membership, the webform will update that membership (the latest one in case of having many), regardless the membership_type defined for the membership in the webfrom_civicrm

After
----------------------------------------
Now the Membership update/creation action will be based in the setting selected as:
1.  Update existing membership of different type and change type.
2.  Update existing membership of same type.
3.  Add new membership and don't touch existing.


Technical Details
----------------------------------------
Noticed I had to revert commit 32f8acab6cb976f5c28f7be812ab0e844aa7373e for CiviCRM ESR 5.27.7 compatibility

Comments
----------------------------------------
still [WIP]
