### PR TITLE
Fix checksum text on additional option tab

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1279,9 +1279,12 @@ class AdminForm implements AdminFormInterface {
       '#group' => 'webform_civicrm',
       '#title' => t('Additional Options'),
       '#attributes' => ['class' => ['civi-icon-prefs']],
-      '#description' => '<p>' .
-        t('To have this form auto-filled for anonymous users, enable the "Existing Contact" field for :contact and send the following link from CiviMail:', [':contact' => $utils->wf_crm_contact_label(1, $this->data, TRUE)]) .
-        '<br /><code>' . Url::fromRoute('entity.webform.canonical', ['webform' => $this->webform->id()], ['query' => ['cid1' => '']])->toString() . '{contact.contact_id}&amp;{contact.checksum}</code></p>',
+    ];
+    $this->form['options']['checksum_text'] = [
+      '#type' => 'item',
+      '#markup' => '<p>' .
+        t('To have this form auto-filled for anonymous users, enable the "Existing Contact" field for :contact and send the following link from CiviMail:', [':contact' => $utils->wf_crm_contact_label(1, $this->data, 'escape')]) .
+        '<br /><pre>' . Url::fromRoute('entity.webform.canonical', ['webform' => $this->webform->id()], ['query' => ['cid1' => ''], 'absolute' => TRUE])->toString() . '{contact.contact_id}&amp;{contact.checksum}</pre></p>',
     ];
     $this->form['options']['create_fieldsets'] = [
       '#type' => 'checkbox',

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -125,6 +125,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
 
     // The label has a <div> in it which can cause weird failures here.
     $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->clickLink('Additional Options');
+    $this->assertSession()->elementTextContains('css', '#edit-checksum-text', 'To have this form auto-filled for anonymous users, enable the "Existing Contact" field for Contact 1 and send the following link from CiviMail');
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contact['id']]]));


### PR DESCRIPTION
Overview
----------------------------------------
Fix checksum text on `Additional options` tab.

Drupal Issue - https://www.drupal.org/project/webform_civicrm/issues/3199537

Before
----------------------------------------
Help text not displayed.

After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/109377604-5c3f4080-78f2-11eb-8767-53bf5ab82334.png)


Comments
----------------------------------------
@KarinG 