### PR TITLE
doPayment throws exceptions when payment fails. Catch and display to the user instead of an internal server error

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2001,7 +2001,13 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $paymentProcessor->doTransferCheckout($params, 'contribute');
     }
     else {
-      $paymentProcessor->doPayment($params);
+      try {
+        $paymentProcessor->doPayment($params);
+      }
+      catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+        drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
+        CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
+      }
     }
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
I found this issue when submitting a payment via omnipay sagepay and failing postcode validation (which is only done once the call to doPayment has happened).  `doPayment` will throw an exception when something goes wrong and it should provide a user friendly error message that we can display to the user. Currently the exception is not trapped and the user sees "internal server error".

Before
----------------------------------------
User sees "internal server error" on payment failure.

After
----------------------------------------
User sees error message and is bounced back to form on payment failure.

Technical Details
----------------------------------------
described above.

Comments
----------------------------------------

