### PR TITLE
[Test only] - Expanding CustomField Testing + ToDo: Test Static Options

### DIFF
--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -217,7 +217,17 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
-    $this->enableStaticOptionOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
+
+    // ToDo: Enable Static Option and Edit Label
+    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
+    $checkbox_edit_button->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
+    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
+    $this->htmlOutput();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -219,15 +219,15 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
 
     // ToDo: Enable Static Option and Edit Label
-    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
-    $checkbox_edit_button->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
-    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
-    $this->htmlOutput();
+    // $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
+    // $checkbox_edit_button->click();
+    // $this->assertSession()->assertWaitOnAjaxRequest();
+    // $this->htmlOutput();
+    // $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+    // $this->assertSession()->assertWaitOnAjaxRequest();
+    // $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
+    // $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
+    // $this->htmlOutput();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
@@ -249,7 +249,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2-timepart').setAttribute('value', '10:20:00')");
 
     // Only check one Checkbox -> Red
-    $this->assertSession()->pageTextContains('Red - Recommended');
+    $this->assertSession()->pageTextContains('Red');
     $this->getSession()->getPage()->checkField('Red');
 
     $this->getSession()->getPage()->checkField('Yes');
@@ -270,7 +270,6 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     // Check the checkbox values
     // Red = 1; Green = 2;
     $this->assertEquals(1, $api_result['values'][2]['latest']['0']);
-    $this->assertEquals(1, $api_result['values'][2]['latest']['1']);
 
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => "checkboxes_1",
@@ -284,11 +283,14 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
         $first_colour = $value['name'];
       }
     }
-
     $this->assertEquals('Red', $first_colour);
 
+    $this->assertEquals(1, $api_result['values'][3]['latest']);
+
     // For the Select List - the default is OptionA - Check that it's stored properly in CiviCRM:
-    $this->assertEquals('OptionA', $api_result['values'][3]['latest']);
+    $this->assertEquals('OptionA', $api_result['values'][4]['latest']);
+
+    // throw new \Exception(var_export($api_result, TRUE));
   }
 
 }

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -122,6 +122,54 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     ]);
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
+
+    // Add OptionGroup for Select element
+    $result = civicrm_api3('OptionGroup', 'create', [
+      'name' => "list_1",
+      'title' => "Select",
+      'data_type' => "String",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add First OptionValue to OptionGroup for Select element
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "list_1",
+      'name' => "Option A",
+      'label' => "Option A",
+      'value' => 'OptionA',
+      'is_default' => 0,
+      'weight' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add Second OptionValue to OptionGroup for Select element
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "list_1",
+      'name' => "Option B",
+      'label' => "Option B",
+      'value' => 'OptionB',
+      'is_default' => 0,
+      'weight' => 1,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    // Add Field of type Select
+    $result = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => "Custom",
+      'label' => "List",
+      'html_type' => "Select",
+      'data_type' => "String",
+      'option_group_id' => "list_1",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
   }
 
   /**
@@ -149,12 +197,14 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_3");
     $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_4");
+    $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_5");
 
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_1");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_2_timepart");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_3");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_4");
+    $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_5");
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -167,6 +217,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
+    $this->enableStaticOptionOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
@@ -187,8 +238,10 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2').setAttribute('value', '2020-12-12')");
     $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2-timepart').setAttribute('value', '10:20:00')");
 
+    // Only check one Checkbox -> Red
+    $this->assertSession()->pageTextContains('Red - Recommended');
     $this->getSession()->getPage()->checkField('Red');
-    $this->getSession()->getPage()->checkField('Green');
+
     $this->getSession()->getPage()->checkField('Yes');
 
     $this->getSession()->getPage()->pressButton('Submit');
@@ -200,14 +253,14 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
       'sequential' => 1,
       'entity_id' => 3,
     ]);
-    $this->assertEquals(4, $api_result['count']);
+    $this->assertEquals(5, $api_result['count']);
     // throw new \Exception(var_export($api_result, TRUE));
     $this->assertEquals('Lorem Ipsum', $api_result['values'][0]['latest']);
     $this->assertEquals('2020-12-12 10:20:00', $api_result['values'][1]['latest']);
     // Check the checkbox values
     // Red = 1; Green = 2;
     $this->assertEquals(1, $api_result['values'][2]['latest']['0']);
-    $this->assertEquals(2, $api_result['values'][2]['latest']['1']);
+    $this->assertEquals(1, $api_result['values'][2]['latest']['1']);
 
     $result = civicrm_api3('OptionValue', 'get', [
       'option_group_id' => "checkboxes_1",
@@ -215,16 +268,17 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(2, $result['count']);
 
+    $first_colour = [];
     foreach ($result['values'] as $value) {
       if ($value['value'] == $api_result['values'][2]['latest']['0']) {
         $first_colour = $value['name'];
-      } elseif ($value['value'] == $api_result['values'][2]['latest']['1']) {
-        $second_colour = $value['name'];
       }
     }
 
     $this->assertEquals('Red', $first_colour);
-    $this->assertEquals('Green', $second_colour);
+
+    // For the Select List - the default is OptionA - Check that it's stored properly in CiviCRM:
+    $this->assertEquals('OptionA', $api_result['values'][3]['latest']);
   }
 
 }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -140,28 +140,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
-    $this->getSession()->getPage()->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
-  }
-
-  /**
-   * Modify settings so the element displays Static Option.
-   */
-  protected function enableStaticOptionOnElement($selector) {
-    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
-    $checkbox_edit_button->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-
-    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
-    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
 
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
   }
 
   /**

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -142,6 +142,26 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+  }
+
+  /**
+   * Modify settings so the element displays Static Option.
+   */
+  protected function enableStaticOptionOnElement($selector) {
+    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
+    $checkbox_edit_button->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
+    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
+
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

- Added: Custom Field of Type Select with Option Values: OptionA and OptionB
- Changed previously added Checkboxes testing to checking just one Checkbox
- Added assertion for previously added Radio -> Checkbox button option

Added ToDo for Testing Static Options. That's currently not working in the Tests - and is likely a Testing issue re: AJAX requests (multiple). 
