### PR TITLE
Load default option for civicrm-option element

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -122,8 +122,8 @@ class CivicrmSelectOptions extends FormElement {
           return 1;
         }
 
-        $a_weight = $weight_values[$a];
-        $b_weight = $weight_values[$b];
+        $a_weight = $weight_values[$a] ?? 0;
+        $b_weight = $weight_values[$b] ?? 0;
         if ($a_weight == $b_weight) {
           return 0;
         }
@@ -157,7 +157,7 @@ class CivicrmSelectOptions extends FormElement {
         '#type' => 'radio',
         '#title' => t('Mark @item as the default value', ['@item' => $option]),
         '#title_display' => 'invisible',
-        '#default_value' => $element['#default_option'] == $key,
+        '#default_value' => $element['#default_option'] == $key ? $key : 0,
         '#parents' => array_merge($element['#parents'], ['default']),
         '#return_value' => $key,
       ];

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -153,8 +153,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    * @param bool $multiple
    * @param bool $enableStatic
    *   TRUE if static radio option should be enabled.
+   * @param bool $default
    */
-  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE) {
+  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL) {
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
     $checkbox_edit_button->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -164,6 +165,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
       $this->assertSession()->assertWaitOnAjaxRequest();
       $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]');
+    }
+    if ($default) {
+      $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);
     }
     $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
     $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
@@ -246,8 +250,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $driver = $this->getSession()->getDriver()->getWebDriverSession();
     $elementXpath = $page->findField($id)->getXpath();
 
-    $element = $this->assertSession()->elementExists('css', "#" . $id);
-    $element->click();
+    $this->assertSession()->elementExists('css', "#" . $id)->click();
     $driver->element('xpath', $elementXpath)->postValue(['value' => [$value]]);
 
     $this->assertSession()->waitForElementVisible('xpath', '//li[contains(@class, "token-input-dropdown")][1]');


### PR DESCRIPTION
Overview
----------------------------------------
Load default option for civicrm-option element (Tags, country, etc).

Before
----------------------------------------
Civicrm Option element does not load the default option on the page. Eg Tags, country, etc.

![image](https://user-images.githubusercontent.com/5929648/109382959-76d0e400-7909-11eb-8635-d0e960ebefb4.png)

After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/109382947-69b3f500-7909-11eb-9cc5-05f115074ab7.png)

Comments
----------------------------------------
@KarinG 