### PR TITLE
D8/9 Existing case not updated when contact is filled via autocomplete widget

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1332,6 +1332,16 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     foreach (wf_crm_aval($this->data, 'case', []) as $n => $data) {
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
+        //Check if webform is set to update the existing case on contact.
+        if (!empty($this->data['case'][$n]['existing_case_status']) && empty($this->ent['case'][$n]['id']) && !empty($this->ent['contact'][$n]['id'])) {
+          $existingCase = $this->findCaseForContact($this->ent['contact'][$n]['id'], [
+            'case_type_id' => wf_crm_aval($this->data['case'][$n], 'case:1:case_type_id'),
+            'status_id' => $this->data['case'][$n]['existing_case_status']
+          ]);
+          if (!empty($existingCase['id'])) {
+            $this->ent['case'][$n]['id'] = $existingCase['id'];
+          }
+        }
         // Set some defaults in create mode
         // Create duplicate case based on existing case if 'duplicate_case' checkbox is checked
         if (empty($this->ent['case'][$n]['id']) || !empty($this->data['case'][$n]['duplicate_case'])) {

--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
+
+use Drupal\Core\Url;
+
+/**
+ * Tests submitting a Webform with CiviCRM: Case
+ *
+ * @group webform_civicrm
+ */
+final class CaseSubmissionTest extends WebformCivicrmTestBase {
+
+  /**
+   * Test Case Submission.
+   */
+  public function testCaseSubmission() {
+    $this->drupalLogin($this->rootUser);
+    $this->enableComponent('CiviCase');
+    $this->_caseContact = $this->createIndividual();
+
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    // Configure Case tab.
+    $this->getSession()->getPage()->clickLink('Cases');
+    $this->getSession()->getPage()->selectFieldOption('case_number_of_case', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('Update Existing Case', 'Ongoing');
+    $this->getSession()->getPage()->selectFieldOption('Case Type', 'Housing Support');
+    $this->getSession()->getPage()->checkField('Case Subject');
+
+    $this->saveCiviCRMSettings();
+
+    //Edit contact element and remove default section.
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
+    $contactElementEdit->click();
+    $this->htmlOutput();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
+
+    $this->assertSession()->waitForField('properties[widget]');
+    $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Autocomplete');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
+    $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
+
+    $this->htmlOutput();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('Set default contact from', '- None -');
+    $this->getSession()->getPage()->uncheckField('properties[allow_url_autofill]');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $caseSubject = "Test Case" . substr(sha1(rand()), 0, 7);
+    $this->submitCaseAndVerifyResult($caseSubject);
+    $caseSubject = "Update Test Case" . substr(sha1(rand()), 0, 7);
+    $this->submitCaseAndVerifyResult($caseSubject);
+
+  }
+
+  /**
+   * Submit Case and verify the result.
+   *
+   * @param string $caseSubject
+   */
+  protected function submitCaseAndVerifyResult($caseSubject) {
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', $this->_caseContact['first_name']);
+
+    $this->assertSession()->fieldValueEquals('First Name', $this->_caseContact['first_name']);
+    $this->assertSession()->fieldValueEquals('Last Name', $this->_caseContact['last_name']);
+
+    $this->getSession()->getPage()->fillField('Case Subject', $caseSubject);
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    $case_result = $this->utils->wf_civicrm_api('Case', 'get', [
+      'sequential' => 1,
+      'contact_id' => $this->_caseContact['id'],
+    ]);
+    $this->assertEquals(1, $case_result['count']);
+    $this->assertEquals($caseSubject, $case_result['values'][0]['subject']);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -45,6 +45,12 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
         unset($tables[$table]);
       }
     }
+
+    // Drop case views if present. These are removed in the civi version 5.37.alpha1 https://github.com/civicrm/civicrm-core/pull/19642
+    // so these stmts wont be needed after few days when our test setup is configured to run on civi > 5.37.alpha1.
+    $civicrm_test_conn->query('DROP VIEW IF EXISTS civicrm_view_case_activity_recent;')->execute();
+    $civicrm_test_conn->query('DROP VIEW IF EXISTS civicrm_view_case_activity_upcoming;')->execute();
+
     $civicrm_test_conn->query('SET FOREIGN_KEY_CHECKS = 1;')->execute();
   }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -257,6 +257,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->createScreenshot($this->htmlOutputDirectory . '/autocomplete.png');
 
     $page->find('xpath', '//li[contains(@class, "token-input-dropdown")][1]')->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
   }
 
   /**
@@ -269,6 +270,23 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       'last_name' => substr(sha1(rand()), 0, 7),
     ];
     return current($this->utils->wf_civicrm_api('contact', 'create', $params)['values']);
+  }
+
+  /**
+   * Enable Component in CiviCRM.
+   *
+   * @param string $componentName
+   */
+  protected function enableComponent($componentName) {
+    $enabledComponents = $this->utils->wf_crm_get_civi_setting('enable_components');
+    if (in_array($componentName, $enabledComponents)) {
+      // component is already enabled
+      return;
+    }
+    $enabledComponents[] = $componentName;
+    $this->utils->wf_civicrm_api('Setting', 'create', [
+      'enable_components' => $enabledComponents,
+    ]);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Existing case not updated when contact is filled via autocomplete widget

Before
----------------------------------------
Existing case not updated when contact is filled via autocomplete. To replicate -

- Create a case on contact A.
- Create a webform with Existing Contact Field, First name and last name.
- Enable Case section and set "Update Existing Case" field.
- Remove the default value in the existing contact field element to let the user fill it while submitting the form.
- Submit the webform with Existing contact = Contact A.
- Notice that a NEW case is created on the contact instead of updating the existing case.

After
----------------------------------------
Fixed. The existing case on the contact is updated.

Comments
----------------------------------------
D7 PR - https://github.com/colemanw/webform_civicrm/pull/509