### PR TITLE
Fix the usage of invalid placeholder `!`.

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1121,7 +1121,7 @@ class AdminForm implements AdminFormInterface {
       $fs = "contribution_sets_lineitem_{$n}_fieldset";
       $this->form['contribution']['sets']['lineitem'][$fs] = array(
         '#type' => 'fieldset',
-        '#title' => t('Line item !num', array('!num' => $n)),
+        '#title' => t('Line item %num', array('%num' => $n)),
         '#attributes' => array('id' => $fs, 'class' => array('web-civi-checkbox-set')),
         'js_select' => $this->addToggle($fs),
       );

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -351,7 +351,7 @@ class ContactComponent implements ContactComponentInterface {
    */
   function wf_crm_contact_component_required($element, &$form_state) {
     if (empty($element['#value'])) {
-      form_error($element, t('!name field is required.', array('!name' => $element['#title'])));
+      form_error($element, t('@name field is required.', array('@name' => $element['#title'])));
     }
   }
 

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -516,7 +516,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             $this->form_state->setErrorByName($eid, format_plural($event['available_places'],
               'Sorry, you tried to register !count people for %event but there is only 1 space remaining.',
               'Sorry, you tried to register !count people for %event but there are only @count spaces remaining.',
-              array('%event' => $event['title'], '!count' => $event['count'])));
+              array('%event' => $event['title'], '@count' => $event['count'])));
           }
         }
       }
@@ -1020,7 +1020,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if (!empty($remove) && $data_type == 'group') {
       $display_name = $utils->wf_civicrm_api('contact', 'get', array('contact_id' => $id, 'return.display_name' => 1));
       $display_name = wf_crm_aval($display_name, "values:$id:display_name", t('Contact'));
-      \Drupal::messenger()->addStatus(t('%contact has been removed from !group.', array('%contact' => $display_name, '!group' => '<em>' . implode('</em> ' . t('and') . ' <em>', $remove) . '</em>')));
+      \Drupal::messenger()->addStatus(t('%contact has been removed from @group.', array('%contact' => $display_name, '@group' => '<em>' . implode('</em> ' . t('and') . ' <em>', $remove) . '</em>')));
     }
   }
 
@@ -1159,7 +1159,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         }
         foreach ($remove as $eid => $title) {
           $utils->wf_civicrm_api('participant', 'create', array('status_id' => "Cancelled", 'id' => $existing[$eid]));
-          \Drupal::messenger()->addStatus(t('Registration cancelled for !event', array('!event' => $title)));
+          \Drupal::messenger()->addStatus(t('Registration cancelled for @event', array('@event' => $title)));
         }
       }
     }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -125,7 +125,7 @@ function webform_civicrm_theme() {
  */
 function webform_civicrm_webform_submission_render_alter(&$sub) {
   if (!empty($sub['#submission']->civicrm['contact'][1]['display_name']) && empty($sub['#email']) && $sub['#format'] == 'html') {
-    drupal_set_title(t('Submission #!num by @name', array('!num' => $sub['#submission']->sid, '@name' => $sub['#submission']->civicrm['contact'][1]['display_name'])));
+    drupal_set_title(t('Submission #@num by @name', array('@num' => $sub['#submission']->sid, '@name' => $sub['#submission']->civicrm['contact'][1]['display_name'])));
   }
 }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix invalid placeholder to get rid of notice/warnings.

Before
----------------------------------------
! is not a valid placeholder in d8 https://api.drupal.org/api/drupal/core!lib!Drupal!Component!Render!FormattableMarkup.php/function/FormattableMarkup%3A%3AplaceholderFormat/8.3.x


![image](https://user-images.githubusercontent.com/5929648/107110230-5c589d00-686c-11eb-8d22-8238ce638e13.png)


After
----------------------------------------
Replaced it with @ or %. No notice displayed on the page.


