### PR TITLE
Remove civicrm-core patch for test support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,5 @@
   "require": {
       "civicrm/civicrm-drupal-8": "~5.0",
       "drupal/webform": "^5.0"
-  },
-  "extra": {
-    "patches": {
-        "civicrm/civicrm-core": {
-            "Fix Drupal 8+ settings location during tests": "https://patch-diff.githubusercontent.com/raw/civicrm/civicrm-core/pull/18843.patch"
-        }
-    }
   }
 }


### PR DESCRIPTION
I'm fairly certain with 5.32 we can now remove this patch.
