### PR TITLE
Fix javascript error due to incorrect path.

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -32,8 +32,8 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     // Unset -> https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.libraries.yml#L31
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    if (substr($user_framework_resource_url,-5) === 'core/') {
-      $libraries['civicrm_contact']['js'][substr($user_framework_resource_url, -5) . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
+    if (substr($user_framework_resource_url, -5) === 'core/') {
+      $libraries['civicrm_contact']['js'][substr($user_framework_resource_url, 0,-5) . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
         'preprocess' => FALSE,
         'minified' => FALSE
       ];

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -30,9 +30,10 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     \Drupal::service('civicrm')->initialize();
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
+    // Unset -> https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.libraries.yml#L31
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    if (substr($user_framework_resource_url, 0,-5) == 'core/') {
-      $libraries['civicrm_contact']['js'][substr($user_framework_resource_url, 0, -5) . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
+    if (substr($user_framework_resource_url,-5) === 'core/') {
+      $libraries['civicrm_contact']['js'][substr($user_framework_resource_url, -5) . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
         'preprocess' => FALSE,
         'minified' => FALSE
       ];

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -31,10 +31,12 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
     \Drupal::service('civicrm')->initialize();
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
-    $libraries['civicrm_contact']['js'][$user_framework_resource_url . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
-      'preprocess' => FALSE,
-      'minified' => FALSE
-    ];
+    if (substr($user_framework_resource_url, 0,-5) == 'core/') {
+      $libraries['civicrm_contact']['js'][substr($user_framework_resource_url, 0, -5) . 'packages/jquery/plugins/jquery.tokeninput.js'] = [
+        'preprocess' => FALSE,
+        'minified' => FALSE
+      ];
+    }
   }
 }
 

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -30,6 +30,7 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
   if ($extension === 'webform_civicrm') {
     \Drupal::service('civicrm')->initialize();
     $user_framework_resource_url = CRM_Core_Config::singleton()->resourceBase;
+    // Todo - review
     // Unset -> https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.libraries.yml#L31
     unset($libraries['civicrm_contact']['js']['/libraries/civicrm/packages/jquery/plugins/jquery.tokeninput.js']);
     if (substr($user_framework_resource_url, -5) === 'core/') {


### PR DESCRIPTION
Overview
----------------------------------------
Raised in: https://www.drupal.org/project/webform_civicrm/issues/3182288
by Makemeweb and fkohrt

The library is added here:
https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.libraries.yml#L31

Then we're removing it here :-)
https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.module#L33

And we re-add it using the `$user_framework_resource_url` - which is incorrect and we error.
https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/webform_civicrm.module#L34

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/5340555/103016308-14b9c400-44ff-11eb-98ff-1c29aa2e400c.png)

After
----------------------------------------
No JS errors

Technical Details
----------------------------------------
`$user_framework_resource_url` -> includes core/ whereas the packages reside next to core/ (not underneath it).

Alternatively -> we could also decide to remove this altogether and just let the admin handle a non-typical install by editing `webform_civicrm.libraries.yml` ?
