### PR TITLE
Expanding Activity Test

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -414,7 +414,6 @@ class Fields implements FieldsInterface {
         'name' => t('Assign Activity # to'),
         'type' => 'select',
         'expose_list' => TRUE,
-        'empty_option' => t('No One'),
         'extra' => ['multiple' => 1],
         'data_type' => 'ContactReference',
       ];

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -32,7 +32,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_duration");
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_activity_1_activity_assignee_contact_id[]', 'Contact 1');
 
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_subject");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -56,7 +56,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Activity Duration', '90');
 
     $this->getSession()->getPage()->pressButton('Submit');
-    // $this->htmlOutput();
+    $this->htmlOutput();
 
     // ToDo -> figure out what Error message it is! The submission itself works well.
     // $this->assertPageNoErrorMessages();
@@ -72,8 +72,17 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals('1', $activity['activity_type_id']);
     $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 60);
     $this->assertEquals(90, $activity['duration']);
-    // ToDo get contact id and activity id from the URL query:
+
+    // ToDo get contact id and activity id from the URL query for authenticated user
     // $this->webform->toUrl('canonical', ['query' => ['cid1' => 12, 'aid' => 12]]);
+    $this->drupalLogin($this->adminUser);
+    $this->webform->toUrl('canonical', ['query' => ['cid1' => 3, 'aid' => $activity['id']]]);
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->waitForField('First Name');
+    $this->htmlOutput();
+    // $this->assertSession()->checkField('civicrm_1_activity_1_activity_subject','Awesome Activity');
+    $this->assertSession()->pageTextContains('Awesome Activity');
+
   }
 
 }

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -32,6 +32,9 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_duration");
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_activity_1_activity_assignee_contact_id[]', 'Contact 1');
+    // ToDo -> assigning multiple contacts may fail with Notice in webform itself:
+    // https://www.drupal.org/project/webform/issues/3191088
 
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_subject");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");
@@ -52,7 +55,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Activity Subject', 'Awesome Activity');
-    // ToDo -> try different dates -> default is 'now'
+    // ToDo -> use different dates -> default is 'now'
     $this->getSession()->getPage()->fillField('Activity Duration', '90');
 
     $this->getSession()->getPage()->pressButton('Submit');
@@ -72,23 +75,39 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 60);
     $this->assertEquals(90, $activity['duration']);
 
-    // ToDo get contact id and activity id from the URL query for authenticated user
-    // $this->webform->toUrl('canonical', ['query' => ['cid1' => 12, 'aid' => 12]]);
+    $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('ActivityContact', 'get', [
+      'sequential' => 1,
+      'return' => ["contact_id"],
+      'record_type_id' => "Activity Assignees",
+      'activity_id' => 1,
+    ]);
+    $activityContact = reset($api_result['values']);
+    // In this test: contact_id 1 = Default Organization; contact_id 2 = Drupal User; contact_id 3 = Frederick
+    $this->assertEquals(3, $activityContact['contact_id']);
+
+    // Ok now let's log back in and retrieve the Activity we just stored - so that we can update it.
     $this->drupalLogin($this->adminUser);
-
-    // Needed?
-    // $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
-    //  'webform' => $this->webform->id(),
-    // ]));
-
-    $this->webform->toUrl('canonical', ['query' => ['cid1' => 3, 'aid' => $activity['id']]]);
+    $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => 3, 'aid' => $activity['id']]]));
     $this->assertPageNoErrorMessages();
-    $this->assertSession()->waitForField('Activity Subject');
 
+    $this->assertSession()->waitForField('Activity Duration');
     $this->htmlOutput();
-    // $this->assertSession()->checkField('civicrm_1_activity_1_activity_subject','Awesome Activity');
-    // $this->assertSession()->pageTextContains('Awesome Activity');
+    $this->getSession()->getPage()->fillField('Activity Duration', '120');
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->htmlOutput();
 
+    // All we've updated is the Activity Duration
+    $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('activity', 'get', [
+      'sequential' => 1,
+    ]);
+    $this->assertEquals(1, $api_result['count']);
+    $activity = reset($api_result['values']);
+    $this->assertEquals(120, $activity['duration']);
+
+    // Everything else should have remained the same:
+    $this->assertEquals('Awesome Activity', $activity['subject']);
+    $this->assertEquals('1', $activity['activity_type_id']);
+    $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 60);
   }
 
 }

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -59,8 +59,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
 
-    // ToDo -> figure out why we get this Notice:
-    // `Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1339 of modules/contrib/webform/src/WebformSubmissionStorage.php).`
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -80,16 +78,17 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->drupalLogin($this->adminUser);
 
     // Needed?
-    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
-      'webform' => $this->webform->id(),
-    ]));
+    // $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+    //  'webform' => $this->webform->id(),
+    // ]));
 
     $this->webform->toUrl('canonical', ['query' => ['cid1' => 3, 'aid' => $activity['id']]]);
     $this->assertPageNoErrorMessages();
-    $this->assertSession()->waitForField('First Name');
+    $this->assertSession()->waitForField('Activity Subject');
+
     $this->htmlOutput();
     // $this->assertSession()->checkField('civicrm_1_activity_1_activity_subject','Awesome Activity');
-    $this->assertSession()->pageTextContains('Awesome Activity');
+    // $this->assertSession()->pageTextContains('Awesome Activity');
 
   }
 

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -32,6 +32,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_duration");
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_activity_1_activity_assignee_contact_id[]', 'Contact 1');
 
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_subject");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");
@@ -58,8 +59,9 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
 
-    // ToDo -> figure out what Error message it is! The submission itself works well.
-    // $this->assertPageNoErrorMessages();
+    // ToDo -> figure out why we get this Notice:
+    // `Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1339 of modules/contrib/webform/src/WebformSubmissionStorage.php).`
+    $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('activity', 'get', [
@@ -76,6 +78,12 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     // ToDo get contact id and activity id from the URL query for authenticated user
     // $this->webform->toUrl('canonical', ['query' => ['cid1' => 12, 'aid' => 12]]);
     $this->drupalLogin($this->adminUser);
+
+    // Needed?
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+
     $this->webform->toUrl('canonical', ['query' => ['cid1' => 3, 'aid' => $activity['id']]]);
     $this->assertPageNoErrorMessages();
     $this->assertSession()->waitForField('First Name');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -58,6 +58,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       'access administration pages',
       'access webform overview',
       'administer webform',
+      'edit all contacts',
+      'view all activities',
     ]);
     $this->webform = $this->createWebform([
       'id' => 'civicrm_webform_test',


### PR DESCRIPTION
Overview/Summary:
----------------------------------------
**Added testing for:**
Activity Assignee
Retrieve and update existing activity using `cid1` and `aid` in the URL

**Fixed:**
Assignee field on config form

Before
----------------------------------------
Just testing Activity can be submitted and is stored properly in CiviCRM.

After
----------------------------------------
More testing and a bug fix! 🙂