### PR TITLE
Fix layout issues with claro theme

### DIFF
--- a/js/contact_component.js
+++ b/js/contact_component.js
@@ -36,7 +36,7 @@ var wfCiviContact = (function ($, D) {
     attach: function (context) {
       $('#edit-extra-default', context).once('wf-civi').change(function() {
         var val = $(this).val().replace(/_/g, '-');
-        $('#edit-defaults > div > .form-item', context).not('.form-item-extra-default, .form-item-extra-allow-url-autofill').each(function() {
+        $('#edit-contact-defaults > div > .form-item', context).not('.form-item-extra-default, .form-item-extra-allow-url-autofill').each(function() {
           if ($(this).hasClass('form-item-extra-default-'+val)) {
             $(this).removeAttr('style');
           }

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -316,16 +316,13 @@ var wfCiviAdmin = (function ($, D) {
         });
         return label.join('<br />') || Drupal.t('- None -');
       });
-      $('details#edit-options', context).once('wf-civi').drupalSetSummary(function (context) {
+      $('details#edit-additional-options', context).once('wf-civi').drupalSetSummary(function (context) {
         var label = '';
         $(':checked', context).each(function() {
           label = (label ? label + ', ' : '') + $.trim($(this).siblings('label').text());
         });
         return label || Drupal.t('- None -');
       });
-
-      // For some reason this tab doesn't jive.
-      document.getElementById('edit-membership').open = true;
 
       $('select[name=participant_reg_type]', context).once('wf-civi').change(function() {
         showHideParticipantOptions('fast');

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -38,7 +38,7 @@
       function changeDefault() {
         var val = $(this).val().replace(/_/g, '-');
 
-        $('[data-drupal-selector=edit-contact-defaults] > div > .form-item', context).not('.form-item-properties-default, .form-item-properties-allow-url-autofill').each(function() {
+        $('[data-drupal-selector=edit-contact-defaults] > div > .form-item', context).not('[class$=properties-default], [class$=properties-allow-url-autofill]').each(function() {
           if (val.length && $(this).is('[class*=form-item-properties-default-'+val+']')) {
             $(this).removeAttr('style');
           }

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1274,25 +1274,25 @@ class AdminForm implements AdminFormInterface {
    */
   private function buildOptionsTab() {
     $utils = \Drupal::service('webform_civicrm.utils');
-    $this->form['options'] = [
+    $this->form['additional_options'] = [
       '#type' => 'details',
       '#group' => 'webform_civicrm',
       '#title' => t('Additional Options'),
       '#attributes' => ['class' => ['civi-icon-prefs']],
     ];
-    $this->form['options']['checksum_text'] = [
+    $this->form['additional_options']['checksum_text'] = [
       '#type' => 'item',
       '#markup' => '<p>' .
         t('To have this form auto-filled for anonymous users, enable the "Existing Contact" field for :contact and send the following link from CiviMail:', [':contact' => $utils->wf_crm_contact_label(1, $this->data, 'escape')]) .
         '<br /><pre>' . Url::fromRoute('entity.webform.canonical', ['webform' => $this->webform->id()], ['query' => ['cid1' => ''], 'absolute' => TRUE])->toString() . '{contact.contact_id}&amp;{contact.checksum}</pre></p>',
     ];
-    $this->form['options']['create_fieldsets'] = [
+    $this->form['additional_options']['create_fieldsets'] = [
       '#type' => 'checkbox',
       '#title' => t('Create Fieldsets'),
       '#default_value' => (bool) $this->settings['create_fieldsets'],
       '#description' => t('Create a fieldset around each contact, activity, etc. Provides visual organization of your form.'),
     ];
-    $this->form['options']['confirm_subscription'] = [
+    $this->form['additional_options']['confirm_subscription'] = [
       '#type' => 'checkbox',
       '#title' => t('Confirm Subscriptions'),
       '#default_value' => (bool) $this->settings['confirm_subscription'],
@@ -1304,24 +1304,24 @@ class AdminForm implements AdminFormInterface {
         $ml = array_slice($ml, 0, 3);
         $ml[] = t('etc.');
       }
-      $this->form['options']['confirm_subscription']['#description'] .= implode(', ', $ml) . '</em>';
+      $this->form['additional_options']['confirm_subscription']['#description'] .= implode(', ', $ml) . '</em>';
     }
     else {
-      $this->form['options']['confirm_subscription']['#description'] .= t('none') . '</em>';
+      $this->form['additional_options']['confirm_subscription']['#description'] .= t('none') . '</em>';
     }
-    $this->form['options']['block_unknown_users'] = [
+    $this->form['additional_options']['block_unknown_users'] = [
       '#type' => 'checkbox',
       '#title' => t('Block Unknown Users'),
       '#default_value' => !empty($this->settings['block_unknown_users']),
       '#description' => t('Only allow users to see this form if they are logged in or following a personalized link from CiviMail.'),
     ];
-    $this->form['options']['create_new_relationship'] = [
+    $this->form['additional_options']['create_new_relationship'] = [
       '#type' => 'checkbox',
       '#title' => t('Create New Relationship'),
       '#default_value' => !empty($this->settings['create_new_relationship']),
       '#description' => t('If enabled, only Active relationships will load on the form, and will be updated on Submit. If there are no Active relationships then a new one will be created.'),
     ];
-    $this->form['options']['new_contact_source'] = [
+    $this->form['additional_options']['new_contact_source'] = [
       '#type' => 'textfield',
       '#title' => t('Source Label'),
       '#maxlength' => 255,

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -415,7 +415,7 @@ class CivicrmContact extends WebformElementBase {
     $form['filters']['check_permissions'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enforce Permissions'),
-      '#default_value' => $element_properties['filters']['check_permissions'],
+      '#default_value' => $element_properties['check_permissions'],
       '#description' => $this->t('Only show contacts the acting user has permission to see in CiviCRM.') . '<br />' . $this->t('WARNING: Keeping this option enabled is highly recommended unless you are effectively controlling access by another method.'),
     ];
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix layout issues with claro theme

Before
----------------------------------------
**Issue 1**: Default Section is not loaded on Contact Element - Previously fixed in https://github.com/colemanw/webform_civicrm/pull/435

![image](https://user-images.githubusercontent.com/5929648/110201177-c07c7a00-7e87-11eb-8560-d99941c047ea.png)

**Issue 2**: Membership section displayed on the Contact tab of civicrm settings page.

![image](https://user-images.githubusercontent.com/5929648/110201143-91660880-7e87-11eb-891f-1a08a4e5bf06.png)

**Issue 3**: E-Notice displayed when existing contact element is loaded in a new window -

>Notice: Undefined index: filters in Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact->form() (line 418 of modules/contrib/webform_civicrm/src/Plugin/WebformElement/CivicrmContact.php).
Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact->form(Array, Object) (Line: 3323)


After
----------------------------------------
Fixed.

1. 
![image](https://user-images.githubusercontent.com/5929648/110201119-78f5ee00-7e87-11eb-9763-9a3fbd5fca49.png)

2. 
![image](https://user-images.githubusercontent.com/5929648/110203101-3259c100-7e92-11eb-8f78-56caf26d7703.png)


Comments
----------------------------------------
@KarinG Can you pls have a quick test on your setup and see if this helps in fixing the problems we saw with the claro theme?

 