### PR TITLE
D8 :Option for allow to create New Membership record instead of Membership type change

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1204,6 +1204,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $existing_type = $types[$mem['membership_type_id']];
           if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
             $params['id'] = $mem['id'];
+            // unset if setting is enabled and membership type are different
+            if (!empty($this->settings['skip_membership_type_change']) &&
+              $mem['membership_type_id'] != $params['membership_type_id']) {
+              unset($params['id']);
+            }
             // If we have an exact match, look no further
             if ($mem['membership_type_id'] == $params['membership_type_id']) {
               $is_active = $mem['is_active'];

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1318,6 +1318,12 @@ class AdminForm implements AdminFormInterface {
       '#default_value' => !empty($this->settings['create_new_relationship']),
       '#description' => t('If enabled, only Active relationships will load on the form, and will be updated on Submit. If there are no Active relationships then a new one will be created.'),
     );
+    $this->form['options']['skip_membership_type_change'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Skip Membership Type Change'),
+      '#default_value' => !empty($this->settings['skip_membership_type_change']),
+      '#description' => t('If enabled, if contact have existing membership and signing up for another one, it will create new membership record of instead of changing membership type.'),
+    );
     $this->form['options']['new_contact_source'] = array(
       '#type' => 'textfield',
       '#title' => t('Source Label'),


### PR DESCRIPTION
Option for allow to create New Membership record instead of Membership type change for existing membership record.

Overview
----------------------------------------
IF any contact have membership for Org A and now signing up for another Membership Type from Same Org, currently Membership Type get changed. If somebody want to Keep separate record of each membership type, its not feasible as of now.

With this : We would have option in Webform to decide to create new record in such situation.


<img width="455" alt="d8_webform_membership_type_change" src="https://user-images.githubusercontent.com/377735/104186707-d435d200-543c-11eb-838f-73e4e39eda0d.png">


Before
----------------------------------------
Membership type get changed.

After
----------------------------------------
New Membership Type get created if Option is enabled for specific webform.