### PR TITLE
Use prefer-dist to prevent civicrm-core from running in development mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,13 +56,14 @@ jobs:
           composer config extra.compile-mode all
           composer config minimum-stability dev
           composer config prefer-stable true
+          composer config preferred-install dist
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} --no-suggest
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages}:${{ matrix.civicrm }} --no-suggest
+          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages}:${{ matrix.civicrm }} --no-suggest --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
         if: matrix.drupal == '^9.0'

--- a/tests/src/FunctionalJavascript/ContributionPageTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPageTest.php
@@ -103,9 +103,7 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');
-    // With CiviCRM 5.33.x, a deprecation notice is bubbling as an error message.
-    // @todo figure out why.
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $api_result = wf_civicrm_api('contribution', 'get', [


### PR DESCRIPTION
🥳 This fixes failures when testing beta/RC CiviCRM releases.