### PR TITLE
Fix checkbox errors on webform

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1764,13 +1764,13 @@ class AdminForm implements AdminFormInterface {
     if ($button === 'edit-delete' || ($button === 'edit-disable' && $this->settings['nid'])) {
       foreach ($delete_me as $id) {
         $field = $this->webform->getElementDecoded($id);
-        unset($enabled[$field['form_key']]);
+        unset($enabled[$field['#form_key']]);
         ++$deleted;
         if ($button === 'edit-delete') {
           $this->webform->deleteElement($field['#form_key']);
         }
         else {
-          $field['form_key'] = 'disabled' . substr($field['form_key'], 7);
+          $field['#form_key'] = 'disabled' . substr($field['#form_key'], 7);
           $this->webform->setElementProperties($field['#form_key'], $field);
         }
       }

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -16,7 +16,7 @@ class CivicrmSelectOptions extends FormElement {
       '#input' => TRUE,
       '#label' => t('option'),
       '#labels' => t('options'),
-      '#live_options' => TRUE,
+      '#civicrm_live_options' => TRUE,
       '#default_option' => NULL,
       '#form_key' => NULL,
       '#process' => [
@@ -68,13 +68,13 @@ class CivicrmSelectOptions extends FormElement {
         'enabled' => [
           'data' => [
             '#markup' => 'Enabled',
-            '#access' => !$element['#live_options'],
+            '#access' => !$element['#civicrm_live_options'],
           ]
         ],
         'label' => [
           'data' => [
             '#markup' => 'Label',
-            '#access' => !$element['#live_options'],
+            '#access' => !$element['#civicrm_live_options'],
           ]
         ],
         'default' => [
@@ -85,7 +85,7 @@ class CivicrmSelectOptions extends FormElement {
         'weight' => [
           'data' => [
             '#markup' => 'Weight',
-            '#access' => !$element['#live_options'],
+            '#access' => !$element['#civicrm_live_options'],
           ]
         ],
       ],
@@ -99,7 +99,7 @@ class CivicrmSelectOptions extends FormElement {
       ],
     ];
 
-    if ($element['#live_options']) {
+    if ($element['#civicrm_live_options']) {
       $element['options']['#tabledrag'] = [];
     }
 
@@ -108,7 +108,7 @@ class CivicrmSelectOptions extends FormElement {
     $field_options = static::getFieldOptions($element['#form_key']);
 
     // Sort the field options by the current options.
-    if (!$element['#live_options']) {
+    if (!$element['#civicrm_live_options']) {
       uasort($field_options, function ($a, $b) use ($current_options) {
         $current_options = array_flip($current_options);
         $weight_values = array_flip(array_values(array_flip($current_options)));
@@ -142,14 +142,14 @@ class CivicrmSelectOptions extends FormElement {
         '#title' => t('Enable @item', ['@item' => $option]),
         '#title_display' => 'invisible',
         '#default_value' => !empty($current_options[$key]),
-        '#access' => !$element['#live_options'],
+        '#access' => !$element['#civicrm_live_options'],
       ];
       $element['options'][$row_key]['label'] = [
         '#type' => 'textfield',
         '#title' => t('Label for @item', ['@item' => $option]),
         '#title_display' => 'invisible',
         '#default_value' => !empty($current_options[$key]) ?  $current_options[$key] : $option,
-        '#access' => !$element['#live_options'],
+        '#access' => !$element['#civicrm_live_options'],
       ];
       $element['options'][$row_key]['default_option'] = [
         '#type' => 'radio',
@@ -166,7 +166,7 @@ class CivicrmSelectOptions extends FormElement {
         // @todo support these values.
         '#default_value' => $weight,
         '#attributes' => ['class' => ['weight']],
-        '#access' => !$element['#live_options'],
+        '#access' => !$element['#civicrm_live_options'],
       ];
       $weight++;
     }
@@ -178,7 +178,7 @@ class CivicrmSelectOptions extends FormElement {
    * Validates webform options element.
    */
   public static function validateSelectOptions(&$element, FormStateInterface $form_state, &$complete_form) {
-    if ($element['#live_options']) {
+    if ($element['#civicrm_live_options']) {
       $options_value = self::getFieldOptions($element['#form_key']);
     }
     else {

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -131,7 +131,7 @@ class CivicrmSelect extends WebformElementBase {
 
     $form['options']['options'] = [
       '#type' => 'civicrm_select_options',
-      '#live_options' => $element_properties['civicrm_live_options'],
+      '#civicrm_live_options' => $element_properties['civicrm_live_options'],
       '#default_option' => $element_properties['default_option'],
       '#form_key' => $this->configuration['#form_key'] ?? $element_properties['form_key'],
     ];

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -522,7 +522,7 @@ abstract class WebformCivicrmBase {
 
     if ($field && $field['#type'] == 'hidden') {
       // Fetch live options
-      $exposed = $utils->wf_crm_field_options($field, 'live_options', $this->data);
+      $exposed = $utils->wf_crm_field_options($field, 'civicrm_live_options', $this->data);
       foreach ($exclude as $i) {
         unset($exposed[$i]);
       }
@@ -539,7 +539,7 @@ abstract class WebformCivicrmBase {
       }
       // Fetch live options
       else {
-        $exposed = $utils->wf_crm_field_options(['form_key' => $field['#form_key']], 'live_options', $this->data);
+        $exposed = $utils->wf_crm_field_options(['form_key' => $field['#form_key']], 'civicrm_live_options', $this->data);
       }
       foreach ($exclude as $i) {
         unset($exposed[$i]);

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -47,6 +47,27 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(1, $result['count']);
 
     $result = civicrm_api3('OptionGroup', 'create', [
+      'name' => "radio_1",
+      'title' => "Label for custom radio field",
+      'data_type' => "String",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "radio_1",
+      'name' => "Yes",
+      'label' => "Yes",
+      'value' => 1,
+      'is_default' => 0,
+      'weight' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('OptionGroup', 'create', [
       'name' => "checkboxes_1",
       'title' => "Checkboxes",
       'data_type' => "String",
@@ -90,6 +111,17 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     ]);
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => "Custom",
+      'label' => "Label for custom radio field",
+      'html_type' => "Radio",
+      'data_type' => "String",
+      'option_group_id' => "radio_1",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
   }
 
   /**
@@ -116,11 +148,13 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_2");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_3");
+    $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_4");
 
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_1");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_3");
+    $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_4");
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -131,15 +165,8 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('Checkboxes');
     $this->htmlOutput();
 
-    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
-    $checkbox_edit_button->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-
-    $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
-    $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
-    $this->getSession()->getPage()->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
+    $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
@@ -147,6 +174,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
+    $this->assertSession()->pageTextContains('Label for custom radio field');
 
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
@@ -161,6 +189,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->checkField('Red');
     $this->getSession()->getPage()->checkField('Green');
+    $this->getSession()->getPage()->checkField('Yes');
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
@@ -171,7 +200,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
       'sequential' => 1,
       'entity_id' => 3,
     ]);
-    $this->assertEquals(3, $api_result['count']);
+    $this->assertEquals(4, $api_result['count']);
     // throw new \Exception(var_export($api_result, TRUE));
     $this->assertEquals('Lorem Ipsum', $api_result['values'][0]['latest']);
     $this->assertEquals('2020-12-12 10:20:00', $api_result['values'][1]['latest']);

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -124,6 +124,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->assertPageNoErrorMessages();
 
     // Change the Checkbox -> no Listbox (that should probably be the default)
     $this->drupalGet($this->webform->toUrl('edit-form'));
@@ -143,8 +144,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->htmlOutput();
-    // ToDo: hunt down this notice
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -130,6 +130,21 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
+   * Modify settings so the element displays as a checkbox.
+   */
+  protected function enableCheckboxOnElement($selector) {
+    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
+    $checkbox_edit_button->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
+    $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
    * Create Payment Processor.
    */
   protected function createPaymentProcessor() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix checkbox errors on the webform

Before
----------------------------------------
Notice on the webform when checkbox custom fields are added.

![image](https://user-images.githubusercontent.com/5929648/106380438-38aed600-63d8-11eb-9fcc-c891b7c6e90a.png)

- Single radio button rendered as a checkbox is missing the label on the form.  To replicate - add a custom field of type "radio" but with only 1 option.

From the screenshot the label of the element is `Agree to terms and conditions` 

![image](https://user-images.githubusercontent.com/5929648/106380649-b58e7f80-63d9-11eb-8e72-b1072d8dd311.png)

but is not displayed on the webform

![image](https://user-images.githubusercontent.com/5929648/106380784-84fb1580-63da-11eb-981d-ad59af991977.png)


After
----------------------------------------
- Notice fixed.
- Label displayed for single radio option/checkbox.

![image](https://user-images.githubusercontent.com/5929648/106380578-3b5dfb00-63d9-11eb-95d5-0f559f3a71b9.png)


Comments
----------------------------------------
@KarinG 