### PR TITLE
When is active is unchecked is_active is set to null string

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -234,7 +234,7 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_field($dao) {
   if (empty($dao->custom_group_id)) {
     $dao->find(TRUE);
   }
-  if ($dao->is_active) {
+  if ($dao->is_active == 1) {
     $admin_form = \Drupal::service('webform_civicrm.admin_form');
     $admin_form::handleDynamicCustomField('create', $dao->id, $dao->custom_group_id);
   }


### PR DESCRIPTION
Overview
----------------------------------------
https://www.drupal.org/project/webform_civicrm/issues/3190897
Before
----------------------------------------
dynamic custom fields from custom group on webform are not disabled when disabled from custom field edit form.

After
----------------------------------------
dynamic custom fields from custom group on webform are disabled when disabled from custom field edit form.
