### PR TITLE
Fix notice error when total amount is enabled on the webform

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -581,7 +581,7 @@ class WebformCivicrmPreProcess extends wf_crm_webform_base implements WebformCiv
     // Support hidden contribution field
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (!$this->line_items && isset($this->enabled[$fid])) {
-      $elements = $this->node->getElementsDecoded();
+      $elements = $this->node->getElementsDecodedAndFlattened();
       $field = $elements[$this->enabled[$fid]];
       if ($field['#type'] === 'hidden') {
         $this->line_items[] = [


### PR DESCRIPTION
Overview
----------------------------------------
Fixes notice error on the webform when total amount is enabled.

Before
----------------------------------------
To replicate

- Create a webform with Contribution section enabled and include total amount. Make sure the total amount is added as a child of contribution page break (this is the default behaviour).

![image](https://user-images.githubusercontent.com/5929648/105835564-f8bfab80-5ff1-11eb-9396-1d4db8b8074d.png)

- Visit the webform main page. 
- The following notice is shown on the page(or logged in drupal).

>Notice: Undefined index: civicrm_1_contribution_1_contribution_total_amount in Drupal\webform_civicrm\WebformCivicrmPreProcess->displayLineItems() (line 589 of /Applications/MAMP/htdocs/d8/modules/contrib/webform_civicrm/src/WebformCivicrmPreProcess.php)


 
After
----------------------------------------
Fixed. 


