### PR TITLE
Set title of list of lineitems to 'Payment Information' to use frontend title for contribution pages

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -604,7 +604,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     ];
     return theme('table', [
       'sticky' => FALSE,
-      'caption' => $this->contribution_page['title'],
+      'caption' => $this->contribution_page['frontend_title'] ?? $this->contribution_page['title'],
       'header' => [],
       'rows' => $rows,
       'attributes' => ['id' => "wf-crm-billing-items"],


### PR DESCRIPTION
Overview
----------------------------------------
This used to be the contributionpage title. In 8.x we are not using the contribution page and the title has changed to "Payment Information". In CiviCRM "frontend_title" was added to contribution pages and is what is should be shown publicly if any title is shown but we were still showing the "title" field. I think it makes more sense to switch 7.x to use the fixed "Payment Information" string instead of trying to load the contribution page title.

Before
----------------------------------------
`title` loaded from contribution page but not using public `frontend_title`.

After
----------------------------------------
`Payment Information` is the title.
![image](https://user-images.githubusercontent.com/2052161/104107200-71b0ca80-52b2-11eb-8617-7b58b8d6e2e9.png)

Technical Details
----------------------------------------

Comments
----------------------------------------
