### PR TITLE
Typo fix in warning message.

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -162,8 +162,7 @@ class ContactComponent implements ContactComponentInterface {
       if (wf_crm_aval($result, 'count') >= $limit) {
         \Drupal::logger('webform_civicrm')->warning(
           'Maximum contacts exceeded, list truncated on the webform "@title". The webform_civicrm "@field" field cannot display more than @limit contacts because it is a select list. Recommend switching to autocomplete widget in component settings.',
-          array('@limit' => $limit, '@field' => $component['#title'], '@title' => $node->label()),
-        );
+          array('@limit' => $limit, '@field' => $component['#title'], '@title' => $node->label()));
         if ($node->access('update') && \Drupal::currentUser()->hasPermission('access CiviCRM')) {
           $warning_message = \Drupal\Core\Render\Markup::create('<strong>' . t('Maximum contacts exceeded, list truncated.') .'</strong><br>' .
           t('The field "@field" cannot show more than @limit contacts because it is a select list. Recommend switching to autocomplete widget.', ['@limit' => $limit, '@field' => $component['#title']]));


### PR DESCRIPTION
Overview
----------------------------------------
Reported by hansrossel
https://www.drupal.org/project/webform_civicrm/issues/3190733

Before
----------------------------------------
"ParseError: syntax error, unexpected ')' in Composer\Autoload\includeFile() (regel 166 van /modules/contrib/webform_civicrm/src/ContactComponent.php)"

After
----------------------------------------
No Error 

Comments
----------------------------------------
https://github.com/colemanw/webform_civicrm/pull/400
