### PR TITLE
Always allow case administrators to view cases

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -638,7 +638,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
           if (isset($_GET["case$n"]) && wf_crm_is_positive($_GET["case$n"])) {
             $id = $_GET["case$n"];
             $item = wf_civicrm_api('case', 'getsingle', ['id' => $id]);
-            if (array_intersect((array)wf_crm_aval($item, 'client_id'), $clients)) {
+            if (array_intersect((array) wf_crm_aval($item, 'client_id'), $clients) || user_access('access all cases and activities')) {
               $this->ent['case'][$n] = ['id' => $id];
             }
             else {


### PR DESCRIPTION
This permits logged-in users with 'access all cases and activities' permission to load cases based on an id in the url, regardless of what contacts are on the form.
Previously, cases could only be loaded if a case client or case manager was a known contact on the form.