### PR TITLE
d8 - Fix check for form_key

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -124,7 +124,7 @@ class CivicrmOptions extends WebformElementBase {
       '#type' => 'civicrm_select_options',
       '#civicrm_live_options' => $element_properties['civicrm_live_options'],
       '#default_option' => $element_properties['default_option'],
-      '#form_key' => $this->configuration['#form_key'] ?? $element_properties['form_key'] ?? $element_properties['custom']['form_key'],
+      '#form_key' => $form_state->get('element_properties')['form_key'],
     ];
 
     return $form;

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -133,7 +133,7 @@ class CivicrmSelect extends WebformElementBase {
       '#type' => 'civicrm_select_options',
       '#civicrm_live_options' => $element_properties['civicrm_live_options'],
       '#default_option' => $element_properties['default_option'],
-      '#form_key' => $this->configuration['#form_key'] ?? $element_properties['form_key'] ?? $element_properties['custom']['form_key'],
+      '#form_key' => $form_state->get('element_properties')['form_key'],
     ];
 
     return $form;


### PR DESCRIPTION
Overview
----------------------------------------
Fix retrieval of form_key

Before
----------------------------------------
Too many assumptions of form_key storage.

After
----------------------------------------
Get it from element properties. The options are still loading fine.

![image](https://user-images.githubusercontent.com/5929648/107853138-4e8db380-6e3a-11eb-9d22-3a98d987b2ca.png)

Comments
----------------------------------------
@KarinG 