### PR TITLE
Display option labels on submission page

### DIFF
--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -94,6 +94,11 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     ])['values'][0]['tags']);
     $this->assertArrayHasKey('Major Donor', array_flip($contactTags));
     $this->assertArrayHasKey('Volunteer', array_flip($contactTags));
+    //Ensure option labels are present on result page.
+    $this->drupalGet($this->webform->toUrl('results-submissions'));
+    $this->htmlOutput();
+    $this->assertSession()->pageTextContains('Major Donor');
+    $this->assertSession()->pageTextContains('Volunteer');
   }
 
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -10,7 +10,6 @@ use Drupal\webform\Entity\Webform;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Entity\WebformSubmission;
-use Drupal\webform_civicrm\Utils;
 use Drupal\node\Entity\Node;
 
 /**
@@ -117,6 +116,34 @@ function webform_civicrm_theme() {
       'base hook' => 'input',
     ],
   ];
+}
+
+/**
+ * Implements hook_entity_load()
+ * Display labels for civicrm option element.
+ */
+function webform_civicrm_webform_submission_load($entities) {
+  $utils = \Drupal::service('webform_civicrm.utils');
+  foreach ($entities as $entity) {
+    $data = $entity->getData();
+    $webform = $entity->getWebform();
+    foreach ($data as $key => $val) {
+      $element = $webform->getElement($key);
+      if ($element['#type'] == 'civicrm_options' && !empty($val)) {
+        if (!empty($element['#webform_multiple'])) {
+          foreach ($val as $k => $v) {
+            if (isset($element['#options'][$v])) {
+              $data[$key][$k] = $element['#options'][$v];
+            }
+          }
+        }
+        elseif (isset($element['#options'][$val])) {
+          $data[$key] = $element['#options'][$val];
+        }
+      }
+    }
+    $entity->setData($data);
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://www.drupal.org/project/webform_civicrm/issues/3150171 - Display option labels on submission page

Before
----------------------------------------
Key values are displayed on result page for civicrm options element. Eg Groups, Tags, Gender, etc.

![image](https://user-images.githubusercontent.com/5929648/110206687-39d69580-7ea5-11eb-862f-917a5590319d.png)

After
----------------------------------------
Labels are displayed.

![image](https://user-images.githubusercontent.com/5929648/110206706-5b378180-7ea5-11eb-818e-e2d167485abb.png)


Comments
----------------------------------------
@KarinG :)