### PR TITLE
Do not override already existing default_value with default_option.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,9 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/webform_civicrm *@dev
+      - name: Install token
+        run: |
+          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/token:^1.9'
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,7 @@ jobs:
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/webform_civicrm *@dev
       - name: Install token
         run: |
+          cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token:^1.9
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/webform_civicrm *@dev
       - name: Install token
         run: |
-          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/token:^1.9'
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token:^1.9
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -139,7 +139,9 @@ class CivicrmOptions extends WebformElementBase {
       // Get additional properties off of the options element.
       $select_options = $form['properties']['options']['options'];
       $properties['#default_option'] = $select_options['#default_option'];
-      $properties['#default_value'] = $select_options['#default_option'];
+      if (empty($properties['#default_value'])) {
+        $properties['#default_value'] = $select_options['#default_option'];
+      }
     }
     if (!isset($properties['#civicrm_live_options'])) {
       $properties['#civicrm_live_options'] = $form_state->getValues()['civicrm_live_options'] ?? 0;

--- a/src/Plugin/WebformElement/CivicrmSelect.php
+++ b/src/Plugin/WebformElement/CivicrmSelect.php
@@ -77,7 +77,9 @@ class CivicrmSelect extends WebformElementBase {
       }
       $element['#options'] = $new;
     }
-    $element['#default_value'] = $element['#default_option'];
+    if (isset($element['#default_option'])) {
+      $element['#default_value'] = $element['#default_option'];
+    }
   }
 
   protected function getFieldOptions($element) {

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -218,7 +218,6 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField('properties[extra][aslist]');
     $this->assertSession()->checkboxChecked('properties[extra][aslist]');
 
-    // $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
     $this->htmlOutput();
 
     $this->getSession()->getPage()->clickLink('Advanced');
@@ -227,11 +226,14 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $fieldset = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]');
     $fieldset->click();
     $this->getSession()->getPage()->fillField('Default value', '[current-page:query:membership]');
+    $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
     $this->getSession()->getPage()->pressButton('Save');
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['membership' => 2]]));
     $this->assertPageNoErrorMessages();
+
+    $this->createScreenshot($this->htmlOutputDirectory . '/a_viewform_screenshot.png');
 
     $this->assertSession()->waitForField('First Name');
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -226,14 +226,13 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $fieldset = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]');
     $fieldset->click();
     $this->getSession()->getPage()->fillField('Default value', '[current-page:query:membership]');
-    $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
     $this->getSession()->getPage()->pressButton('Save');
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['membership' => 2]]));
+    $this->createScreenshot($this->htmlOutputDirectory . '/aviewformscreenshot.png');
     $this->assertPageNoErrorMessages();
-
-    $this->createScreenshot($this->htmlOutputDirectory . '/a_viewform_screenshot.png');
 
     $this->assertSession()->waitForField('First Name');
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
@@ -242,7 +241,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
 
     $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . '/a_post_submission_screenshot.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/apostsubmissionscreenshot.png');
 
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -148,11 +148,50 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->clickLink('Memberships');
 
     $this->getSession()->getPage()->selectFieldOption('membership_1_number_of_membership', 1);
+    // Make it a - User Select -
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
+    $this->getSession()->getPage()->selectFieldOption("edit-civicrm-1-membership-1-membership-membership-type-id", 'create_civicrm_webform_element');
+    $this->htmlOutput();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $membershipElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-membership-1-membership-membership-type-id-operations"] a.webform-ajax-link');
+    $membershipElementEdit->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $advanced_tab = 'tabby-toggle_webform-tab--advanced';
+    $advanced_tab = $this->assertSession()->elementExists('css', $advanced_tab . 'a.link');
+    $advanced_tab->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->fillField('Value', '[current-page:query:membership]');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $membershipElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-membership-1-membership-membership-type-id-operations"] a.webform-ajax-link');
+    $membershipElementEdit->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $advanced_tab = 'tabby-toggle_webform-tab--advanced';
+    $advanced_tab = $this->assertSession()->elementExists('css', $advanced_tab . 'a.link');
+    $advanced_tab->click();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('Value');
+    $this->assertSession()->fieldValueEquals('Value','[current-page:query:membership]');
+    $this->htmlOutput();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -218,13 +218,13 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField('properties[extra][aslist]');
     $this->assertSession()->checkboxChecked('properties[extra][aslist]');
 
-    $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
     $this->htmlOutput();
 
-    $advanced_tab = 'tabby-toggle_webform-tab--advanced';
-    $advanced_tab = $this->assertSession()->elementExists('css', $advanced_tab . ' a.link');
-    $advanced_tab->click();
+    $this->getSession()->getPage()->clickLink('Advanced');
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('Default value');
+    $this->createScreenshot($this->htmlOutputDirectory . '/in_advanced_tab.png');
     $this->getSession()->getPage()->fillField('Default value', '[current-page:query:membership]');
     $this->getSession()->getPage()->pressButton('Save');
 

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -148,11 +148,10 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->clickLink('Memberships');
 
     $this->getSession()->getPage()->selectFieldOption('membership_1_number_of_membership', 1);
-    // Make it a - User Select -
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    $this->getSession()->getPage()->selectFieldOption("edit-civicrm-1-membership-1-membership-membership-type-id", 'create_civicrm_webform_element');
+    $this->getSession()->getPage()->selectFieldOption("civicrm_1_membership_1_membership_membership_type_id", 'create_civicrm_webform_element');
     $this->htmlOutput();
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -226,22 +226,22 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $fieldset = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]');
     $fieldset->click();
     $this->getSession()->getPage()->fillField('Default value', '[current-page:query:membership]');
-    // $this->createScreenshot($this->htmlOutputDirectory . '/advanced_tab.png');
     $this->getSession()->getPage()->pressButton('Save');
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['membership' => 2]]));
-    $this->createScreenshot($this->htmlOutputDirectory . '/aviewformscreenshot.png');
-    $this->assertPageNoErrorMessages();
+    $this->htmlOutput();
+    // ToDo ->
+    // $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->assertSession()->pageTextContains('Basic Plus');
     $this->getSession()->getPage()->pressButton('Submit');
-
-    $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . '/apostsubmissionscreenshot.png');
+    $this->htmlOutput();
+    // ToDo ->
+    // $this->assertPageNoErrorMessages();
 
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -253,8 +253,6 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->assertEquals('Basic Plus', $membership['membership_name']);
     $this->assertEquals('1', $membership['status_id']);
-
-    // throw new \Exception(var_export($today, TRUE));
   }
 
 }

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -223,8 +223,9 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->clickLink('Advanced');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->waitForField('Default value');
-    $this->createScreenshot($this->htmlOutputDirectory . '/in_advanced_tab.png');
+    $this->htmlOutput();
+    $fieldset = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]');
+    $fieldset->click();
     $this->getSession()->getPage()->fillField('Default value', '[current-page:query:membership]');
     $this->getSession()->getPage()->pressButton('Save');
 
@@ -239,6 +240,8 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
 
     $this->assertPageNoErrorMessages();
+    $this->createScreenshot($this->htmlOutputDirectory . '/a_post_submission_screenshot.png');
+
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
     $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'get', [

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -193,7 +193,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->createMembershipType(1, TRUE, 'Basic');
     $this->createMembershipType(1, TRUE, 'Basic Plus');
 
-    $this->drupalLogin($this->adminUser);
+    $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
     ]));
@@ -232,7 +232,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['membership' => 2]]));
     $this->htmlOutput();
     // ToDo ->
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
 
     $this->assertSession()->waitForField('First Name');
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
@@ -241,7 +241,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     // ToDo ->
-    // $this->assertPageNoErrorMessages();
+    $this->assertPageNoErrorMessages();
 
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -16,6 +16,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     'webform',
     'webform_ui',
     'webform_civicrm',
+    'token',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Using token module we can set defaults like this:

http://d8civicrm.local/form/paid-membership?membership=3

![image](https://user-images.githubusercontent.com/5340555/111718076-eeb27000-881e-11eb-831e-86a4c3c73944.png)

Before
----------------------------------------
`#default_value': '[current-page:query:membership]'`
had to be added in Source as the value would not save when Editing the Membership - User Select - Element

After
----------------------------------------
Saving it!

The first commit contains the fix and is composer requiring Token module. I'll be adding a Test.
