### PR TITLE
Do not render civicrm_option element as listbox by default

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2112,7 +2112,7 @@ class AdminForm implements AdminFormInterface {
       if ($options = $utils->wf_crm_field_options($field, 'component_insert', $settings['data'])) {
         $field['options'] = $options;
         $field['extra']['items'] = $utils->wf_crm_array2str($options);
-        $field['extra']['aslist'] = TRUE;
+        $field['extra']['aslist'] = $field['extra']['aslist'] ?? FALSE;
         $field['type'] = 'civicrm_options';
       }
     }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -996,6 +996,10 @@ class Fields implements FieldsInterface {
         }
         elseif ($fields[$id]['data_type'] !== 'Boolean' && $fields[$id]['type'] == 'select') {
           $fields[$id]['civicrm_live_options'] = 1;
+          $fields[$id]['extra']['aslist'] = 1;
+          if (in_array($custom_field['html_type'], ['Radio', 'CheckBox'])) {
+            $fields[$id]['extra']['aslist'] = 0;
+          }
         }
         elseif ($fields[$id]['type'] == 'textarea') {
           $fields[$id]['extra']['cols'] = $custom_field['note_columns'] ?? 60;

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -212,8 +212,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->assertSession()->waitForField('Checkboxes');
     $this->htmlOutput();
-
-    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-3-operations');
+    //enable static option on radio field.
     $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-4-operations', FALSE, TRUE);
 
     // ToDo: Enable Static Option and Edit Label

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -46,12 +46,6 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
     $this->assertPageNoErrorMessages();
 
-    // Ensure the Tags render like checkboxes by deselecting List ->
-    $this->drupalGet($this->webform->toUrl('edit-form'));
-    $this->assertSession()->waitForField('Checkboxes');
-    $this->htmlOutput();
-    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-other-tag-operations');
-
     //Create another tag and confirm if it loads fine on the webform.
     $tagID = $utils->wf_civicrm_api('Tag', 'create', [
       'name' => "Tag" . substr(sha1(rand()), 0, 4),


### PR DESCRIPTION
Overview
----------------------------------------
Do not render civicrm_option element as listbox by default
 
Before
----------------------------------------
Civicrm Option element is displayed as listbox by default. Eg groups, tags, checkbox custom fields, etc.

![image](https://user-images.githubusercontent.com/5929648/108712785-4a9a1980-753d-11eb-9723-fdce91873b8e.png)

After
----------------------------------------
Loads correct html by default.

![image](https://user-images.githubusercontent.com/5929648/108713100-c4320780-753d-11eb-99b9-344961b21486.png)


Comments
----------------------------------------
@KarinG 