### PR TITLE
D8 - Add Pay Later Receipt message to receipts

### DIFF
--- a/includes/wf_crm_admin_form.inc
+++ b/includes/wf_crm_admin_form.inc
@@ -1142,14 +1142,6 @@ class wf_crm_admin_form {
           '#required' => TRUE,
           '#description' => t('Enter the FROM email address to be used in receipt emails.'),
         ],
-        'receipt_1_number_of_receipt_receipt_text' => [
-          '#type' => 'textarea',
-          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_receipt_text", ''),
-          '#title' => t('Receipt Text'),
-          '#prefix' => '<div class="auto-width">',
-          '#suffix' => '</div>',
-          '#description' => t('Enter a message you want included at the beginning of emailed receipts. NOTE: The text entered here will be used for both TEXT and HTML versions of receipt emails so we do not recommend including HTML tags / formatting here.'),
-        ],
         'receipt_1_number_of_receipt_cc_receipt' => [
           '#type' => 'textfield',
           '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_cc_receipt", ''),
@@ -1161,6 +1153,22 @@ class wf_crm_admin_form {
           '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_bcc_receipt", ''),
           '#title' => t('BCC Receipt To'),
           '#description' => t('If you want member(s) of your organization to receive a BLIND carbon copy of each emailed receipt, enter one or more email addresses here. Multiple email addresses should be separated by a comma (e.g. jane@example.org, paula@example.org).'),
+        ],
+        'receipt_1_number_of_receipt_pay_later_receipt' => [
+          '#type' => 'textarea',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_pay_later_receipt", ''),
+          '#title' => t('Pay Later Text'),
+          '#prefix' => '<div class="auto-width">',
+          '#suffix' => '</div>',
+          '#description' => t("Text added to the confirmation email, when the user selects the 'pay later' option (e.g. 'Mail your check to ... within 3 business days.')."),
+        ],
+        'receipt_1_number_of_receipt_receipt_text' => [
+          '#type' => 'textarea',
+          '#default_value' => wf_crm_aval($this->data, "receipt:number_number_of_receipt_receipt_text", ''),
+          '#title' => t('Receipt Text'),
+          '#prefix' => '<div class="auto-width">',
+          '#suffix' => '</div>',
+          '#description' => t('Enter a message you want included at the beginning of emailed receipts. NOTE: The text entered here will be used for both TEXT and HTML versions of receipt emails so we do not recommend including HTML tags / formatting here.'),
         ],
       ];
       foreach ($emailFields as $k => $fld) {

--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -329,7 +329,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
 
     //Assign receipt values set on the webform config page.
     $receipt = wf_crm_aval($this->data, "receipt", []);
-    $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
+    $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'pay_later_receipt', 'receipt_from_name', 'receipt_from_email'];
     foreach ($receiptValues as $val) {
       $params[$val] = $receipt["number_number_of_receipt_{$val}"] ?? '';
     }

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -160,7 +160,7 @@ function webform_civicrm_update_8001() {
     if (!empty($contribution['contribution_page_id'])) {
       $returnParams = [
         "financial_type_id", "currency", "bcc_receipt", "cc_receipt",
-        "receipt_text", "receipt_from_name", "receipt_from_email", "is_email_receipt"
+        "receipt_text", "pay_later_receipt", "receipt_from_name", "receipt_from_email", "is_email_receipt"
       ];
       $contribution_page = current(wf_crm_apivalues('ContributionPage', 'get', [
         'return' => $returnParams,
@@ -173,7 +173,7 @@ function webform_civicrm_update_8001() {
       $settings['contribution_1_settings_currency'] = $settings['data']['contribution'][1]['currency'] = $contribution_page['currency'] ?? '';
       if (!empty($contribution_page['is_email_receipt'])) {
         $settings['receipt_1_number_of_receipt'] = $settings['data']['receipt']['number_number_of_receipt'] = 1;
-        $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'receipt_from_name', 'receipt_from_email'];
+        $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'pay_later_receipt', 'receipt_from_name', 'receipt_from_email'];
         foreach ($receiptValues as $val) {
           $settings["receipt_1_number_of_receipt_{$val}"] = $settings['data']['receipt']["number_number_of_receipt_{$val}"] =  $contribution_page[$val] ?? '';
         }


### PR DESCRIPTION
Overview
----------------------------------------
An extension of #372. Allow webform to set pay later receipt message on the settings page.

Before
----------------------------------------
As contribution page dependency is now removed, there is no way to set custom text for the pay later contributions.

After
----------------------------------------
Added pay later receipt text on the settings page -

![Screenshot 2020-12-05 at 3 40 27 PM](https://user-images.githubusercontent.com/5929648/101239815-c6d84a00-3710-11eb-9cdb-b205a53adfe2.jpg)

Comments
----------------------------------------
Needs https://github.com/civicrm/civicrm-core/pull/19129 PR in core to be applied for this to work as expected. @KarinG Seems like this was pending since we got https://github.com/colemanw/webform_civicrm/pull/372 merged? 