### PR TITLE
[Test only] - to see if we can remove/clear a Tag and Save the Submission

### DIFF
--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -89,6 +89,15 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("Volunteer");
     $this->assertSession()->checkboxNotChecked("Company");
 
+    // Ok switch!
+    $this->getSession()->getPage()->uncheckField('Volunteer');
+    $this->getSession()->getPage()->checkField('Company');
+    $this->htmlOutput();
+    $this->getSession()->getPage()->pressButton('Submit');
+    // ToDo -> Fix Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1343 of /Applications/MAMP/htdocs/d9civicrm.local/web/modules/contrib/webform/src/WebformSubmissionStorage.php)
+    // $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
     // throw new \Exception(var_export($api_result, TRUE));
   }
 

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -86,12 +86,12 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $this->assertSession()->waitForField('Volunteer');
-    $this->assertSession()->checkboxChecked("Volunteer");
-    $this->assertSession()->checkboxNotChecked("Company");
+    $this->assertSession()->checkboxChecked('Volunteer');
+    $this->assertSession()->checkboxNotChecked('Company');
 
-    // Ok switch!
+    // Ok clear the Tag:
     $this->getSession()->getPage()->uncheckField('Volunteer');
-    $this->getSession()->getPage()->checkField('Company');
+    $this->assertSession()->checkboxNotChecked('Volunteer');
     $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Submit');
     // ToDo -> Fix Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1343 of /Applications/MAMP/htdocs/d9civicrm.local/web/modules/contrib/webform/src/WebformSubmissionStorage.php)

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -98,7 +98,16 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     // $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $api_result = $utils->wf_civicrm_api('Contact', 'get', [
+      'sequential' => 1,
+      'return' => ["tag"],
+      'contact_id' => 2,
+    ]);
+
     // throw new \Exception(var_export($api_result, TRUE));
+    $this->assertNotEquals('Volunteer', $api_result['values'][0]['tags']);
+
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------

The test was already loading to make sure that the Volunteer Tag we selected earlier on is indeed Selected and that the Company Tag is indeed not selected:

```
    // Ok let's go back to the Webform and see it is loading the previously selected Tag properly
    $this->drupalGet($this->webform->toUrl('canonical'));
    $this->assertPageNoErrorMessages();
    $this->assertSession()->waitForField('Volunteer');
    $this->assertSession()->checkboxChecked('Volunteer');
    $this->assertSession()->checkboxNotChecked('Company');
```
Now added in this PR: we're deselecting the Volunteer Tag and we are pressing the Submit button and checking that we get the 'New submission added to CiviCRM Webform Test.' Confirmation message

```
    // Ok clear the Tag:
    $this->getSession()->getPage()->uncheckField('Volunteer');
    $this->assertSession()->checkboxNotChecked('Volunteer');
    $this->htmlOutput();
    $this->getSession()->getPage()->pressButton('Submit');
    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
```

In addition pull up the Tags for this CiviCRM Contact and test that there is no Volunteer Tag:

```
    $utils = \Drupal::service('webform_civicrm.utils');
    $api_result = $utils->wf_civicrm_api('Contact', 'get', [
      'sequential' => 1,
      'return' => ["tag"],
      'contact_id' => 2,
    ]);

    // throw new \Exception(var_export($api_result, TRUE));
    $this->assertNotEquals('Volunteer', $api_result['values'][0]['tags']);
```

`throw new \Exception(var_export($api_result, TRUE));` shows there are indeed no Tags:
![image](https://user-images.githubusercontent.com/5340555/107124675-87d68a00-6862-11eb-883b-c059991ac026.png)

