### PR TITLE
Fix static widget for existing contact element

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -52,6 +52,7 @@ var wfCivi = (function ($, D, drupalSettings) {
     var cid = $field.val(),
       prep = null,
       hideOrDisable = $field.attr('data-hide-method'),
+      showHiddenContact = $field.attr('show-hidden-contact') == '1',
       showEmpty = $field.attr('data-no-hide-blank') == '1';
 
     function getCallbackPath() {
@@ -88,6 +89,9 @@ var wfCivi = (function ($, D, drupalSettings) {
         tokenInputSettings.queryParam = 'str';
         tokenInputSettings.tokenLimit = 1;
         tokenInputSettings.prePopulate = prep;
+        if (showHiddenContact) {
+          tokenInputSettings.deleteText = '';
+        }
         $field.tokenInput(getCallbackPath, tokenInputSettings);
       }
     }

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -39,17 +39,6 @@ class ContactComponent implements ContactComponentInterface {
   }
 
   /**
-   * Theme function.
-   * Format the output of data for this component.
-   */
-  function theme_display_civicrm_contact($variables) {
-    $element = $variables['element'];
-    $prefix = $element['#format'] == 'html' ? '' : $element['#field_prefix'];
-    $suffix = $element['#format'] == 'html' ? '' : $element['#field_suffix'];
-    return $element['#value'] !== '' ? ($prefix . $element['#value'] . $suffix) : ' ';
-  }
-
-  /**
    * Implements _webform_table_component().
    */
   function _webform_table_civicrm_contact($component, $value) {
@@ -352,51 +341,6 @@ class ContactComponent implements ContactComponentInterface {
     return $params;
   }
 
-  /**
-   * Theme the wrapper for a static contact element
-   * Includes normal webform theme wrappers plus a tokeninput-style name field
-   */
-  function theme_static_contact_element($vars) {
-    $element = $vars['element'];
-    $component = $element['#webform_component'];
-
-    // All elements using this for display only are given the "display" type.
-    $type = wf_crm_aval($element, '#format') == 'html' ? 'display' : 'civicrm_contact';
-
-    // Convert the parents array into a string, excluding the "submitted" wrapper.
-    $nested_level = $element['#parents'][0] == 'submitted' ? 1 : 0;
-    $parents = str_replace('_', '-', implode('--', array_slice($element['#parents'], $nested_level)));
-
-    $wrapper_classes = array(
-      'form-item',
-      'webform-component',
-      'webform-component-' . $type,
-      'static',
-      'webform-component--' . $parents,
-    );
-
-    if ($component['extra']['title_display'] === 'inline') {
-      $wrapper_classes[] = 'webform-container-inline';
-    }
-
-    $output = '<div class="' . implode(' ', $wrapper_classes) . '">' . "\n";
-
-    // Display static value in addition to hidden field
-    if ($type == 'civicrm_contact' && !empty($element['#attributes']['data-civicrm-name'])) {
-
-      if ($component['extra']['title_display'] != 'none') {
-        $output .= theme('form_element_label', array('element' => $element));
-      }
-
-      $output .= '<ul class="token-input-list"><li class="token-input-token"><p>' . $element['#attributes']['data-civicrm-name'] . "</p></li></ul>\n";
-
-      if (!empty($component['extra']['description'])) {
-        $output .= ' <div class="description">' . filter_xss($element['#description']) . "</div>\n";
-      }
-    }
-
-    return $output . $element['#children'] . "\n</div>\n";
-  }
 
   /**
    * Validation callback

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -98,15 +98,7 @@ class CivicrmContact extends WebformElementBase {
     $element['#attached']['drupalSettings']['webform_civicrm'][$element['#form_key']] = [
       'hiddenFields' => [],
     ];
-    $element['#theme'] = 'webform_civicrm_contact';
     $element['#type'] = $element['#widget'] === 'autocomplete' ? 'textfield' : $element['#widget'];
-    list(, $c, ) = explode('_', $element['#form_key'], 3);
-    $element['#attributes']['data-civicrm-contact'] = $c;
-    $element['#attributes']['data-form-id'] = $webform_submission ? $webform_submission->getWebform()->id() : NULL;
-    $element['#attributes']['data-hide-method'] = $this->getElementProperty($element, 'hide_method');
-    $element['#attributes']['data-no-hide-blank'] = (int) $this->getElementProperty($element, 'no_hide_blank');
-
-
     $cid = $this->getElementProperty($element, 'default_value');
     if ($element['#type'] === 'hidden') {
       // User may not change this value for hidden fields
@@ -114,7 +106,13 @@ class CivicrmContact extends WebformElementBase {
       if (empty($element['#show_hidden_contact'])) {
         return;
       }
+      $element['#attributes']['show-hidden-contact'] = 1;
     }
+    list(, $c, ) = explode('_', $element['#form_key'], 3);
+    $element['#attributes']['data-civicrm-contact'] = $c;
+    $element['#attributes']['data-form-id'] = $webform_submission ? $webform_submission->getWebform()->id() : NULL;
+    $element['#attributes']['data-hide-method'] = $this->getElementProperty($element, 'hide_method');
+    $element['#attributes']['data-no-hide-blank'] = (int) $this->getElementProperty($element, 'no_hide_blank');
     if (!empty($cid)) {
       $webform = $webform_submission->getWebform();
       $contactComponent = \Drupal::service('webform_civicrm.contact_component');
@@ -489,7 +487,8 @@ class CivicrmContact extends WebformElementBase {
     $cid = wf_crm_aval($element, '#default_value', '');
     $contactComponent = \Drupal::service('webform_civicrm.contact_component');
     if ($element['#type'] == 'hidden') {
-      if (!isset($component['#show_hidden_contact']) || !$component['#show_hidden_contact']) {
+      $element['#value'] = $cid;
+      if (empty($element['#show_hidden_contact'])) {
         return;
       }
     }

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -562,7 +562,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             }
           }
           if ($name == 'existing') {
-            \Drupal::ModuleHandler()->loadInclude('webform_civicrm', 'inc', 'includes/contact_component');
             CivicrmContact::wf_crm_fill_contact_value($this->node, $component, $element, $this->ent);
           }
         }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -120,24 +120,6 @@ function webform_civicrm_theme() {
 }
 
 /**
- * Implements hook_webform_component_info().
- *
- * @return array
- */
-function webform_civicrm_webform_component_info() {
-  return array(
-    'civicrm_contact' => array(
-      'label' => t('CiviCRM Contact'),
-      'description' => t('Choose existing contact.'),
-      'features' => array(
-        'email_name' => TRUE,
-      ),
-      'file' => 'includes/contact_component.inc',
-    ),
-  );
-}
-
-/**
  * Implements hook_webform_submission_render_alter().
  * Add display name to title while viewing a submission.
  */


### PR DESCRIPTION
Overview
----------------------------------------
Fix Static widget for existing contact element. 

Before
----------------------------------------
1. Unnecessary horizontal line is displayed for static element.

![image](https://user-images.githubusercontent.com/5929648/106354542-954abc00-6318-11eb-9c70-4816495609bb.png)

2. Existing contact is not updated if cid is passed in the URL or if contact element is default to the logged in user. To replicate -
- Create a contact in civicrm.
- Use the cid in the URL. This will load the existing value of the contact.
- Update first name or last name to some other value and submit the webform.
- The values are not updated in the existing contact. Instead a NEW contact is created in civicrm.


After
----------------------------------------
- Deprecated code removed from d7.
- Handling of static widget is added.
- If the display name is enabled in settings -
![image](https://user-images.githubusercontent.com/5929648/106354634-4e10fb00-6319-11eb-91f5-fb34c3289324.png)

The widget is displayed correctly on the webform without letting the user to update the value.

![image](https://user-images.githubusercontent.com/5929648/106354657-6c76f680-6319-11eb-8824-fb20d8430e30.png)

- FuncJs test added to assert both 1 and 2 problems mentioned above.

Comments
----------------------------------------
@KarinG 