### PR TITLE
Fix add element error on webform

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -156,7 +156,7 @@ class CivicrmOptions extends WebformElementBase {
     $is_multiple = !empty($element['#extra']['multiple']);
     $use_live_options = !empty($element['#civicrm_live_options']);
     $data = [];
-    if ($webform_submission) {
+    if ($webform_submission && $webform_submission->getWebform()->getHandlers()->has('webform_civicrm')) {
       $data = $webform_submission->getWebform()->getHandler('webform_civicrm')->getConfiguration()['settings']['data'] ?? [];
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix add element error on webform

Before
----------------------------------------
Add element button sometimes fails with -

>|Drupal\Component\Plugin\Exception\PluginNotFoundException: Plugin ID 'webform_civicrm' was not found. in Drupal\Core\Plugin\DefaultLazyPluginCollection->initializePlugin() (line 79 of /var/www/drupal/web/core/lib/Drupal/Core/Plugin/DefaultLazyPluginCollection.php)

After
----------------------------------------
Fixed.

Comments
----------------------------------------
This isn't replicating on d9 so should be something wrong with how handlers were loaded in Drupal 8.x version. Confirming it before retrieving the handler must be able to fix the error.

@KarinG 