### PR TITLE
D8: fix unported D7-style error handling on 'Existing Contact' widget

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -162,19 +162,15 @@ class ContactComponent implements ContactComponentInterface {
         }
       }
       // If we get exactly $limit results, there are probably more - warn that the list is truncated
-      // TODO Error reporting is still Drupal7-ish
       if (wf_crm_aval($result, 'count') >= $limit) {
-        watchdog(
-          'webform_civicrm',
-          'Maximum contacts exceeded, list truncated on the webform "@title". The webform_civicrm "@field" field cannot display more than !limit contacts because it is a select list. Recommend switching to autocomplete widget in component settings.',
-          array('!limit' => $limit, '@field' => $component['name'], '@title' => $node->title),
-          WATCHDOG_WARNING,
-          l(t('Edit component'), "node/{$node->nid}/webform/components/{$component['cid']}")
+        \Drupal::logger('webform_civicrm')->warning(
+          'Maximum contacts exceeded, list truncated on the webform "@title". The webform_civicrm "@field" field cannot display more than @limit contacts because it is a select list. Recommend switching to autocomplete widget in component settings.',
+          array('@limit' => $limit, '@field' => $component['#title'], '@title' => $node->label()),
         );
-        if (wf_crm_admin_access($node) && node_is_page($node)) {
-          \Drupal::messenger()->addWarning('<strong>' . t('Maximum contacts exceeded, list truncated.') .'</strong><br>' .
-          t('The field "@field" cannot show more than !limit contacts because it is a select list. Recommend switching to autocomplete widget in <a !link>component settings</a>.',
-            array('!limit' => $limit, '@field' => $component['name'], '!link' => 'href="' . url("node/{$node->nid}/webform/components/{$component['cid']}") . '"')));
+        if ($node->access('update') && \Drupal::currentUser()->hasPermission('access CiviCRM')) {
+          $warning_message = \Drupal\Core\Render\Markup::create('<strong>' . t('Maximum contacts exceeded, list truncated.') .'</strong><br>' .
+          t('The field "@field" cannot show more than @limit contacts because it is a select list. Recommend switching to autocomplete widget.', ['@limit' => $limit, '@field' => $component['#title']]));
+          \Drupal::messenger()->addMessage($warning_message);
         }
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When "Existing Contact" triggers this warning message, it breaks validation of all future elements.  By fixing the error handling, validation of other elements works normally.

Before
----------------------------------------
Undefined call to watchdog.

After
----------------------------------------
Watchdog and on-screen message display correctly.

Technical Details
----------------------------------------
I don't know why `wf_crm_admin_access()` no longer exists.  I'm assuming there's a good reason, but it was a one-line function, so I simply put the D8 equivalent directly inline.

This is my first time looking at `webform_civicrm`'s code - if someone tells me that this is the correct approach, I can also replace the other remaining instances of this function.