### PR TITLE
Set case role (relationship) start date when creating case role, update existing active case role (relationship) if it already exists

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1350,16 +1350,31 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $this->handleEntityTags('case', $result['id'], $n, $params);
           // Store id
           $this->ent['case'][$n]['id'] = $result['id'];
+          $relationshipStartDate = date('Ymd');
           // Save case roles
           foreach ($params as $param => $val) {
             if ($val && strpos($param, 'role_') === 0) {
               foreach ((array) $params['client_id'] as $client) {
-                wf_civicrm_api('relationship', 'create', array(
-                  'relationship_type_id' => substr($param, 5),
-                  'contact_id_a' => $client,
-                  'contact_id_b' => $val,
-                  'case_id' => $result['id'],
-                ));
+                foreach ((array) $val as $contactB) {
+                  $relationshipParams = [
+                    'relationship_type_id' => substr($param, 5),
+                    'contact_id_a' => $client,
+                    'contact_id_b' => $contactB,
+                    'case_id' => $result['id'],
+                    'is_active' => TRUE,
+                  ];
+                  // We can't create a duplicate relationship so check if active relationship exists first.
+                  $existingRelationships = wf_civicrm_api('relationship', 'get', $relationshipParams);
+                  if (!empty($existingRelationships['count'])) {
+                    // Update the existing active relationship (case role)
+                    $relationshipParams['id'] = reset($existingRelationships['values'])['id'];
+                  }
+                  else {
+                    // We didn't used to set start_date - now we do when creating new relationships (case roles)
+                    $relationshipParams['start_date'] = $relationshipStartDate;
+                  }
+                  wf_civicrm_api('relationship', 'create', $relationshipParams);
+                }
               }
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fix creating/updating case roles (relationships).

See related https://github.com/colemanw/webform_civicrm/pull/332

D7 or D8?
----------------------------------------
D8 (See #393 for D7).

Before
----------------------------------------
Error in relationship.create API call if a "duplicate" relationship exists (that could be active or inactive).

After
----------------------------------------
If an active relationship already exists with the same params update it (we probably don't actually need to update because I don't think there are any changes but this feels safest and means that hooks etc will continue to fire.

If an active relationship does not already exist (an inactive one might but we don't want to reactivate that because it preserves history) then we create a new relationship (case role) with the start_date set to today.

Previously we were not setting the start_date.

Technical Details
----------------------------------------
Check for existing relationships and add start_date to new ones.

Comments
----------------------------------------
