### PR TITLE
Add Sales Tax testing to Contribution test

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -594,7 +594,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
         $taxSettings = wf_crm_get_civi_setting('contribution_invoice_settings');
 
         if (($itemTaxRate !== 0) && ($taxSettings['tax_display_settings'] !== 'Do_not_show')) {
-          $item['label'] .= ' (' . t('includes !rate @tax', ['!rate' => (float) $itemTaxRate . '%', '@tax' => $taxSettings['tax_term']]) . ')';
+          $item['label'] .= ' (' . t('includes @rate @tax', ['@rate' => (float) $itemTaxRate . '%', '@tax' => $taxSettings['tax_term']]) . ')';
         }
 
         // Add calculation for financial type that contains tax

--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -39,7 +39,7 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
     $civicrm_schema = $civicrm_test_conn->schema();
     $tables = $civicrm_schema->findTables('%');
     // Comment out if you want to view the tables/contents before deleting them
-    // throw new \Exception(var_export($tables, TRUE));
+    throw new \Exception(var_export($tables, TRUE));
     foreach ($tables as $table) {
       if ($civicrm_schema->dropTable($table)) {
         unset($tables[$table]);

--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -39,7 +39,7 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
     $civicrm_schema = $civicrm_test_conn->schema();
     $tables = $civicrm_schema->findTables('%');
     // Comment out if you want to view the tables/contents before deleting them
-    throw new \Exception(var_export($tables, TRUE));
+    // throw new \Exception(var_export($tables, TRUE));
     foreach ($tables as $table) {
       if ($civicrm_schema->dropTable($table)) {
         unset($tables[$table]);

--- a/tests/src/FunctionalJavascript/ContributionPageTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPageTest.php
@@ -168,6 +168,7 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
     $this->assertEquals('Donation', $contribution['financial_type']);
     $this->assertEquals('60.98', $contribution['total_amount']);
+    $contribution_total_amount = $contribution['total_amount'];
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
 
@@ -178,6 +179,7 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     ]);
     $contribution = reset($api_result['values']);
     $this->assertEquals('1.48', $contribution['tax_amount']);
+    $tax_total_amount = $contribution['tax_amount'];
 
     $api_result = wf_civicrm_api('line_item', 'get', [
       'sequential' => 1,
@@ -194,7 +196,8 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     // throw new \Exception(var_export($api_result, TRUE));
     $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
     $sum_tax_amount = $api_result['values'][2]['tax_amount'];
-    $this->assertEquals($contribution['total_amount'], $sum_line_total + $sum_tax_amount);
+    $this->assertEquals($tax_total_amount, $sum_tax_amount);
+    $this->assertEquals($contribution_total_amount, $sum_line_total + $sum_tax_amount);
   }
 
 }

--- a/tests/src/FunctionalJavascript/ContributionPageTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPageTest.php
@@ -45,7 +45,6 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     $params = array_merge([
       'name' => 'Sales tax account ' . substr(sha1(rand()), 0, 4),
       'financial_account_type_id' => key(CRM_Core_PseudoConstant::accountOptionValues('financial_account_type', NULL, " AND v.name LIKE 'Liability' ")),
-      'is_deductible' => 1,
       'is_tax' => 1,
       'tax_rate' => 5,
       'is_active' => 1,
@@ -74,6 +73,7 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     $payment_processor = $this->createPaymentProcessor();
 
     $financialAccount = $this->setupSalesTax(2, $accountParams = []);
+    // throw new \Exception(var_export($financialAccount, TRUE));
 
     $this->drupalLogin($this->adminUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
@@ -107,7 +107,8 @@ final class ContributionPageTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("civicrm_1_lineitem_1_contribution_line_total");
     $this->getSession()->getPage()->checkField("civicrm_1_lineitem_2_contribution_line_total");
     $this->assertSession()->checkboxChecked("civicrm_1_lineitem_2_contribution_line_total");
-    $this->getSession()->getPage()->selectFieldOption('Financial Type', 2);
+    // $this->getSession()->getPage()->selectFieldOption('Financial Type', 2);
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -118,7 +118,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
-   * Asserts the page has no error mesages.
+   * Asserts the page has no error messages.
    */
   protected function assertPageNoErrorMessages() {
     $error_messages = $this->getSession()->getPage()->findAll('css', '.messages.messages--error');


### PR DESCRIPTION
Overview
----------------------------------------
Adding Sales Tax test to the ContributionPage test.

Before
----------------------------------------
Testing Contribution Amount + Line Items

After
----------------------------------------
Testing Contribution Amount + Line Items (one with Sales Tax)

Technical Details
----------------------------------------
Copied over https://github.com/civicrm/civicrm-core/blob/master/tests/phpunit/CiviTest/CiviUnitTestCase.php#L3104

Because I think we would like to be able to pass in Sales Tax Rate (it's hardcoded in that CiviCRM function), so that we can calculate what the expected values should be.
