### PR TITLE
Show Case Option to file activity On Case

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -538,8 +538,8 @@ class AdminForm implements AdminFormInterface {
             }
             $wrap['case']["activity_{$n}_settings_case_type_id"]['#options'] = [
               t('- None -'),
-              t('This Webform') => $webform_cases,
-              t('Find by Case Type') => $case_types,
+              'This Webform' => $webform_cases,
+              'Find by Case Type' => $case_types,
             ];
           }
           $this->help($wrap['case']["activity_{$n}_settings_case_type_id"], 'file_on_case');


### PR DESCRIPTION
Overview
----------------------------------------
Add activity to Existing Case

Before
----------------------------------------
Case option was not available..
<img width="445" alt="file_activity_case_before" src="https://user-images.githubusercontent.com/377735/109393592-aa7f2e80-7948-11eb-8eba-b338d8a11ba1.png">


After
----------------------------------------
Option to add Activity to case option is available
<img width="532" alt="file_activity_case" src="https://user-images.githubusercontent.com/377735/109393618-cbe01a80-7948-11eb-9e00-b11d7fb3f614.png">


Technical Details
----------------------------------------
If Option Group Label is translated then option group and their option are not rendering.

Comments
----------------------------------------
https://www.drupal.org/forum/support/post-installation/2016-08-16/group-menus-select-list-with-optgroup-drupal-8
https://www.drupal.org/project/examples/issues/2283665