### PR TITLE
Replace all leftover Decoded with DecodedAndFlattened.

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2355,7 +2355,7 @@ class AdminForm implements AdminFormInterface {
       $enabled = $utils->wf_crm_enabled_fields($webform, NULL, TRUE);
       $updated = array();
       // Handle update & delete of existing components
-      $elements = $webform->getElementsDecoded();
+      $elements = $webform->getElementsDecodedAndFlattened();
       foreach ($elements as $component_key => $component) {
         if (substr($component['#form_key'], 0 - strlen($field_name)) === $field_name) {
           if ($pieces = $utils->wf_crm_explode_key($component['#form_key'])) {

--- a/src/Plugin/WebformHandler/CivicrmWebformHandler.php
+++ b/src/Plugin/WebformHandler/CivicrmWebformHandler.php
@@ -152,7 +152,7 @@ class CivicrmWebformHandler extends WebformHandlerBase {
    * {@inheritdoc}
    */
   public function deleteHandler() {
-    $elements = array_filter($this->webform->getElementsDecoded(), function (array $element) {
+    $elements = array_filter($this->webform->getElementsDecodedAndFlattened(), function (array $element) {
       return strpos($element['#form_key'], 'civicrm_') !== 0;
     });
     $this->webform->setElements($elements);

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1619,7 +1619,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         'qty' => 1,
         'unit_price' => $this->getData($fid),
         'financial_type_id' => wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id'),
-        'label' => wf_crm_aval($this->node->getElementsDecoded(), $this->enabled[$fid] . ':title', t('Contribution')),
+        'label' => wf_crm_aval($this->node->getElementsDecodedAndFlattened(), $this->enabled[$fid] . ':title', t('Contribution')),
         'element' => 'civicrm_1_contribution_1',
         'entity_table' => 'civicrm_contribution',
       );
@@ -1634,7 +1634,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             'qty' => 1,
             'unit_price' => $lineitem['line_total'],
             'financial_type_id' => $lineitem['financial_type_id'],
-            'label' => wf_crm_aval($this->node->getElementsDecoded(), $this->enabled[$fid] . ':title', t('Line item')),
+            'label' => wf_crm_aval($this->node->getElementsDecodedAndFlattened(), $this->enabled[$fid] . ':title', t('Line item')),
             'element' => "civicrm_1_lineitem_{$n}",
             'entity_table' => 'civicrm_contribution',
           );

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -259,7 +259,7 @@ function webform_civicrm_civicrm_buildForm($formName, $form) {
         if (!$handler_collection->has('webform_civicrm')) {
           continue;
         }
-        $elements = $webform->getElementsDecoded();
+        $elements = $webform->getElementsDecodedAndFlattened();
         foreach (array_keys($elements) as $element_form_key) {
           if (strpos($element_form_key, "custom_$fid") !== FALSE) {
             $nodes[] = $webform->toLink()->toString();


### PR DESCRIPTION
Overview
----------------------------------------
We've come across a few instances where we need `DecodedAndFlattened()`. I spoke with @jitendrapurohit and we agreed it would probably be safer to do this everywhere. 
