### PR TITLE
Do not load civicrm elements on the Add element form

### DIFF
--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -159,6 +159,15 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
 
     //Enable Autocomplete on the contact Element.
     $this->drupalGet($this->webform->toUrl('edit-form'));
+    //Assert civicrm elements are not loaded on Add Element form.
+    $this->assertSession()->elementExists('css', '#webform-ui-add-element')->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->assertSession()->elementNotExists('css', '[data-drupal-selector="edit-elements-civicrm-contact"]');
+    $this->assertSession()->elementNotExists('css', '[data-drupal-selector="edit-elements-civicrm-options"]');
+    $this->assertSession()->elementNotExists('css', '[data-drupal-selector="edit-elements-civicrm-select"]');
+    $this->getSession()->getPage()->pressButton('Close');
+
     $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
     $contactElementEdit->click();
     $this->assertSession()->assertWaitOnAjaxRequest();

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -49,6 +49,15 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
     \Drupal::service('civicrm')->initialize();
     \CRM_Core_Resources::singleton()->addCoreResources();
   }
+  //Do not load civicrm elements on the "Add element" form.
+  if ($form_id == 'webform_ui_element_type_select_form') {
+    foreach ($form as $k => $fieldset) {
+      if (!empty($fieldset['#title']) && strtolower($fieldset['#title']) == 'civicrm') {
+        unset($form[$k]);
+        return;
+      }
+    }
+  }
 
   /*
   // Alter back-end webform component edit forms


### PR DESCRIPTION
Overview
----------------------------------------
Do not load civicrm elements on the Add element form

Before
----------------------------------------
CiviCRM Elements are loaded on Add Element form.

![image](https://user-images.githubusercontent.com/5929648/110234581-3d275b00-7f51-11eb-9e8f-09a6841b9486.png)


After
----------------------------------------
Not loaded.


Comments
----------------------------------------
@KarinG 