### PR TITLE
Fetch domain because APIv3 does not do so reliably

### DIFF
--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -580,7 +580,9 @@ abstract class wf_crm_webform_base {
     static $status_types;
     static $membership_types;
     if (!isset($membership_types)) {
-      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => 'current_domain', 'return' => 'id']));
+      $domain = wf_civicrm_api('domain', 'get', ['current_domain' => 1, 'return' => 'id']);
+      $domain = wf_crm_aval($domain, 'id', 1);
+      $membership_types = array_keys(wf_crm_apivalues('membershipType', 'get', ['is_active' => 1, 'domain_id' => $domain, 'return' => 'id']));
     }
     $existing = wf_crm_apivalues('membership', 'get', [
       'contact_id' => $cid,


### PR DESCRIPTION
Overview
----------------------------------------
APIv3 has inconsitent handling of the 'current_domain' keyword,
so we'll do it ourselves to ensure it works.

This fixes a bug noted in https://github.com/colemanw/webform_civicrm/commit/32f8acab6cb976f5c28f7be812ab0e844aa7373e