### PR TITLE
Existing case not updated when contact is filled via autocomplete widget

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1241,6 +1241,16 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     foreach (wf_crm_aval($this->data, 'case', []) as $n => $data) {
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
+        //Check if webform is set to update the existing case on contact.
+        if (!empty($this->data['case'][$n]['existing_case_status']) && empty($this->ent['case'][$n]['id']) && !empty($this->ent['contact'][$n]['id'])) {
+          $existingCase = $this->findCaseForContact($this->ent['contact'][$n]['id'], [
+            'case_type_id' => wf_crm_aval($this->data['case'][$n], 'case:1:case_type_id'),
+            'status_id' => $this->data['case'][$n]['existing_case_status']
+          ]);
+          if (!empty($existingCase['id'])) {
+            $this->ent['case'][$n]['id'] = $existingCase['id'];
+          }
+        }
         // Set some defaults in create mode
         // Create duplicate case based on existing case if 'duplicate_case' checkbox is checked
         if (empty($this->ent['case'][$n]['id']) || !empty($this->data['case'][$n]['duplicate_case'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Existing case not updated when contact is filled via autocomplete

Before
----------------------------------------
Existing case not updated when contact is filled via autocomplete. To replicate -

- Create a case on contact A.
- Create a webform with Existing Contact Field, First name and last name.
- Enable Case section and set "Update Existing Case" field.
- Remove the default value in the existing contact field element to let the user fill it while submitting the form.
- Submit the webform with Existing contact = Contact A.
- Notice that a NEW case is created on the contact instead of updating the existing case.

After
----------------------------------------
Fixed. The existing case on the contact is updated.

Technical Details
----------------------------------------
$this->ent['contact'] is calculated much before in [preprocess](https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/includes/wf_crm_webform_preprocess.inc#L50) file. This process is also used to find an existing case on the contact https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/includes/wf_crm_webform_preprocess.inc#L654. And it remains empty if it is not set after the initial webform page is loaded.

This PR only fetches the existing case if the contact is loaded but case is not. Ideally we could use something like below to set the contact in the preprocess itself.
```diff
diff --git a/sites/all/modules/webform_civicrm/includes/wf_crm_webform_preprocess.inc b/sites/all/modules/webform_civicrm/includes/wf_crm_webform_preprocess.inc
index b2b20cfe..53240dd1 100644
--- a/sites/all/modules/webform_civicrm/includes/wf_crm_webform_preprocess.inc
+++ b/sites/all/modules/webform_civicrm/includes/wf_crm_webform_preprocess.inc
@@ -47,11 +47,17 @@ class wf_crm_webform_preprocess extends wf_crm_webform_base {
     }
     $submitted_contacts = [];
     // Keep track of cids across multipage forms
-    if (!empty($this->form_state['values']['submitted']) && wf_crm_aval($this->form_state, 'webform:page_count') > 1) {
+    if (!empty($this->form_state['input']['submitted'])
+      || (!empty($this->form_state['values']['submitted']) && wf_crm_aval($this->form_state, 'webform:page_count') > 1)) {
       foreach ($this->enabled as $k => $v) {
-        if (substr($k, -8) == 'existing' && isset($this->form_state['values']['submitted'][$v])) {
+        if (substr($k, -8) == 'existing') {
           list(, $c) = explode('_', $k);
-          $val = $this->form_state['values']['submitted'][$v];
+          if (isset($this->form_state['values']['submitted'][$v])) {
+            $val = $this->form_state['values']['submitted'][$v];
+          }
+          elseif (!empty($this->form_state['input']['submitted'])) {
+            $val = CRM_Utils_Array::retrieveValueRecursive($this->form_state['input']['submitted'], $k);
+          }
           $cid_data["cid$c"] = $this->ent['contact'][$c]['id'] = (int) (is_array($val) ? $val[0] : $val);
           $submitted_contacts[$c] = TRUE;
         }

```

But i think the existing change in the PR is more safe?
