### PR TITLE
Add missing Participant Notes field.

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -719,6 +719,10 @@ class Fields implements FieldsInterface {
           'value' => 0,
           'exposed_empty_option' => '- ' . t('Automatic') . ' -',
         );
+        $fields['participant_note'] = [
+          'name' => t('Participant Notes'),
+          'type' => 'textarea',
+        ];
         if (isset($sets['contribution'])) {
           $fields['participant_fee_amount'] = array(
               'name' => t('Participant Fee'),


### PR DESCRIPTION
Overview
----------------------------------------
https://www.drupal.org/project/webform_civicrm/issues/3183822
Bug in D8WFC - type: feature parity with D7WFC

Before
----------------------------------------
Participant Notes field is missing

After
----------------------------------------
Participant Notes field is there!

Technical Details
----------------------------------------
Not sure why it got missed - but easy to add.
