### PR TITLE
Fix Notice: Array to string conversion in saveData()

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -215,4 +215,21 @@ class CivicrmOptions extends WebformElementBase {
     return $element;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function hasMultipleWrapper() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasMultipleValues(array $element) {
+    if (!empty($element['#extra']['multiple']) || (!empty($element['#options']) && count($element['#options']) === 1)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -68,8 +68,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     $this->getSession()->getPage()->pressButton('Submit');
-    // ToDo -> Fix Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1343 of /Applications/MAMP/htdocs/d9civicrm.local/web/modules/contrib/webform/src/WebformSubmissionStorage.php)
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -94,8 +93,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxNotChecked('Volunteer');
     $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Submit');
-    // ToDo -> Fix Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1343 of /Applications/MAMP/htdocs/d9civicrm.local/web/modules/contrib/webform/src/WebformSubmissionStorage.php)
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $utils = \Drupal::service('webform_civicrm.utils');

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -68,7 +68,8 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     $this->getSession()->getPage()->pressButton('Submit');
-    $this->assertPageNoErrorMessages();
+    // ToDo: Fix Notice on GitHub tests Notice: Undefined index: #form_key in Drupal\webform_civicrm\Utils->wf_crm_enabled_fields() (line 477 of /home/runner/work/webform_civicrm/webform_civicrm/src/Utils.php).
+    // $this->assertPageNoErrorMessages();
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -93,7 +94,8 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxNotChecked('Volunteer');
     $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Submit');
-    $this->assertPageNoErrorMessages();
+    // ToDo: Fix Notice on GitHub tests Notice: Undefined index: #form_key in Drupal\webform_civicrm\Utils->wf_crm_enabled_fields() (line 477 of /home/runner/work/webform_civicrm/webform_civicrm/src/Utils.php).
+    // $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $utils = \Drupal::service('webform_civicrm.utils');


### PR DESCRIPTION
Overview
----------------------------------------
On submission of a webform with CiviCRM Options -> Notice appears:

Before
----------------------------------------
`Notice: Array to string conversion in Drupal\webform\WebformSubmissionStorage->saveData() (line 1343 of /Applications/MAMP/htdocs/d9civicrm.local/web/modules/contrib/webform/src/WebformSubmissionStorage.php)`

After
----------------------------------------
On local via UI - no notice! 👆 is no longer there.
On Github Actions: Different notice

Technical Details
----------------------------------------
On Github Actions -> notice:
`Notice: Undefined index: #form_key in Drupal\webform_civicrm\Utils->wf_crm_enabled_fields() (line 477 of /home/runner/work/webform_civicrm/webform_civicrm/src/Utils.php). 
`
