### PR TITLE
Up CiviCRM versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         include:
           - drupal: '^8.9'
-            civicrm: '~5.34'
+            civicrm: '~5.35'
           - drupal: '^8.9'
-            civicrm: '5.35.x-dev'
+            civicrm: '5.36.x-dev'
           - drupal: '^9.0'
-            civicrm: '5.35.x-dev'
+            civicrm: '5.36.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM 5.35.0 was released this week!

After
----------------------------------------
We're now testing 5.35.x and 5.36rc
