### PR TITLE
Remove webform requirement 6.0 from yml file.

### DIFF
--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -4,5 +4,5 @@ description: 'Webform CiviCRM Integration'
 core_version_requirement: ^8.8 || ^9
 package: 'Custom'
 dependencies:
-  - drupal:webform (>= 6.0)
+  - drupal:webform
   - civicrm


### PR DESCRIPTION
Overview
----------------------------------------
We can remove the 6.0 version requirement for webform in the `info.yml` file - It causes issues when manually trying to install webform_civicrm module using the UI (finding blank and not being able to satisfy the >6.0 requirement).

And composer -> finds it in webform_civicrm's `composer.json` which says:
      `"drupal/webform": "^6.0"`

Before
----------------------------------------
Can not install webform_civicrm module via UI

After
----------------------------------------
Yes we can!