### PR TITLE
[Test only] - Standardize Themes -> Bartik + Seven.

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -51,6 +51,15 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    */
   protected function setUp() {
     parent::setUp();
+
+    // Make sure we are using distinct default and administrative themes for
+    // the duration of these tests.
+    \Drupal::service('theme_installer')->install(['bartik', 'seven']);
+    $this->config('system.theme')
+      ->set('default', 'bartik')
+      ->set('admin', 'seven')
+      ->save();
+
     $this->adminUser = $this->createUser([
       'access content',
       'administer CiviCRM',


### PR DESCRIPTION
Overview
----------------------------------------
Standardize Themes -> Bartik + Seven.
We have fixed at least one theme issue with Claro -> Existing Contact Element -> Default Settings would not show. So I think for testing it's best we standardize this.