### PR TITLE
Remove contribution page dependency from the webform

### DIFF
--- a/includes/wf_crm_admin_component.inc
+++ b/includes/wf_crm_admin_component.inc
@@ -93,7 +93,7 @@ class wf_crm_admin_component {
       $this->form['value']['#empty_value'] = '';
     }
 
-    elseif ($name == 'contribution_page_id') {
+    elseif ($name == 'enable_contribution') {
       $this->form['value']['#access'] = FALSE;
       $this->form['#prefix'] = '<p>' . t('This is a placeholder for a Contribution Page.') . '</p>';
     }
@@ -207,7 +207,7 @@ class wf_crm_admin_component {
   public function adjustPageBreak() {
     $components = $this->node->webform['components'];
     foreach ($components as $cid => $component) {
-      if ($component['form_key'] == 'civicrm_1_contribution_1_contribution_contribution_page_id') {
+      if ($component['form_key'] == 'civicrm_1_contribution_1_contribution_enable_contribution') {
         // Iterate up through parents
         while ($component['pid']) {
           $component = $components[$component['pid']];
@@ -573,7 +573,7 @@ class wf_crm_admin_component {
             $row['data'][3]['data'] = $val;
           }
           // Contribution page - link to civicrm config form instead of component edit form
-          if ($name == 'contribution_page_id') {
+          if ($name == 'enable_contribution') {
             $type = t('CiviCRM Billing Fields');
             $class .= ' contribution';
             $row['data'][6]['data'] = l(t('Configure'), 'civicrm/admin/contribute/settings', array(
@@ -614,7 +614,7 @@ class wf_crm_admin_component {
         if (in_array($key, $field_ids)) {
           $payment_fields[$cid] = $component;
         }
-        elseif ($key == 'contribution_contribution_page_id') {
+        elseif ($key == 'contribution_enable_contribution') {
           $contribution_page_page = $component['page_num'];
         }
       }
@@ -756,7 +756,7 @@ function wf_crm_components_form_validate($form, &$form_state) {
   $components = wf_crm_aval($form_state, 'values:components', array());
   foreach ($components as $cid => $component) {
     $component += $form['#node']->webform['components'][$cid];
-    if ($component['form_key'] == 'civicrm_1_contribution_1_contribution_contribution_page_id') {
+    if ($component['form_key'] == 'civicrm_1_contribution_1_contribution_enable_contribution') {
       // Iterate up through parents
       while ($component['pid']) {
         $component = $components[$component['pid']];

--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1027,22 +1027,26 @@ class wf_crm_admin_form {
       '#description' => t('In order to process live transactions for events, memberships, or contributions, select a contribution page and its billing fields will be included on the webform.'),
       '#attributes' => array('class' => array('civi-icon-contribution')),
     );
-    $fid = 'civicrm_1_contribution_1_contribution_contribution_page_id';
-    $this->form['contribution'][$fid] = $this->addItem($fid, $this->fields['contribution_contribution_page_id']);
-    unset($this->sets['contribution']['fields']['contribution_contribution_page_id']);
+    $fid = 'civicrm_1_contribution_1_contribution_enable_contribution';
+    $enable_contribution = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
+    unset($this->sets['contribution']['fields']['contribution_enable_contribution']);
+    $this->form['contribution'][$fid] = [
+      '#type' => 'select',
+      '#title' => t('Enable Contribution?'),
+      '#default_value' => $enable_contribution,
+      '#options' => [t('No'), t('Yes')],
+      '#description' => t('Enable this section to submit a payment for the contact.'),
+    ];
     $this->addAjaxItem('contribution', $fid, 'sets');
-    $page_id = wf_crm_aval($this->data, 'contribution:1:contribution:1:contribution_page_id');
-    if ($page_id) {
-      $page = wf_civicrm_api('contribution_page', 'getsingle', array('id' => $page_id));
-    }
-    if (!$page_id || empty($page['financial_type_id'])) {
+    $contribution = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
+    if (!$contribution) {
       return;
     }
     // Make sure webform is set-up to prevent credit card abuse.
     $this->checkSubmissionLimit();
     // Add contribution fields
     foreach ($this->sets as $sid => $set) {
-      if ($set['entity_type'] == 'contribution' && (empty($set['sub_types']) || in_array($page['financial_type_id'], $set['sub_types']) )) {
+      if ($set['entity_type'] == 'contribution' && (empty($set['sub_types']))) {
         $this->form['contribution']['sets'][$sid] = array(
           '#type' => 'fieldset',
           '#title' => $set['label'],
@@ -1058,6 +1062,27 @@ class wf_crm_admin_form {
         }
       }
     }
+    //Add financial type config.
+    $ft_options = (array) wf_crm_apivalues('Contribution', 'getoptions', [
+      'field' => "financial_type_id",
+    ]);
+    $this->form['contribution']['sets']['contribution']['civicrm_1_contribution_1_contribution_financial_type_id'] = [
+      '#type' => 'select',
+      '#title' => t('Financial Type'),
+      '#default_value' => wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id'),
+      '#options' => $ft_options,
+      '#required' => TRUE,
+    ];
+
+    //Add Currency.
+    $this->form['contribution']['sets']['contribution']['contribution_1_settings_currency'] = [
+      '#type' => 'select',
+      '#title' => t('Currency'),
+      '#default_value' => wf_crm_aval($this->data, "contribution:1:currency"),
+      '#options' => CRM_Core_OptionGroup::values('currencies_enabled'),
+      '#required' => TRUE,
+    ];
+
     // LineItem
     $num = wf_crm_aval($this->data, "lineitem:number_number_of_lineitem", 0);
     $this->form['contribution']['sets']["lineitem_1_number_of_lineitem"] = array(
@@ -1757,7 +1782,7 @@ class wf_crm_admin_form {
       }*/
 
       $i = 0;
-      $created = array();
+      $created = [];
       foreach ($this->settings as $key => $val) {
         if (strpos($key, 'civicrm') === 0) {
           ++$i;
@@ -2073,8 +2098,8 @@ class wf_crm_admin_form {
        $fieldset_key = self::addFieldset($c, $field, $enabled, $settings, $ent, $create_fieldsets);
        $field['parent'] = $fieldset_key;
     }
-    // Create page break for contribution page
-    if ($name === 'contribution_page_id') {
+    // Create page break for contribution
+    if ($name === 'enable_contribution') {
       // @todo properly inject a page break.
       // there needs to be a root page and nested elements.
       $enabled['contribution_pagebreak'] = [
@@ -2083,6 +2108,8 @@ class wf_crm_admin_form {
         'title' => (string) t('Payment'),
       ];
       self::addPageBreak($field);
+      unset($enabled[$field['form_key']]);
+      return;
     }
     // Merge defaults and create webform component
     $field += ['extra' => []];

--- a/includes/wf_crm_webform_base.inc
+++ b/includes/wf_crm_webform_base.inc
@@ -15,7 +15,6 @@ use Drupal\Core\File\FileSystemInterface;
  * Class wf_crm_webform_base
  *
  * @property array $payment_processor
- * @property array $contribution_page
  * @property number $tax_rate
  * @property number $civicrm_version
  */
@@ -36,7 +35,6 @@ abstract class wf_crm_webform_base {
 
   // No direct access - storage for variables fetched via __get
   private $_payment_processor;
-  private $_contribution_page;
   // tax integration
   private $_tax_rate;
 
@@ -59,20 +57,15 @@ abstract class wf_crm_webform_base {
         }
         return $this->_payment_processor;
 
-      case 'contribution_page':
-        $contribution_page_id = wf_crm_aval($this->data, 'contribution:1:contribution:1:contribution_page_id');
-        if ($contribution_page_id && !$this->_contribution_page) {
-          $this->_contribution_page = wf_civicrm_api('contribution_page', 'getsingle', array('id' => $contribution_page_id));
-        }
-        return $this->_contribution_page;
-
       case 'tax_rate':
         $taxSettings = wf_crm_get_civi_setting('contribution_invoice_settings');
         if (is_array($taxSettings) && !empty($taxSettings['invoicing'])) {
-          if ($this->contribution_page) {
+          $contribution_enabled = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
+          if ($contribution_enabled) {
             // tax integration
             $taxRates = CRM_Core_PseudoConstant::getTaxRates();
-            $this->_tax_rate = isset($taxRates[$this->_contribution_page['financial_type_id']]) ? $taxRates[$this->_contribution_page['financial_type_id']] : NULL;
+            $ft = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
+            $this->_tax_rate = $taxRates[$ft] ?? NULL;
           }
           return $this->_tax_rate;
         }

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -129,7 +129,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     // Process live contribution. If the transaction is unsuccessful it will trigger a form validation error.
-    if ($this->contribution_page) {
+    $contribution_enabled = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
+    if ($contribution_enabled) {
       // Ensure contribution js is still loaded if the form has to refresh
       $this->addPaymentJs();
       $this->loadMultiPageData();
@@ -300,7 +301,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    * Send receipt
    */
   private function sendReceipt() {
-    $receipt = wf_crm_aval($this->data, "receipt", []);
     // tax integration
     if (!is_null($this->tax_rate)) {
       $template = CRM_Core_Smarty::singleton();
@@ -310,15 +310,30 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $template = CRM_Core_Smarty::singleton();
       $template->assign('is_pay_later', 1);
     }
-    $params = array_merge($this->contribution_page, array('id' => $this->ent['contribution'][1]['id']));
-    $params['payment_processor_id'] = $this->data['contribution'][1]['contribution'][1]['payment_processor_id'];
+    wf_civicrm_api('contribution', 'sendconfirmation', $this->getReceiptParams());
+  }
+
+  /**
+   * Build params for contribution receipt.
+   *
+   * @return array
+   */
+  private function getReceiptParams() {
+    $contributionData = wf_crm_aval($this->data, 'contribution:1:contribution:1');
+    $params = ['id' => $this->ent['contribution'][1]['id']];
+    $params['payment_processor_id'] = $contributionData['payment_processor_id'];
     unset($params['payment_processor']);
+
+    $params['financial_type_id'] = $contributionData['financial_type_id'];
+    $params['currency'] = wf_crm_aval($this->data, "contribution:1:currency");
+
     //Assign receipt values set on the webform config page.
+    $receipt = wf_crm_aval($this->data, "receipt", []);
     $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
     foreach ($receiptValues as $val) {
       $params[$val] = $receipt["number_number_of_receipt_{$val}"] ?? '';
     }
-    wf_civicrm_api('contribution', 'sendconfirmation', $params);
+    return $params;
   }
 
   /**
@@ -1569,7 +1584,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $this->line_items[] = array(
         'qty' => 1,
         'unit_price' => $this->getData($fid),
-        'financial_type_id' => $this->contribution_page['financial_type_id'],
+        'financial_type_id' => wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id'),
         'label' => wf_crm_aval($this->node->getElementsDecoded(), $this->enabled[$fid] . ':title', t('Contribution')),
         'element' => 'civicrm_1_contribution_1',
         'entity_table' => 'civicrm_contribution',
@@ -1926,7 +1941,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['is_pay_later'] = $this->contributionIsPayLater;
     //Fix IPN payments marked as paid by cheque
     if (empty($params['payment_instrument_id'])) {
-      if (!empty($params['payment_processor_id']) && $this->contribution_page['is_monetary']) {
+      if (!empty($params['payment_processor_id'])) {
         $defaultPaymentInstrument = CRM_Core_OptionGroup::values('payment_instrument', FALSE, FALSE, FALSE, 'AND is_default = 1');
         $params['payment_instrument_id'] = key($defaultPaymentInstrument);
       }
@@ -1964,12 +1979,12 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['qfKey'] = $this->getQfKey();
 
     $params['contactID'] = $params['contact_id'];
-    $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
+    $params['currency'] = $params['currencyID'] = wf_crm_aval($this->data, "contribution:1:currency");
     $params['total_amount'] = round($this->totalContribution, 2);
     // Some processors want this one way, some want it the other
     $params['amount'] = $params['total_amount'];
 
-    $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
+    $params['financial_type_id'] = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
 
     $params['source'] = $this->settings['new_contact_source'];
     $params['item_name'] = $params['description'] = t('Webform Payment: @title', array('@title' => $this->node->label()));
@@ -2025,8 +2040,8 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
    */
   private function contributionParams() {
     $params = $this->billing_params + $this->data['contribution'][1]['contribution'][1];
-    $params['financial_type_id'] = $this->contribution_page['financial_type_id'];
-    $params['currency'] = $params['currencyID'] = $this->contribution_page['currency'];
+    $params['financial_type_id'] = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
+    $params['currency'] = $params['currencyID'] = wf_crm_aval($this->data, "contribution:1:currency");
     $params['skipRecentView'] = $params['skipLineItem'] = 1;
     $params['contact_id'] = $this->ent['contact'][1]['id'];
     $params['total_amount'] = round($this->totalContribution, 2);
@@ -2142,7 +2157,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           'contact_id' => $cid,
           'contribution_id' => $id,
           'amount' => $amount,
-          'currency' => $this->contribution_page['currency'],
+          'currency' => wf_crm_aval($this->data, "contribution:1:currency"),
           'soft_credit_type_id' => $default_soft_credit_type['value'],
         ));
       }

--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -171,6 +171,16 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     // Passing $submitted helps avoid overwriting values that have been entered on a multi-step form
     $submitted = $this->form_state->getValue('submitted', []);
     $this->fillForm($this->form, $submitted);
+
+    $enable_contribution = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
+    if ($enable_contribution && $this->form_state->get('current_page') === 'contribution_pagebreak' && empty($this->form['payment_section'])) {
+      $this->form['payment_section'] = [
+        'line_items' => $this->displayLineItems(),
+        'billing_payment_block' => [
+          '#markup' => Markup::create('<div class="crm-container crm-public" id="billing-payment-block"></div>'),
+        ],
+      ];
+    }
   }
 
   /**
@@ -198,7 +208,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     if (!empty($this->data['contribution'])) {
       $this->addPaymentJs();
       $this->form['#attached']['library'][] = 'webform_civicrm/payment';
-      $currency = $this->contribution_page['currency'];
+      $currency = wf_crm_aval($this->data, "contribution:1:currency");
       $contributionCallbackQuery = ['currency' => $currency, 'snippet' => 4, 'is_drupal_webform' => 1];
       $contributionCallbackUrl = 'base://civicrm/payment/form';
       $js_vars['processor_id_key'] = 'processor_id';
@@ -534,20 +544,6 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/contact_component');
             CivicrmContact::wf_crm_fill_contact_value($this->node, $component, $element, $this->ent);
           }
-          if ($name === 'contribution_page_id') {
-            // Work around to remove manual rendering of display line items.
-            // This prevents us from needing to setup a composite element
-            // immediately and remove rendering hacks.
-            $contribution_element = [];
-            $contribution_element['contribution_page_id'] = $element;
-            $contribution_element['contribution_page_id']['#value'] = wf_crm_aval($this->data, 'contribution:1:contribution:1:contribution_page_id');
-            unset($contribution_element['contribution_page_id']['#default_value']);
-            $contribution_element['line_items'] = $this->displayLineItems();
-            $contribution_element['billing_payment_block'] = [
-              '#markup' => Markup::create('<div class="crm-container crm-public" id="billing-payment-block"></div>'),
-            ];
-            $element = $contribution_element;
-          }
         }
       }
     }
@@ -625,7 +621,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     return [
       '#type' => 'table',
       '#sticky' => FALSE,
-      '#caption' => $this->contribution_page['title'],
+      '#caption' => 'Payment Information',
       '#header' => [],
       '#rows' => $rows,
       '#attributes' => ['id' => 'wf-crm-billing-items'],

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -523,7 +523,7 @@ var wfCiviAdmin = (function ($, D) {
       }).change();
 
       function billingMessages() {
-        var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]');
+        var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_enable_contribution]');
         // Warning about contribution page with no email
         if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
           var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(1)});
@@ -550,7 +550,7 @@ var wfCiviAdmin = (function ($, D) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $('[name=civicrm_1_contribution_1_contribution_contribution_page_id], [name=civicrm_1_contact_1_email_email]', context).once('email-alert').change(billingMessages);
+      $('[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_1_contact_1_email_email]', context).once('email-alert').change(billingMessages);
       billingMessages();
 
       // Handlers for submit-limit & tracking-mode mini-forms
@@ -563,11 +563,11 @@ var wfCiviAdmin = (function ($, D) {
         $('#configure-submit-limit').show();
       });
       $('#configure-submit-limit-save', context).once('wf-civi').click(function() {
-        $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]').change();
+        $('[name=civicrm_1_contribution_1_contribution_enable_contribution]').change();
       });
       $('#webform-tracking-mode', context).once('wf-civi').click(function() {
         $('[name=webform_tracking_mode]').val('strict');
-        $('[name=civicrm_1_contribution_1_contribution_contribution_page_id]').change();
+        $('[name=civicrm_1_contribution_1_contribution_enable_contribution]').change();
       });
     }
   };

--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -127,29 +127,6 @@ class AdminHelp implements AdminHelpInterface {
       '</p>';
   }
 
-
-  protected function contribution_contribution_page_id() {
-    return '<p>' .
-      t('It is recommended to <a href=":link">create a new contribution page</a>
-      solely for webform use. When configuring the page, most options will be
-      irrelevant (such as profiles, premiums, widgets, recurring, etc.). Only
-      the following need to be configured:',
-      array(
-        ':link' => Url::fromUri(
-            'internal:/civicrm/admin/contribute/add',
-            array('query' => array('reset' => 1, 'action' => 'add'))
-          )->toString()
-      )) .
-      '</p><ul>' .
-      '<li>' . t('Title: Displayed on the webform.') . '</li>' .
-      '<li>' . t('Financial Type: Controls overall contribution type.') . '</li>' .
-      '<li>' . t('Currency: Sets currency for all payment fields on this form.') . '</li>' .
-      '<li>' . t('Payment Processors: Controls list of options here.') . '</li>' .
-      '<li>' . t('Contribution Amounts: Must be enabled with a label and Allow Other Amounts checked.') . '</li>' .
-      '<li>' . t('Email Receipt: Configure email receipts from this webform.') . '</li>' .
-      '</ul>';
-  }
-
   protected function contribution_payment_processor_id() {
     return '<p>' .
       t('Supported payment processors enabled on the contribution page are available here. "Pay Later" option allows the user to purchase events/memberships without entering a credit card.') .

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -614,8 +614,8 @@ class Fields implements FieldsInterface {
           'value' => 0,
           'weight' => 9996,
         ];
-        $fields['contribution_contribution_page_id'] = array(
-          'name' => ts('Contribution Page'),
+        $fields['contribution_enable_contribution'] = array(
+          'name' => ts('Enable Contribution?'),
           'type' => 'hidden',
           'expose_list' => TRUE,
           'empty_option' => 'None',

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -158,20 +158,28 @@ function webform_civicrm_update_8001() {
     }
     $contribution = wf_crm_aval($config, "webform_civicrm:settings:data:contribution:1:contribution:1", []);
     if (!empty($contribution['contribution_page_id'])) {
+      $returnParams = [
+        "financial_type_id", "currency", "bcc_receipt", "cc_receipt",
+        "receipt_text", "receipt_from_name", "receipt_from_email", "is_email_receipt"
+      ];
       $contribution_page = current(wf_crm_apivalues('ContributionPage', 'get', [
-        'return' => ["bcc_receipt", "cc_receipt", "receipt_text", "receipt_from_name", "receipt_from_email", "is_email_receipt"],
+        'return' => $returnParams,
         'id' => $contribution['contribution_page_id'],
       ]));
+      $settings = &$config['webform_civicrm']['settings'];
+      $settings['civicrm_1_contribution_1_contribution_enable_contribution'] = $settings['data']['contribution'][1]['contribution'][1]["enable_contribution"] = 1;
+      unset($settings['data']['contribution'][1]['contribution'][1]["contribution_page_id"]);
+      $settings['civicrm_1_contribution_1_contribution_financial_type_id'] = $settings['data']['contribution'][1]['contribution'][1]["financial_type_id"] = $contribution_page['financial_type_id'] ?? '';
+      $settings['contribution_1_settings_currency'] = $settings['data']['contribution'][1]['currency'] = $contribution_page['currency'] ?? '';
       if (!empty($contribution_page['is_email_receipt'])) {
-        $settings = &$config['webform_civicrm']['settings'];
         $settings['receipt_1_number_of_receipt'] = $settings['data']['receipt']['number_number_of_receipt'] = 1;
         $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
         foreach ($receiptValues as $val) {
           $settings["receipt_1_number_of_receipt_{$val}"] = $settings['data']['receipt']["number_number_of_receipt_{$val}"] =  $contribution_page[$val] ?? '';
         }
-        $handler->setConfiguration($config);
-        $webform->save();
       }
+      $handler->setConfiguration($config);
+      $webform->save();
     }
   }
 }


### PR DESCRIPTION
Overview
----------------------------------------
Adding a contribution section no longer requires enabling a contribution page.

D7 or D8?
----------------------------------------
D8

Before
----------------------------------------
The contribution section is dependent on civicrm contribution page for various fields - financial type, currency etc.

After
----------------------------------------
Contribution Page dropdown is removed. 

![webform_contribution](https://user-images.githubusercontent.com/5929648/98461609-91a11080-21d3-11eb-85db-46fb85deb9c0.jpg)


Comments
----------------------------------------
Upgrade code included. Ping @KarinG 