### PR TITLE
Fix saving of activity tag when a tag is selected in activity settings but it is not 'user select'

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1464,7 +1464,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       list($set, $type) = explode('_', $fid, 2);
       if ($set == $entityType && isset($field['table']) && $field['table'] == 'tag') {
         $field_name = 'civicrm_' . $n . '_' . $entityType. '_1_' . $fid;
-        if (isset($this->enabled[$field_name]) && isset($this->data[$entityType][$n])) {
+        if ((isset($params['tag']) || isset($this->enabled[$field_name])) && isset($this->data[$entityType][$n])) {
           $add = wf_crm_aval($this->data[$entityType][$n], $entityType . ":1:$type", []);
           $remove = $this->getExposedOptions($field_name, $add);
           $this->addOrRemoveMultivaluedData('tag', $entityType, $entityId, $add, $remove);


### PR DESCRIPTION
Overview
----------------------------------------
When you set a tag for an activity but don't add it to the form:
![image](https://user-images.githubusercontent.com/2052161/104914491-215afc00-5987-11eb-9274-e2b7430f0ff6.png)

Before
----------------------------------------
Tag is not saved.

After
----------------------------------------
Tag is saved.

Technical Details
----------------------------------------
`enabled` is not set if field is not added to the form. But if you have configured a tag it should still be saved.

Comments
----------------------------------------
This is a bug I found on 7.x. I don't know if it is a problem on 8.x
