### PR TITLE
Allow hidden elements to have array values

### DIFF
--- a/includes/wf_crm_webform_preprocess.inc
+++ b/includes/wf_crm_webform_preprocess.inc
@@ -486,7 +486,7 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
               $val = wf_crm_explode_multivalue_str($val);
             }
-            if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date'
+            if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date' && $element['#type'] != 'value'
               && empty($element['#multiple']) && is_array($val)) {
               // If there's more than one value for a non-multi field, pick the most appropriate
               if (!empty($element['#options'])) {


### PR DESCRIPTION
Overview
----------------------------------------
This PR solves the problem experienced by sending a WebForm associated with a Case.
If the case has more than one tag associated, and the tag is a hidden field of the form, then only one of those values is preserved. 


Before
----------------------------------------
In particular, for one of our customers, there is a first form, F1, in which the tags can be selected. The tag field is then rendered with the widget "Select options".
After the Form is correctly saved, a Case is created with, for example, tags Tag1, Tag2, Tag3. 
If this same Case requires to get updated through another form, F3, in which the Tags should not be edited (therefore hidden), we observe that after submission Tag2 and Tag3 were removed.
- Result after form F1
![image](https://user-images.githubusercontent.com/74304572/106298068-01301480-6286-11eb-916b-17f9ec45d344.png)
- Result after form F3
![image](https://user-images.githubusercontent.com/74304572/106298160-24f35a80-6286-11eb-8593-d3cc8e03149e.png)


After
----------------------------------------
The tags are all correctly preserved.


Technical Details
----------------------------------------
In the modified script, this code fragment is verifying if some value **to be displayed** does not allow multiple options, but is an array:
```php
            if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date'
              && empty($element['#multiple']) && is_array($val)) {
              // If there's more than one value for a non-multi field, pick the most appropriate
              if (!empty($element['#options'])) {
                foreach ($element['#options'] as $k => $v) {
                  if (in_array($k, $val)) {
                    $val = $k;
                    break;
                  }
                }
              }
              else {
                $val = array_pop($val);
              }
            }
```
I put emphasis on "to be displayed" part, because it is not considering the situation in which those values don't need to be presented.
According to the documentation, and also with the observed during the test of the changes, the "#type" of the a hidden element is 'value': https://api.drupal.org/api/drupal/developer!topics!forms_api_reference.html/7.x#val then we avoid to reduce the options by filtering appropriately.
