### PR TITLE
Fix select widget for contact element

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -5,16 +5,20 @@
         var toHide = []
         var field = $(el)
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));
-        wfCivi.existingInit(
-          field,
-          field.data('civicrm-contact'),
-          field.data('form-id'),
-          autocompleteUrl,
-          toHide, {
-          hintText: "- Choose existing -",
-          noResultsText: "+ Create new +",
-          searchingText: "Searching..."
-        });
+        var isSelect = field.data('is-select');
+        if (!isSelect) {
+          wfCivi.existingInit(
+            field,
+            field.data('civicrm-contact'),
+            field.data('form-id'),
+            autocompleteUrl,
+            toHide, {
+            hintText: "- Choose existing -",
+            noResultsText: "+ Create new +",
+            searchingText: "Searching..."
+          });
+        }
+
         field.change(function () {
           wfCivi.existingSelect(
             field.data('civicrm-contact'),

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -100,6 +100,7 @@ class CivicrmContact extends WebformElementBase {
     ];
     $element['#type'] = $element['#widget'] === 'autocomplete' ? 'textfield' : $element['#widget'];
     $cid = $this->getElementProperty($element, 'default_value');
+    list(, $c, ) = explode('_', $element['#form_key'], 3);
     if ($element['#type'] === 'hidden') {
       // User may not change this value for hidden fields
       $element['#value'] = $cid;
@@ -108,7 +109,10 @@ class CivicrmContact extends WebformElementBase {
       }
       $element['#attributes']['show-hidden-contact'] = 1;
     }
-    list(, $c, ) = explode('_', $element['#form_key'], 3);
+    elseif ($element['#type'] === 'select') {
+      $element['#options'] = [];
+      $element['#attributes']['data-is-select'] = 1;
+    }
     $element['#attributes']['data-civicrm-contact'] = $c;
     $element['#attributes']['data-form-id'] = $webform_submission ? $webform_submission->getWebform()->id() : NULL;
     $element['#attributes']['data-hide-method'] = $this->getElementProperty($element, 'hide_method');
@@ -511,11 +515,11 @@ class CivicrmContact extends WebformElementBase {
     }
     // Set options list for select elements. We do this here so we have access to entity ids.
     if (is_array($ids) && $element['#type'] == 'select') {
-      $filters = $contactComponent->wf_crm_search_filters($node, $component);
-      $element['#options'] = $contactComponent->wf_crm_contact_search($node, $component, $filters, wf_crm_aval($ids, 'contact', []));
+      $filters = $contactComponent->wf_crm_search_filters($node, $element);
+      $element['#options'] = $contactComponent->wf_crm_contact_search($node, $element, $filters, wf_crm_aval($ids, 'contact', []));
       // Display empty option unless there are no results
-      if (!$component['#allow_create'] || count($element['#options']) > 1) {
-        $element['#empty_option'] = Xss::filter($component[$element['#options'] ? 'search_prompt' : 'none_prompt']);
+      if (!$element['#allow_create'] || count($element['#options']) > 1) {
+        $element['#empty_option'] = Xss::filter($element[$element['#options'] ? '#search_prompt' : '#none_prompt']);
       }
     }
   }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -155,4 +155,24 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     return current($result['values']);
   }
 
+  /**
+   * Enables civicrm on the webform.
+   */
+  public function enableCivicrmOnWebform() {
+    $this->assertSession()->waitForText('Enable CiviCRM Processing');
+    $this->assertSession()->waitForField('nid');
+    $this->htmlOutput();
+    $this->getSession()->getPage()->checkField('nid');
+    $this->getSession()->getPage()->selectFieldOption('1_contact_type', 'individual');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
+   * Save the settings configured on the civicrm tab.
+   */
+  public function saveCiviCRMSettings() {
+    $this->getSession()->getPage()->pressButton('Save Settings');
+    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix select widget for contact element

Before
----------------------------------------
Select Element displayed as autocomplete on the webform

![image](https://user-images.githubusercontent.com/5929648/106377704-e1533a80-63c4-11eb-936a-528882830752.png)

After
----------------------------------------
Select Element is rendered for select widget.

![image](https://user-images.githubusercontent.com/5929648/106377680-af41d880-63c4-11eb-9d7b-d6e78b2fa0b9.png)

Added unit test to assert the select element and verifies if the contact options are loaded as per the filter enabled on the element.

Comments
----------------------------------------
@KarinG :)