### PR TITLE
Fix live option handling for civicrm_options element

### DIFF
--- a/js/webform_civicrm_options.js
+++ b/js/webform_civicrm_options.js
@@ -40,7 +40,7 @@ if (typeof jQuery.fn.prop !== 'function') {
       }
     });
   }
-  
+
   D.behaviors.webform_civicrmOptions = {
     attach: function (context) {
       $('input.civicrm-enabled', context).once('wf-civi').change(function() {
@@ -65,9 +65,9 @@ if (typeof jQuery.fn.prop !== 'function') {
         }
         $('input.civicrm-enabled').change();
       });
-      
+
       var defaultName = 'civicrm_options_fieldset[civicrm_defaults]';
-      
+
       var multiple = $('input[name="extra[multiple]"]');
       if (multiple.is(':checkbox')) {
         multiple.once('wf-civi').change(function() {
@@ -78,27 +78,6 @@ if (typeof jQuery.fn.prop !== 'function') {
       else if (multiple.attr('value') !== '1') {
         defaultBoxes('radio', defaultName);
       }
-      
-      $('a.tabledrag-handle, a.tabledrag-toggle-weight').not('.live-options-hide a').wrap('<div class="live-options-hide" />');
-      
-      $('input[name="extra[civicrm_live_options]"]').once('wf-civi').change(function() {
-        if ($(this).is(':checked')) {
-          switch ($(this).attr('value')) {
-            case "0":
-              $('.live-options-hide').show();
-              $('.live-options-show').hide();
-              $('.tabledrag-hide.visible').removeClass('visible').show();
-              break;
-            case "1":
-              $('.live-options-hide').hide();
-              $('.live-options-show').show();
-              $('.tabledrag-hide:visible').addClass('visible').hide();
-              $('input.civicrm-enabled, input.select-all-civi-options').prop('checked', true);
-              $('input.civicrm-enabled').change();
-              break;
-          }
-        }
-      }).change();
     }
   };
 })(jQuery, Drupal);

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1448,7 +1448,6 @@ class AdminForm implements AdminFormInterface {
       '#title' => str_replace('#', '', $field['name']),
       '#attributes' => wf_crm_aval($field, 'attributes'),
     );
-
     // Create dropdown list
     if (!empty($field['expose_list'])) {
       $field['form_key'] = $fid;
@@ -1470,6 +1469,7 @@ class AdminForm implements AdminFormInterface {
         '#type' => 'select',
         '#options' => $options,
         '#multiple' => !empty($field['extra']['multiple']),
+        '#civicrm_live_options' => !empty($field['civicrm_live_options']),
         '#default_value' => !empty($field['empty_option']) ? 0 : NULL,
       );
       if (isset($field['empty_option'])) {

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -116,7 +116,8 @@ class Fields implements FieldsInterface {
       $fields['contact_contact_sub_type'] = array(
         'name' => t('Type of @contact'),
         'type' => 'select',
-        'extra' => array('multiple' => 1, 'civicrm_live_options' => 1),
+        'extra' => array('multiple' => 1),
+        'civicrm_live_options' => 1,
         'expose_list' => TRUE,
       );
       $fields['contact_existing'] = array(
@@ -285,7 +286,7 @@ class Fields implements FieldsInterface {
       $fields['address_country_id'] = array(
         'name' => t('Country'),
         'type' => 'select',
-        'extra' => array('civicrm_live_options' => 1),
+        'civicrm_live_options' => 1,
         'value' => $utils->wf_crm_get_civi_setting('defaultContactCountry', 1228),
       );
       $fields['address_state_province_id'] = array(
@@ -367,7 +368,8 @@ class Fields implements FieldsInterface {
       $fields['other_group'] = array(
         'name' => t('Group(s)'),
         'type' => 'select',
-        'extra' => array('multiple' => 1, 'civicrm_live_options' => 1),
+        'civicrm_live_options' => 1,
+        'extra' => array('multiple' => 1),
         'table' => 'group',
         'expose_list' => TRUE,
       );
@@ -535,7 +537,8 @@ class Fields implements FieldsInterface {
           $fields[$entity . '_tag' . ($pid ? "_$pid" : '')] = [
             'name' => $name,
             'type' => 'select',
-            'extra' => ['multiple' => 1, 'civicrm_live_options' => 1],
+            'civicrm_live_options' => 1,
+            'extra' => ['multiple' => 1],
             'table' => 'tag',
             'expose_list' => TRUE,
           ];
@@ -545,8 +548,8 @@ class Fields implements FieldsInterface {
         'name' => t('Relationship Type(s)'),
         'type' => 'select',
         'expose_list' => TRUE,
+        'civicrm_live_options' => 1,
         'extra' => array(
-          'civicrm_live_options' => 1,
           'multiple' => 1,
         ),
       );
@@ -593,9 +596,9 @@ class Fields implements FieldsInterface {
           'name' => 'Payment Processor',
           'type' => 'select',
           'expose_list' => TRUE,
+          'civicrm_live_options' => TRUE,
           'extra' => [
             'aslist' => 0,
-            'civicrm_live_options' => TRUE,
             'required' => TRUE
           ],
           'exposed_empty_option' => 'Pay Later',
@@ -661,7 +664,7 @@ class Fields implements FieldsInterface {
           'name' => t('Financial Type'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'extra' => array('civicrm_live_options' => 1),
+          'civicrm_live_options' => TRUE,
           'value' => 1,
           'default' => 1,
           'set' => 'line_items',
@@ -697,7 +700,8 @@ class Fields implements FieldsInterface {
         $fields['participant_event_id'] = array(
           'name' => t('Event(s)'),
           'type' => 'select',
-          'extra' => array('multiple' => 1, 'civicrm_live_options' => 1),
+          'civicrm_live_options' => TRUE,
+          'extra' => array('multiple' => 1),
           'expose_list' => TRUE,
         );
         $fields['participant_role_id'] = array(
@@ -797,14 +801,14 @@ class Fields implements FieldsInterface {
           'type' => 'select',
           'expose_list' => TRUE,
           'empty_option' => t('None'),
-          'extra' => array('civicrm_live_options' => 1),
+          'civicrm_live_options' => TRUE,
         );
         foreach (array_intersect(array('activity', 'membership', 'participant', 'contribution'), array_keys($sets)) as $ent) {
           $fields[$ent . '_campaign_id'] = array(
             'name' => t('Campaign'),
             'type' => 'select',
             'expose_list' => TRUE,
-            'extra' => array('civicrm_live_options' => 1),
+            'civicrm_live_options' => TRUE,
             'empty_option' => t('None'),
           );
         }
@@ -821,7 +825,7 @@ class Fields implements FieldsInterface {
           'name' => t('Grant Type'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'extra' => array('civicrm_live_options' => 1),
+          'civicrm_live_options' => TRUE,
         );
         $fields['grant_status_id'] = array(
           'name' => t('Grant Status'),
@@ -991,7 +995,7 @@ class Fields implements FieldsInterface {
           $fields[$id]['empty_option'] = t('None');
         }
         elseif ($fields[$id]['data_type'] !== 'Boolean' && $fields[$id]['type'] == 'select') {
-          $fields[$id]['extra']['civicrm_live_options'] = 1;
+          $fields[$id]['civicrm_live_options'] = 1;
         }
         elseif ($fields[$id]['type'] == 'textarea') {
           $fields[$id]['extra']['cols'] = $custom_field['note_columns'] ?? 60;

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -141,6 +141,9 @@ class CivicrmOptions extends WebformElementBase {
       $properties['#default_option'] = $select_options['#default_option'];
       $properties['#default_value'] = $select_options['#default_option'];
     }
+    if (!isset($properties['#civicrm_live_options'])) {
+      $properties['#civicrm_live_options'] = $form_state->getValues()['civicrm_live_options'] ?? 0;
+    }
     return $properties;
   }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -144,7 +144,7 @@ abstract class WebformCivicrmBase {
             }
             // Hack for gender as textfield. More general solution needed for all pseudoconsant fields
             $gender_field = $this->node->getElement("civicrm_{$c}_contact_1_contact_gender_id");
-            if ($gender_field && $gender_field['type'] == 'textfield') {
+            if ($gender_field && $gender_field['#type'] == 'textfield') {
               $result[1]['gender_id'] = wf_crm_aval($result[1], 'gender');
             }
           }
@@ -535,7 +535,7 @@ abstract class WebformCivicrmBase {
     }
     if ($field && $field['#type'] == 'select') {
       // Fetch static options
-      if (empty($field['#extra']['civicrm_live_options'])) {
+      if (empty($field['civicrm_live_options'])) {
         $exposed = $utils->wf_crm_str2array($field['#extra']['items']);
       }
       // Fetch live options

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -480,7 +480,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           // Provide live options from the Civi DB
           if (!empty($element['#civicrm_live_options']) && isset($element['#options'])) {
             $params = [
-              'extra' => wf_crm_aval($field, 'extra', []) + $element['#extra'],
+              'extra' => wf_crm_aval($field, 'extra', []) + wf_crm_aval($element, '#extra', []),
               'form_key' => $element['#webform_key'],
             ];
             $new = $utils->wf_crm_field_options($params, 'live_options', $this->data);

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -206,17 +206,15 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_4");
     $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_5");
 
-    $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
-    $this->assertPageNoErrorMessages();
+    $this->saveCiviCRMSettings();
 
     // Change the Checkbox -> no Listbox (that should probably be the default)
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->assertSession()->waitForField('Checkboxes');
     $this->htmlOutput();
 
-    $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
-    $this->enableCheckboxOnElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations');
+    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
+    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations', FALSE, TRUE);
 
     // ToDo: Enable Static Option and Edit Label
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations"] a.webform-ajax-link');
@@ -230,6 +228,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->createScreenshot($this->htmlOutputDirectory . '/afterlabelchange.png');
     $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -139,18 +139,33 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
-   * Modify settings so the element displays as a checkbox.
+   * Modify settings so the element displays as a checkbox
+   *
+   * @param string $selector
+   * @param bool $multiple
+   * @param bool $enableStatic
+   *   TRUE if static radio option should be enabled.
    */
-  protected function enableCheckboxOnElement($selector) {
+  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE) {
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
     $checkbox_edit_button->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
+    if ($enableStatic) {
+      $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]');
+    }
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
     $this->htmlOutput();
 
+    if ($multiple) {
+      $this->getSession()->getPage()->checkField('properties[extra][multiple]');
+      $this->assertSession()->checkboxChecked('properties[extra][multiple]');
+      $this->htmlOutput();
+    }
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
   }
@@ -199,6 +214,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   public function saveCiviCRMSettings() {
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->assertPageNoErrorMessages();
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix dynamic load of option values on the webform.

https://www.drupal.org/project/webform_civicrm/issues/3188442

Before
----------------------------------------
If a new option is added to the tag, custom field, etc, it requires a rebuild on the setting page to show the updated values on the webform. 

After
----------------------------------------
Fixed. Newly added values to the custom field options or the tag, etc are loaded straight on the webform. No rebuild is required. 

Technical Details
----------------------------------------
Moved `civicrm_live_options` out of the `extra` key since it is handled as a main property in the plugins https://github.com/colemanw/webform_civicrm/blob/8.x-5.x/src/Plugin/WebformElement/CivicrmOptions.php#L42.

Comments
----------------------------------------
@KarinG 