### PR TITLE
Membership select fixes

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -731,7 +731,7 @@ class Fields implements FieldsInterface {
       if (isset($sets['membership'])) {
         $fields['membership_membership_type_id'] = [
           'name' => t('Membership Type'),
-          'type' => 'civicrm_select',
+          'type' => 'select',
           'expose_list' => TRUE,
           'civicrm_live_options' => 1,
         ];

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -579,7 +579,7 @@ class Utils implements UtilsInterface {
       $label = Html::escape($label);
     }
     if ($html == 'wrap') {
-      $label = Markup::create('<span class="contact-label number-' . $n . '">' . $label . '</span>');
+      $label = Markup::create($label);
     }
     return $label;
   }

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -60,6 +60,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Frequency of Installments', 'year');
 
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
+    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings_before_save.png');
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -69,11 +70,12 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
+    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');
+
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
     $this->getSession()->getPage()->selectFieldOption('Membership Type', 'Basic');
-    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');
 
     $this->getSession()->getPage()->pressButton('Next >');
 

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -46,7 +46,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_membership_type_id', '- User Select -');
     $this->htmlOutput();
-    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings.png');
 
     // Configure Contribution tab and enable recurring.
     $this->getSession()->getPage()->clickLink('Contribution');
@@ -60,7 +60,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Frequency of Installments', 'year');
 
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
-    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings_before_save.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings_before_save.png');
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -70,12 +70,12 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');
 
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-    $this->getSession()->getPage()->selectFieldOption('Membership Type', 'Basic');
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_membership_type_id', '1');
 
     $this->getSession()->getPage()->pressButton('Next >');
 
@@ -94,7 +94,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
     $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page2.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page2.png');
 
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
@@ -121,6 +121,14 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     ]);
     $membership = reset($api_result['values']);
     $this->assertNotEmpty($membership['contribution_recur_id']);
+
+    // Let's make sure we have a Contribution by ensuring we have a Transaction ID
+    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+      'sequential' => 1,
+    ]);
+    $contribution = reset($api_result['values']);
+    $this->assertNotEmpty($contribution['trxn_id']);
+    $this->assertEquals('1.00', $contribution['total_amount']);
   }
 
   /**

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -44,6 +44,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     // Configure Membership tab.
     $this->getSession()->getPage()->selectFieldOption('membership_1_number_of_membership', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('Membership Type', '- User Select -');
     $this->htmlOutput();
 
     // Configure Contribution tab and enable recurring.
@@ -70,6 +71,9 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+    $this->getSession()->getPage()->selectFieldOption('Membership Type', 'Basic');
+    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');
+
     $this->getSession()->getPage()->pressButton('Next >');
 
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
@@ -87,6 +91,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
     $this->getSession()->getPage()->fillField('City', 'Milwaukee');
+    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page2.png');
 
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -44,7 +44,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     // Configure Membership tab.
     $this->getSession()->getPage()->selectFieldOption('membership_1_number_of_membership', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption('Membership Type', '- User Select -');
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_membership_type_id', '- User Select -');
     $this->htmlOutput();
 
     // Configure Contribution tab and enable recurring.
@@ -121,7 +121,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
   }
 
   /**
-   * Test submitting a Membership
+   * Test submitting a Free Membership
    */
   public function testSubmitWebform() {
     $this->createMembershipType();

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -46,6 +46,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_membership_type_id', '- User Select -');
     $this->htmlOutput();
+    $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings.png');
 
     // Configure Contribution tab and enable recurring.
     $this->getSession()->getPage()->clickLink('Contribution');


### PR DESCRIPTION
Before
----------------------------------------
If Membership is configured as - User Select - -> Membership is not saved (neither in Webform Results nor in CiviCRM).

After
----------------------------------------
Saved 🎉 

I did a quick check in `Fields.php` to see if there are any other Fields that have an incorrect select type - but nope - it was just this one. 
