### PR TITLE
To significantly expand CustomFieldSubmission testing

### DIFF
--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -191,8 +191,11 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
+    $radio_button_one = $this->assertSession()->elementExists('css', 'input:checked');
+    $radio_button_two = $this->assertSession()->elementExists('css', 'input:not(:checked)');
+    $radio_button_two->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
+
     // ToDo this should work if switch to Static Options worked
     // $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
@@ -207,7 +210,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     // ToDo: hunt down this notice
-    $this->assertPageNoErrorMessages();
+    // $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
 

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -135,11 +135,13 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    // static
+    // Static
     $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->htmlOutput();
+
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
 

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -251,6 +251,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(2, $result['count']);
 
+    $first_colour = [];
     foreach ($result['values'] as $value) {
       if ($value['value'] == $api_result['values'][2]['latest']['0']) {
         $first_colour = $value['name'];

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -137,6 +137,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     // static
     $this->getSession()->getPage()->checkField('Static Options');
+    $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
 
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -136,7 +136,6 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     // static
-    $this->getSession()->getPage()->checkField('Static Options');
     $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
 
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -207,7 +207,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     // ToDo: hunt down this notice
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
 

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -192,17 +192,8 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
-
-    // $radio_buttons = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-properties-civicrm-live-options"]');
-    // $radio_button_one = $this->assertSession()->elementExists('css', 'input:checked');
-    // $radio_button_two = $this->assertSession()->elementExists('css', 'input:not(:checked)');
-    // $radio_button_two->click();
-    
     $this->assertSession()->assertWaitOnAjaxRequest();
-
-    // ToDo this should work if switch to Static Options worked
     $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
-
     $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
@@ -232,6 +223,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2-timepart').setAttribute('value', '10:20:00')");
 
     // Only check one Checkbox -> Red
+    $this->assertSession()->pageTextContains('Red - Recommended');
     $this->getSession()->getPage()->checkField('Red');
 
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -137,9 +137,9 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     // static
     $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
-
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
+    $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
 

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -135,6 +135,9 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
+    // static
+    $this->getSession()->getPage()->checkField('properties[civicrm_live_options]');
+
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->getSession()->getPage()->pressButton('Save');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -193,7 +193,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000);
+    $this->getSession()->wait(60000);
     $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
     $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -136,7 +136,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     // static
-    $this->getSession()->getPage()->checkField('properties[civicrm_live_options]');
+    $this->getSession()->getPage()->checkField('Static Options');
 
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -13,6 +13,7 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
 final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
   private function createCustomFields() {
+    // Create Set of Custom Fields
     $params = [
       'title' => "Custom",
       'extends' => 'Individual',
@@ -23,6 +24,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(1, $result['count']);
     $customgroup_id = $result['id'];
 
+    // Add Field of type Text
     $params = [
       'custom_group_id' => $customgroup_id,
       'label' => 'Text',
@@ -34,6 +36,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
 
+    // Add Field of type Data/Time
     $result = civicrm_api3('CustomField', 'create', [
       'custom_group_id' => "Custom",
       'label' => "DateTime",
@@ -46,6 +49,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
 
+    // Add OptionGroup for Checkboxes element
     $result = civicrm_api3('OptionGroup', 'create', [
       'name' => "checkboxes_1",
       'title' => "Checkboxes",
@@ -54,8 +58,8 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     ]);
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
-    $optiongroup_id = $result['id'];
 
+    // Add First OptionValue to OptionGroup for Checkboxes element
     $result = civicrm_api3('OptionValue', 'create', [
       'option_group_id' => "checkboxes_1",
       'name' => "Red",
@@ -68,6 +72,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
 
+    // Add Second OptionValue to OptionGroup for Checkboxes element
     $result = civicrm_api3('OptionValue', 'create', [
       'option_group_id' => "checkboxes_1",
       'name' => "Green",
@@ -80,12 +85,61 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
 
+    // Add Field of type Checkboxes
     $result = civicrm_api3('CustomField', 'create', [
       'custom_group_id' => "Custom",
       'label' => "Checkboxes",
       'html_type' => "CheckBox",
       'data_type' => "String",
       'option_group_id' => "checkboxes_1",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add OptionGroup for Select element
+    $result = civicrm_api3('OptionGroup', 'create', [
+      'name' => "list_1",
+      'title' => "Select",
+      'data_type' => "String",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add First OptionValue to OptionGroup for Select element
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "list_1",
+      'name' => "Option A",
+      'label' => "Option A",
+      'value' => 'OptionA',
+      'is_default' => 0,
+      'weight' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add Second OptionValue to OptionGroup for Select element
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "list_1",
+      'name' => "Option B",
+      'label' => "Option B",
+      'value' => 'OptionB',
+      'is_default' => 0,
+      'weight' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add Field of type Select
+    $result = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => "Custom",
+      'label' => "List",
+      'html_type' => "Select",
+      'data_type' => "String",
+      'option_group_id' => "list_1",
       'is_active' => 1,
     ]);
     $this->assertEquals(0, $result['is_error']);
@@ -116,11 +170,13 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_2");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_3");
+    $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_4");
 
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_1");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_3");
+    $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_4");
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -135,9 +191,10 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    // Static
     $this->getSession()->getPage()->selectFieldOption('Static Options', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
+    // ToDo this should work if switch to Static Options worked
+    // $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->htmlOutput();
@@ -148,6 +205,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->htmlOutput();
+
     // ToDo: hunt down this notice
     // $this->assertPageNoErrorMessages();
 
@@ -176,7 +234,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
       'sequential' => 1,
       'entity_id' => 3,
     ]);
-    $this->assertEquals(3, $api_result['count']);
+    $this->assertEquals(4, $api_result['count']);
     // throw new \Exception(var_export($api_result, TRUE));
     $this->assertEquals('Lorem Ipsum', $api_result['values'][0]['latest']);
     $this->assertEquals('2020-12-12 10:20:00', $api_result['values'][1]['latest']);
@@ -198,9 +256,12 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
         $second_colour = $value['name'];
       }
     }
-
     $this->assertEquals('Red', $first_colour);
     $this->assertEquals('Green', $second_colour);
+
+    // For the Select List - the default is OptionA - Check that it's stored properly in CiviCRM:
+    $this->assertEquals('OptionA', $api_result['values'][3]['latest']);
+    //throw new \Exception(var_export($api_result, TRUE));
   }
 
 }

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -191,13 +191,19 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    $radio_button_one = $this->assertSession()->elementExists('css', 'input:checked');
-    $radio_button_two = $this->assertSession()->elementExists('css', 'input:not(:checked)');
-    $radio_button_two->click();
+    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+
+    // $radio_buttons = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-properties-civicrm-live-options"]');
+    // $radio_button_one = $this->assertSession()->elementExists('css', 'input:checked');
+    // $radio_button_two = $this->assertSession()->elementExists('css', 'input:not(:checked)');
+    // $radio_button_two->click();
+    
     $this->assertSession()->assertWaitOnAjaxRequest();
 
     // ToDo this should work if switch to Static Options worked
-    // $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
+    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
+
+    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->htmlOutput();

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -193,6 +193,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->wait(1000);
     $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
     $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -222,8 +222,8 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2').setAttribute('value', '2020-12-12')");
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2-timepart').setAttribute('value', '10:20:00')");
 
+    // Only check one Checkbox -> Red
     $this->getSession()->getPage()->checkField('Red');
-    $this->getSession()->getPage()->checkField('Green');
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
@@ -240,28 +240,26 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals('2020-12-12 10:20:00', $api_result['values'][1]['latest']);
     // Check the checkbox values
     // Red = 1; Green = 2;
+
     $this->assertEquals(1, $api_result['values'][2]['latest']['0']);
-    $this->assertEquals(2, $api_result['values'][2]['latest']['1']);
+    $this->assertEquals(1, count($api_result['values'][2]['latest']));
 
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => "checkboxes_1",
     ]);
+
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(2, $result['count']);
 
     foreach ($result['values'] as $value) {
       if ($value['value'] == $api_result['values'][2]['latest']['0']) {
         $first_colour = $value['name'];
-      } elseif ($value['value'] == $api_result['values'][2]['latest']['1']) {
-        $second_colour = $value['name'];
       }
     }
     $this->assertEquals('Red', $first_colour);
-    $this->assertEquals('Green', $second_colour);
 
     // For the Select List - the default is OptionA - Check that it's stored properly in CiviCRM:
     $this->assertEquals('OptionA', $api_result['values'][3]['latest']);
-    //throw new \Exception(var_export($api_result, TRUE));
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Add test to switch to Static Options

Before
----------------------------------------
Testing with Live Options

Technical Details
----------------------------------------
DRAFT - I can't confirm (yet) that I'm selecting the field...

Goal
----------------------------------------
To significantly expand testing to include the following custom fields: 

- text ✅
- checkboxes (static - with one label altered) 🚒
- date/time ✅
- select (with values OptionA and OptionB - rather than 1 and 2) ✅

![image](https://user-images.githubusercontent.com/5340555/106221884-ab7f3d80-619b-11eb-964f-6137b7dd3d77.png)
