### PR TITLE
D7 - Fix the submission of multiple contact reference custom fields

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -172,6 +172,9 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if (!$cid) {
         continue;
       }
+      if (!empty($contact['update_contact_ref'])) {
+        $this->saveContactRefs($contact, $cid);
+      }
       $this->saveCurrentEmployer($contact, $cid);
 
       $this->fillHiddenContactFields($cid, $c);
@@ -2252,6 +2255,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     static $c = '';
     static $table = '';
     static $n = '';
+    $customName = NULL;
     if ($values === NULL) {
       $values = $this->data;
     }
@@ -2260,7 +2264,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       if ($depth < 4 && is_array($val)) {
         $this->fillContactRefs($customOnly, $val, $depth + 1);
       }
-      elseif ($depth == 4 && $val && wf_crm_aval($this->all_fields, "{$table}_$name:data_type") == 'ContactReference') {
+      elseif ($depth == 4 && $val && wf_crm_aval($this->all_fields, "{$table}_{$name}:data_type") == 'ContactReference') {
         if ($customOnly && substr($name, 0, 6) != 'custom') {
           return;
         }
@@ -2268,16 +2272,28 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           $this->data[$ent][$c][$table][$n][$name] = [];
           foreach ($val as $v) {
             if (is_numeric($v) && !empty($this->ent['contact'][$v]['id'])) {
-              $table = $customOnly ? $ent : $table;
-              $this->data[$ent][$c][$table][$n][$name][] = $this->ent['contact'][$v]['id'];
+              $tableName = $customOnly ? $ent : $table;
+              $this->data[$ent][$c][$tableName][$n][$name][] = $this->ent['contact'][$v]['id'];
             }
           }
         }
         else {
-          unset($this->data[$ent][$c][$table][$n][$name]);
+          $createModeKey = 'civicrm_' . $c . '_contact_' . $n . '_' . $table . '_createmode';
+          $multivaluesCreateMode = $this->data['config']['create_mode'][$createModeKey] ?? NULL;
+          $cgMaxInstance = $this->all_sets[$table]['max_instances'] ?? 1;
+          if (substr($name, 0, 6) == 'custom' && $cgMaxInstance > 1) {
+            // Retrieve name for multi value custom fields.
+            $customName = $this->getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n);
+            $n = $c;
+          }
           if (!empty($this->ent['contact'][$val]['id'])) {
-            $table = $customOnly ? $ent : $table;
-            $this->data[$ent][$c][$table][$n][$name] = $this->ent['contact'][$val]['id'];
+            unset($this->data[$ent][$c][$table][$n][$name]);
+            $tableName = substr($name, 0, 6) == 'custom' ? $ent : $table;
+            $fld = $customName ?? $name;
+            $this->data[$ent][$c][$tableName][$n][$fld] = $this->ent['contact'][$val]['id'];
+          }
+          elseif (substr($name, 0, 6) == 'custom') {
+            $this->data[$ent][$c]['update_contact_ref'][] = $name;
           }
         }
       }
@@ -2408,22 +2424,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
               $cgMaxInstance = $this->all_sets[$table]['max_instances'] ?? 1;
               // Is this a multi-value custom field?
               if ($cgMaxInstance > 1) {
-                $existingValue = NULL;
-                //For edit mode, update the keys to 'custom_<fieldID>_<existing_value_id>.
-                if (empty($multivaluesCreateMode) && !empty($this->existing_contacts[$c])) {
-                  $existingValue = $this->getCustomData($this->existing_contacts[$c], NULL, FALSE)[$table] ?? NULL;
-                  if (!empty($existingValue) && is_array($existingValue)) {
-                    $existingValue = key(array_slice($existingValue, $n - 1, 1, TRUE));
-                    if (!empty($existingValue)) {
-                      $name = "{$name}_{$existingValue}";
-                    }
-                  }
-                }
-                // If webform is configured to only "insert" new values,
-                // modify the params in the format of custom_<fieldID>_-1, custom_<fieldID>_-2, etc.
-                if (empty($existingValue)) {
-                  $name = "{$name}_-{$n}";
-                }
+                $name = $this->getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n);
                 $n = $c;
               }
             }
@@ -2646,6 +2647,66 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     }
 
     return $reorderedArray;
+  }
+
+  /**
+   * Retrieve name for multi-value custom fields.
+   *
+   * For edit mode, update the $name key to 'custom_<fieldID>_<existing_value_id>.
+   *
+   * If webform is configured to only "insert" new values,
+   * modify the params in the format of custom_<fieldID>_-1, custom_<fieldID>_-2, etc.
+   *
+   * @param bool $multivaluesCreateMode
+   * @param string $name
+   * @param string $table
+   * @param int $c
+   * @param int $n
+   *
+   * @return string $name
+   */
+  private function getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n): string {
+    $existingValue = NULL;
+    if (empty($multivaluesCreateMode) && !empty($this->existing_contacts[$c])) {
+      $existingValue = $this->getCustomData($this->existing_contacts[$c], NULL, FALSE)[$table] ?? NULL;
+      if (!empty($existingValue) && is_array($existingValue)) {
+        $existingValue = key(array_slice($existingValue, $n - 1, 1, TRUE));
+        if (!empty($existingValue)) {
+          return "{$name}_{$existingValue}";
+        }
+      }
+    }
+
+    // No existing value found, insert a new value.
+    if (empty($existingValue)) {
+      return "{$name}_-{$n}";
+    }
+    return $name;
+  }
+
+  /**
+   * Save custom contact reference created
+   * during the current submission of the webform.
+   *
+   * @param array $params
+   * @param int $cid
+   */
+  private function saveContactRefs($params, $cid): void {
+    $updateParams = [
+      'id' => $cid,
+    ];
+    foreach ($params['update_contact_ref'] as $refKey) {
+      foreach ($params['contact'] as $contactParams) {
+        foreach ($contactParams as $key => $value) {
+          if (strpos($key, $refKey) === 0 && !isset($updateParams[$key])) {
+            $updateParams[$key] = $value;
+          }
+        }
+      }
+    }
+    if (count($updateParams) > 1) {
+      wf_civicrm_api('contact', 'create', $updateParams);
+    }
   }
 
   private function unsetEmptyValueIndexes($values, $entity) {


### PR DESCRIPTION
Overview
----------------------------------------
D7 Fix for https://github.com/colemanw/webform_civicrm/pull/519

Before
----------------------------------------
Contact reference custom fields on activity is not saved if no of fields added to the webform > 1.

To replicate -

- Add 2 contact ref custom fields on acivity.
- Create a webform with 3 contacts.
- Enable them on the webform with custom field 1 = Contact 2 and custom field 2 = Contact 3.
- Submit the webform.
- Only value for custom field 1 is saved. 

After
----------------------------------------
All contact ref custom fields are saved.

Technical Details
----------------------------------------
This was a problem with the variable usage in the foreach loop. On the first iteration, the `$table` value is changed leading to a key miss from the second loop execution.

Comments
----------------------------------------
D8 PR - https://github.com/colemanw/webform_civicrm/pull/519