### PR TITLE
Record line_item amounts without rounding.

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2163,11 +2163,6 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
         }
       }
 
-      // Format (and round) monetary values before saving the line items
-      isset($item['unit_price']) ? $item['unit_price'] = CRM_Utils_Money::format($item['unit_price'], NULL, NULL, TRUE) : NULL;
-      isset($item['line_total']) ? $item['line_total'] = CRM_Utils_Money::format($item['line_total'], NULL, NULL, TRUE) : NULL;
-      isset($item['tax_amount']) ? $item['tax_amount'] = CRM_Utils_Money::format($item['tax_amount'], NULL, NULL, TRUE) : NULL;
-
       // Save the line_item
       $line_result = wf_civicrm_api('line_item', 'create', $item);
       $item['id'] = $line_result['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Removes the rounding that is applied to line item amounts during the contribution processing. This fixes some tax round errors that have already been addressed in CiviCRM core by avoiding premature rounding.

Before
----------------------------------------
When a contribution is created from a webform submission, the line item total amount, unit price, and tax amount are rounded.  This can result in a 1c difference between the line item amount and the contribution total per line item.

Example:
- 1 x Membership with at $704.5454
- 10% tax is added ($70.45454)
- Contribution records this exactly, comes out to ~$775.00 after final rounding
- Line item records $704.55 + $70.46† comes to ~$775.01
- Contribution total and line item total *do not match*

† I think it's already rounded the total amount once, so I guess more work might be required here.

One place this causes issues is when you're recording a payment against a "pay later" contribution created in this way, it "Balanced owed" is the line item amount, not the contribution amount.  If you record the contribution amount, the contribution is marked as "Partially paid."

After
----------------------------------------
Amounts are not rounded when creating the line item.  As a result, the contribution amount and line item total / balance owed match.
Actual rounding is deferred to CiviCRM to keep precision for as long as possible.

Technical Details
----------------------------------------
Removes the calls to CRM_Utils_Money::format entirely. These were only used for rounding purposes as far as I could tell.

Comments
----------------------------------------
Agileware ref CIVIWF-5