### PR TITLE
Fail tests if civicrm_ tables exist

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -58,6 +58,14 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
     unset($civicrm_connection_info['prefix']);
     Database::addConnectionInfo('civicrm_test', 'default', $civicrm_connection_info);
     Database::addConnectionInfo('civicrm', 'default', $civicrm_connection_info);
+
+    // Assert that there are no `civicrm_` tables in the test database.
+    $connection = Database::getConnection('default', 'civicrm_test');
+    $schema = $connection->schema();
+    $tables = $schema->findTables('civicrm_%');
+    if (count($tables) > 0) {
+      throw new \RuntimeException('The provided database connection in SIMPLETEST_DB contains CiviCRM tables, use a different database.');
+    }
   }
 
   /**


### PR DESCRIPTION
This prevents tests from running if there are any `civicrm_` tables in the test database. In 5.33 the CiviCRM module fails loudly on this; but currently, it is a soft warning and that means existing data will be dropped in the database.

We discussed a new `SIMPLETEST_CIVICRM_DB` environment variable. But what if you don't want a second database (see tests). It's better off just pointing the entire test suite to use a database that contains no data. 

Example failure output:

```
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Testing Drupal\Tests\webform_civicrm\FunctionalJavascript\ContributionPageTest
E                                                                   1 / 1 (100%)

Time: 22.76 seconds, Memory: 4.00MB

There was 1 error:

1) Drupal\Tests\webform_civicrm\FunctionalJavascript\ContributionPageTest::testSubmitContribution
RuntimeException: The provided database connection in SIMPLETEST_DB contains CiviCRM tables, use a different database.

/var/www/html/web/modules/contrib/webform_civicrm/tests/src/FunctionalJavascript/CiviCrmTestBase.php:67
/var/www/html/web/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php:672
/var/www/html/web/core/tests/Drupal/Tests/BrowserTestBase.php:405
/var/www/html/web/modules/contrib/webform_civicrm/tests/src/FunctionalJavascript/CiviCrmTestBase.php:25
/var/www/html/web/modules/contrib/webform_civicrm/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php:53
Standard input code:57
Standard input code:110

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.
```

I don't know if GitHub Actions allows us to "expect" something to fail. If they do, we could make a job that makes a table entry and tries to run a test and verifies it dies. But that may be a bit much.