### PR TITLE
#form_key notice issue in Automated Tests but not in UI/Manual Testing

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -474,6 +474,7 @@ class Utils implements UtilsInterface {
               continue;
             }
             if ($submission) {
+              \Drupal::messenger()->addStatus(t('c = @c', array('@c' => $c['#title'])));
               $enabled[$key] = wf_crm_aval($submission, $c['#form_key'], NULL, TRUE);
             }
             else {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -475,6 +475,7 @@ class Utils implements UtilsInterface {
             }
             if ($submission) {
               \Drupal::messenger()->addStatus(t('c = @c', array('@c' => $c['#title'])));
+              \Drupal::messenger()->addStatus(t('f = @f', array('@f' => $c['#form_key'])));
               $enabled[$key] = wf_crm_aval($submission, $c['#form_key'], NULL, TRUE);
             }
             else {

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -49,7 +49,6 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
 
     // Ensure the Tags render like checkboxes by deselecting List ->
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $this->assertSession()->waitForField('Checkboxes');
     $this->htmlOutput();
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-other-tag-operations');
 
@@ -66,10 +65,11 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField('Volunteer');
     $this->assertSession()->checkboxChecked("Volunteer");
     $this->htmlOutput();
-
+    $this->createScreenshot($this->htmlOutputDirectory . '/webform.png');
     $this->getSession()->getPage()->pressButton('Submit');
     // ToDo: Fix Notice on GitHub tests Notice: Undefined index: #form_key in Drupal\webform_civicrm\Utils->wf_crm_enabled_fields() (line 477 of /home/runner/work/webform_civicrm/webform_civicrm/src/Utils.php).
-    // $this->assertPageNoErrorMessages();
+    $this->createScreenshot($this->htmlOutputDirectory . '/submitted.png');
+    $this->assertPageNoErrorMessages();
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 


### PR DESCRIPTION
Overview
----------------------------------------
We're getting a notice when running tests on Github Actions:
`Notice: Undefined index: #form_key in Drupal\webform_civicrm\Utils->wf_crm_enabled_fields() (line 477 of /home/runner/work/webform_civicrm/webform_civicrm/src/Utils.php).`

On my local/UI - all is well: starting to debug this by adding some messaging:

![image](https://user-images.githubusercontent.com/5340555/107131929-3ba63c80-6898-11eb-84d1-664b03042a3d.png)


Before
----------------------------------------


After
----------------------------------------


Technical Details
----------------------------------------

Comments
----------------------------------------
