### PR TITLE
Fix static option display and assert form key error on submit.

### DIFF
--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -179,7 +179,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->createCustomFields();
 
-    $this->drupalLogin($this->adminUser);
+    $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
     ]));
@@ -219,15 +219,15 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
 
     // ToDo: Enable Static Option and Edit Label
-    // $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
-    // $checkbox_edit_button->click();
-    // $this->assertSession()->assertWaitOnAjaxRequest();
-    // $this->htmlOutput();
-    // $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
-    // $this->assertSession()->assertWaitOnAjaxRequest();
-    // $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
-    // $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
-    // $this->htmlOutput();
+    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
+    $checkbox_edit_button->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
+    $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
+    $this->htmlOutput();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
@@ -237,8 +237,12 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('First Name');
     $this->assertSession()->pageTextContains('Label for custom radio field');
 
-    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+    $params = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+    ];
+    $this->getSession()->getPage()->fillField('First Name', $params['first_name']);
+    $this->getSession()->getPage()->fillField('Last Name', $params['last_name']);
 
     $this->getSession()->getPage()->fillField('Text', 'Lorem Ipsum');
 
@@ -255,13 +259,15 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField('Yes');
 
     $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     // Note: custom fields are on contact_id=3 (1=default org; 2=the drupal user)
     $utils = \Drupal::service('webform_civicrm.utils');
+    $contactID = $utils->wf_civicrm_api('Contact', 'get', $params)['id'];
     $api_result = $utils->wf_civicrm_api('CustomValue', 'get', [
       'sequential' => 1,
-      'entity_id' => 3,
+      'entity_id' => $contactID,
     ]);
     $this->assertEquals(5, $api_result['count']);
     // throw new \Exception(var_export($api_result, TRUE));


### PR DESCRIPTION
Overview
----------------------------------------
Fix static option display and assert form key error on submit.

Before
----------------------------------------
No options displayed on selecting static option.

After
----------------------------------------
Displayed correctly.

![image](https://user-images.githubusercontent.com/5929648/107873265-4d5e9400-6ed7-11eb-9304-0140d790d559.png)

Comments
----------------------------------------
`$this->rootUser` is provided by core drupal. This is also used by `webform` module in verifying all the test executions so it should be fine to use it in our test setup too? @KarinG 