### PR TITLE
D8/9 - Fix the submission of multiple contact reference custom fields

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2338,16 +2338,16 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $this->data[$ent][$c][$table][$n][$name] = [];
           foreach ($val as $v) {
             if (is_numeric($v) && !empty($this->ent['contact'][$v]['id'])) {
-              $table = $customOnly ? $ent : $table;
-              $this->data[$ent][$c][$table][$n][$name][] = $this->ent['contact'][$v]['id'];
+              $tableName = $customOnly ? $ent : $table;
+              $this->data[$ent][$c][$tableName][$n][$name][] = $this->ent['contact'][$v]['id'];
             }
           }
         }
         else {
           unset($this->data[$ent][$c][$table][$n][$name]);
           if (!empty($this->ent['contact'][$val]['id'])) {
-            $table = $customOnly ? $ent : $table;
-            $this->data[$ent][$c][$table][$n][$name] = $this->ent['contact'][$val]['id'];
+            $tableName = $customOnly ? $ent : $table;
+            $this->data[$ent][$c][$tableName][$n][$name] = $this->ent['contact'][$val]['id'];
           }
         }
       }

--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -37,25 +37,7 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
     //Edit contact element and remove default section.
     $this->drupalGet($this->webform->toUrl('edit-form'));
 
-    $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
-    $contactElementEdit->click();
-    $this->htmlOutput();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
-
-    $this->assertSession()->waitForField('properties[widget]');
-    $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Autocomplete');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
-    $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
-
-    $this->htmlOutput();
-    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption('Set default contact from', '- None -');
-    $this->getSession()->getPage()->uncheckField('properties[allow_url_autofill]');
-    $this->getSession()->getPage()->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->editContactElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
 
     $caseSubject = "Test Case" . substr(sha1(rand()), 0, 7);
     $this->submitCaseAndVerifyResult($caseSubject);

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -241,6 +241,44 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
+   * Edit contact element on the build form.
+   *
+   * @param string $selector
+   * @param string $widget
+   * @param string $default
+   * @param bool $removeDefaultURL
+   */
+  protected function editContactElement($selector, $widget, $default = NULL, $removeDefaultURL = FALSE) {
+    $contactElementEdit = $this->assertSession()->elementExists('css', "[data-drupal-selector='{$selector}'] a.webform-ajax-link");
+    $contactElementEdit->click();
+    $this->htmlOutput();
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
+
+    $this->assertSession()->waitForField('properties[widget]');
+    $this->getSession()->getPage()->selectFieldOption('Form Widget', $widget);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    if ($widget == 'Autocomplete') {
+      $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
+      $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
+    }
+    $this->htmlOutput();
+
+    if ($default) {
+      $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      $this->getSession()->getPage()->selectFieldOption('Set default contact from', $default);
+    }
+
+    if ($removeDefaultURL) {
+      $this->getSession()->getPage()->uncheckField('properties[allow_url_autofill]');
+    }
+
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
    * Fill Contact Autocomplete widget.
    *
    * @param string $id


### PR DESCRIPTION
Overview
----------------------------------------
Fix the submission of activity custom field with type = contact reference

Before
----------------------------------------
Contact reference custom fields on activity is not saved if no of fields added to the webform > 1.

To replicate -

- Add 2 contact ref custom fields on acivity.
- Create a webform with 3 contacts.
- Enable them on the webform with custom field 1 = Contact 2 and custom field 2 = Contact 3.
- Submit the webform.
- Only value for custom field 1 is saved. 

After
----------------------------------------
All contact ref custom fields are saved.

Technical Details
----------------------------------------
This was a problem with the variable usage in the foreach loop. On the first iteration, the tableName is changed leading to a key miss from the second loop execution.

Comments
----------------------------------------
@KarinG I recall you mentioned having the same problem few days ago? This is also a problem in d7 so would raise a d7 PR too. I'll be adding a test soon.