### PR TITLE
[Test + Help text only] - Minor Edits

### DIFF
--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -308,8 +308,6 @@ class AdminHelp implements AdminHelpInterface {
   protected function membership_fee_amount() {
     return '<p>' .
       t('Price for this membership per term. If this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .
-      '</p><p>' .
-      t('Note that if this field is enabled, the default minimum membership fee from CiviCRM membership type settings will not be loaded.') .
       '</p>';
     $this->fee();
   }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1674,8 +1674,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             $type = $membership_item['membership_type_id'];
             $price = $this->getMembershipTypeField($type, 'minimum_fee');
 
-            //if number of terms is set, regard membership fee field as price per term
-            //if you choose to set dates manually while membership fee field is enabled, take the membership fee as total cost of this membership
+            // if number of terms is set, regard membership fee field as price per term
+            // if you choose to set dates manually while membership fee field is enabled, take the membership fee as total cost of this membership
             if (isset($membership_item['fee_amount'])) {
               $price = $membership_item['fee_amount'];
               if (empty($membership_item['num_terms'])) {

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -41,12 +41,12 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField('nid');
     $this->getSession()->getPage()->clickLink('Memberships');
 
-    //Configure Membership tab.
+    // Configure Membership tab.
     $this->getSession()->getPage()->selectFieldOption('membership_1_number_of_membership', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    //Configure Contribution tab and enable recurring.
+    // Configure Contribution tab and enable recurring.
     $this->getSession()->getPage()->clickLink('Contribution');
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -105,7 +105,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
-    //Assert if recur is attached to the created membership.
+    // Assert if recur is attached to the created membership.
     $utils = \Drupal::service('webform_civicrm.utils');
     $api_result = $utils->wf_civicrm_api('membership', 'get', [
       'sequential' => 1,
@@ -149,8 +149,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->pressButton('Submit');
 
-    // ToDo -> figure out what Error message it is! The submission itself works well.
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'get', [


### PR DESCRIPTION
Remove duplicate statement in help text and managed to remove one `ToDo` from the `MembershipSubmission Test`

Also: I added a style formatting for Comments rule in Phpstorm - so there are some edits related to that. 

Before
`//comment`

After
`// Comment`