### PR TITLE
Fix failing pipelines

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
           COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:^8.9 ~/drupal --no-interaction
           cd ~/drupal
           composer config extra.enable-patching true
+          composer config extra.compile-mode all
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:^8.9 civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages}:'~5.29' drupal/webform_civicrm *@dev  --no-suggest

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -23,6 +23,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('settings'));
     $this->getSession()->getPage()->clickLink('CiviCRM');
     // @todo Randomly this fails saying that the checkbox does not exist.
+    $this->assertSession()->waitForText('Enable CiviCRM Processing');
     $this->assertSession()->waitForField('Enable CiviCRM Processing');
     $this->htmlOutput();
     $this->getSession()->getPage()->checkField('Enable CiviCRM Processing');


### PR DESCRIPTION
For non-interactive installs, the `compile-mode` must be set to `all`.

Once that is fixed, we'll tackle the random failure on configuring CiviCRM for a Webform
