### PR TITLE
Lock in versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,14 +66,13 @@ jobs:
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages}:${{ matrix.civicrm }} --no-suggest --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
-        if: matrix.drupal == '^9.0'
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.0@beta' --no-suggest
+          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev' --no-suggest
       - name: Install webform_civicrm
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require  drupal/webform_civicrm *@dev
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/webform_civicrm *@dev
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,6 @@
   },
   "require": {
       "civicrm/civicrm-drupal-8": "~5.0",
-      "drupal/webform": "^5.0 || ^6.0"
+      "drupal/webform": "^6.0"
   }
 }

--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -1,8 +1,8 @@
-name: 'CiviCRM Webform'
+name: 'Webform CiviCRM'
 type: module
-description: 'CiviCRM and Webform integration'
-core_version_requirement: ^8.7.7 || ^9
+description: 'Webform CiviCRM Integration'
+core_version_requirement: ^8.8 || ^9
 package: 'Custom'
 dependencies:
-  - webform
+  - drupal: webform (>= 6.0)
   - civicrm

--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -4,5 +4,5 @@ description: 'Webform CiviCRM Integration'
 core_version_requirement: ^8.8 || ^9
 package: 'Custom'
 dependencies:
-  - drupal: webform (>= 6.0)
+  - drupal:webform (>= 6.0)
   - civicrm


### PR DESCRIPTION
Overview
----------------------------------------
Standardize versions -> requiring webform module ^6.0

Before
----------------------------------------
Sites could have webform module 8.x-5.x OR ^6.0 installed and though small we noticed some important differences esp. re: #form_key handling. Jake Rockowitz (maintainer of Drupal webform module) recommends we just focus on ^6.0 going forwards.

After
----------------------------------------
Requiring in the info.yml file:
  - drupal:webform (>= 6.0)

Github Actions specifically pulls in:
          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev' --no-suggest

Checking that
----------------------------------------
![image](https://user-images.githubusercontent.com/5340555/107155428-8aee7a80-6935-11eb-9322-884dbde2ceed.png)
