### PR TITLE
Fix fatal error on contact element removal

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1743,7 +1743,8 @@ class AdminForm implements AdminFormInterface {
         list(, $c, $ent, $n, $table, $name) = explode('_', $key, 6);
         $info = '';
         $element = $this->webform->getElement($id);
-        $info = '<em>' . $this->getSettings()["{$c}_webform_label"];
+        $label = $this->getSettings()["{$c}_webform_label"] ?? '';
+        $info = '<em>' . $label;
         if ($info && isset($this->sets[$table]['max_instances'])) {
           $info .= ' ' . $this->sets[$table]['label'] . ' ' . $n;
         }
@@ -1791,8 +1792,9 @@ class AdminForm implements AdminFormInterface {
           if (substr($key, -8) == 'fieldset') {
             list(, $c, $ent, $i) = explode('_', $key);
             if ($ent == 'contact' && $i == 1 && (!$this->settings['nid'] || $c > $this->settings['number_of_contacts'])) {
-              if (!_wf_crm_child_components($this->node->nid, $id)) {
-                webform_component_delete($this->node, $this->node->webform['components'][$id]);
+              $children = $this->webform->getElement($id)['#webform_children'] ?? [];
+              if (empty($children)) {
+                $this->webform->deleteElement($id);
               }
             }
           }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -147,14 +147,17 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   }
 
   /**
-   * Modify data in webform submission.
+   * Modify data in webform submission. civicrm_options element's key is submitted to the delta
+   * column of webform_submission_data. Make sure it is not set to a string value.
    *
    * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
    */
   protected function modifyWebformSubmissionData(WebformSubmissionInterface $webform_submission) {
     $data = $webform_submission->getData();
+    $webform = $webform_submission->getWebform();
     foreach ($data as $field_key => $val) {
-      if (substr($field_key, -20) === 'relationship_type_id' && is_array($val)) {
+      $element = $webform->getElement($field_key);
+      if ($element['#type'] == 'civicrm_options' && is_array($val) && count(array_filter(array_keys($val), 'is_string')) > 0) {
         $data[$field_key] = array_values($val);
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on contact element removal.

Before
----------------------------------------
1. Reaf life bug - lots of fields sets -> nested elements -> trying to remove contacts (with lots of nested elements/fields) from the webform by in CiviCRM Settings -> changing number of contacts from 5 -> 2 -> produces:

>Error: Call to undefined function Drupal\webform_civicrm\_wf_crm_child_components() in Drupal\webform_civicrm\AdminForm->postProcess() (line 1797 of /var/www/drupal/web/sites/default/modules/webform_civicrm/src/AdminForm.php)

2. Custom field with option value = string returns a fatal error on submission. To replicate 

Create custom field checkbox as follow

![image](https://user-images.githubusercontent.com/5929648/110120860-9b363000-7de3-11eb-9b44-1944937ba1f8.png)

Note the last option has a string value.

- Add this element to the webform and submit.

```
The website encountered an unexpected error. Please try again later.

Drupal\Core\Entity\EntityStorageException: SQLSTATE[HY000]: General error: 1366 Incorrect integer value: 'check5' for column 'delta' at row 18: INSERT INTO {webform_submission_data} ("webform_id", "sid", "name", "property", "delta", "value") VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5), (:db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8, :db_insert_placeholder_9, :db_insert_placeholder_10, :db_insert_placeholder_11), (:db_insert_placeholder_12, :db_insert_placeholder_13, :db_insert_placeholder_14, :db_insert_placeholder_15, :db_insert_place....

```

After
----------------------------------------
Fixed.

Comments
----------------------------------------
@KarinG 