### PR TITLE
fix radio element line item calculation

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -118,7 +118,7 @@ cj(function($) {
     updateLineItem(lineKey, amount, label);
   }
 
-  $('.civicrm-enabled.contribution-line-item')
+  $('.civicrm-enabled.contribution-line-item:not(".form-radios")')
     .each(calculateLineItemAmount)
     .on('change keyup', calculateLineItemAmount)
     .each(function() {


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://www.drupal.org/project/webform_civicrm/issues/3183061

Before
----------------------------------------
Contribution Amount if displayed as radio, does not display the calculated amount in the line item section.

![image](https://user-images.githubusercontent.com/5929648/100872466-dd3f9500-34c7-11eb-94be-526a6c1e0975.png)


After
----------------------------------------
The calculated value is displayed correctly. Tested with Membership Fee, contribution amount and 2 line items amount.

![image](https://user-images.githubusercontent.com/5929648/100872528-f3e5ec00-34c7-11eb-9ef4-de448f790d02.png)


Technical Details
----------------------------------------
`form-radios` is the class for the div which holds all the radio button. This change avoids the js call to be made from div and instead triggers the js function for the exact input radio element.

Comments
----------------------------------------
ping @KarinG 