### PR TITLE
D8/9 - Use drupal 8 datetime widget for civi datetime fields

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -425,14 +425,9 @@ class Fields implements FieldsInterface {
       ];
       $fields['activity_activity_date_time'] = [
         'name' => t('Activity # Date'),
-        'type' => 'date',
+        'type' => 'datetime',
         'default_value' => 'now',
-      ];
-      $fields['activity_activity_date_time_timepart'] = [
-        'name' => t('Activity # Time'),
-        /*This must be set to webform_time in order to appear on the build tab as Type = Time; later we'll convert the type to glue it to the date*/
-        'type' => 'webform_time',
-        'default_value' => 'now',
+        'date_time_step' => 60,
       ];
       $fields['activity_duration'] = [
         'name' => t('Activity # Duration'),
@@ -978,16 +973,17 @@ class Fields implements FieldsInterface {
         }
 
         if ($fields[$id]['type'] == 'date') {
-          $fields[$id]['extra']['start_date'] = (!empty($custom_field['start_date_years']) ? '-' . $custom_field['start_date_years'] : '-50') . ' years';
-          $fields[$id]['extra']['end_date'] = (!empty($custom_field['end_date_years']) ? '+' . $custom_field['end_date_years'] : '+50') . ' years';
+          $fields[$id]['date_date_min'] = (!empty($custom_field['start_date_years']) ? '-' . $custom_field['start_date_years'] : '-50') . ' years';
+          $fields[$id]['date_date_max'] = (!empty($custom_field['end_date_years']) ? '+' . $custom_field['end_date_years'] : '+50') . ' years';
           // Add "time" component for datetime fields
           if (!empty($custom_field['time_format'])) {
-            $fields[$id]['name'] .= ' - ' . t('date');
-            $fields[$id . '_timepart'] = [
-              'name' => $custom_field['label'] . ' - ' . t('time'),
-              'type' => 'webform_time',
-              'extra' => ['hourformat' => $custom_field['time_format'] == 1 ? '12-hour' : '24-hour'],
-            ];
+            $fields[$id]['type'] = 'datetime';
+            $fields[$id]['date_time_step'] = 60;
+            if ($custom_field['time_format'] == 2) {
+              $fields[$id]['date_time_element'] = 'timepicker';
+              $fields[$id]['date_time_placeholder'] = 'hh:mm';
+              $fields[$id]['date_time_format'] = 'H:i';
+            }
           }
         }
         elseif ($fields[$id]['data_type'] == 'ContactReference') {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2478,13 +2478,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $options = $utils->wf_crm_field_options($component, '', $this->data);
           $val = array_search($val, $options);
         }
-        // Fudge together date and time fields
-        if (($field['type'] === 'time' || $field['type'] === 'webform_time') && substr($name, -8) === 'timepart') {
-          $name = str_replace('_timepart', '', $name);
-          // Add date (default to today)
-          $date = wf_crm_aval($this->data, "$ent:$c:$table:$n:$name", date('Ymd'));
-          $val = $date . str_replace(':', '', $val);
-        }
 
         // Only known contacts are allowed to empty a field
         if (($val !== '' && $val !== NULL && $val !== []) || !empty($this->existing_contacts[$c])) {

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -59,7 +59,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_details");
     $this->getSession()->getPage()->uncheckField('activity_1_settings_details[view_link]');
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time");
-    $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_activity_date_time_timepart");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_duration");
 
     $multiple = FALSE;
@@ -75,7 +74,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_subject");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_details");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");
-    $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time_timepart");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_duration");
 
     $this->saveCiviCRMSettings();

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -264,10 +264,6 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     foreach ($this->_customFields as $name => $id) {
       $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_{$id}");
       $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_{$id}");
-      if ($name == 'DateTime') {
-        $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_{$id}_timepart");
-        $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_{$id}_timepart");
-      }
     }
     $this->saveCiviCRMSettings();
 
@@ -308,11 +304,8 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->fillField('Text', 'Lorem Ipsum');
 
-    // ToDo - Could not figure out how to use $this->getSession()->getPage()->fillField so using javascript instead
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2').setAttribute('value', '2020-12-12')");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contact-1-cg1-custom-2-timepart').setAttribute('value', '10:20:00')");
+    $this->getSession()->getPage()->fillField('civicrm_1_contact_1_cg1_custom_2[date]', '12-12-2020');
+    $this->getSession()->getPage()->fillField('civicrm_1_contact_1_cg1_custom_2[time]', '10:20:00');
 
     // Only check one Checkbox -> Red
     $this->assertSession()->pageTextContains('Red - Recommended');

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -184,3 +184,51 @@ function webform_civicrm_update_8001() {
     }
   }
 }
+
+/**
+ * Remove timepart field from
+ * all the webforms.
+ */
+function webform_civicrm_update_8002() {
+  \Drupal::service('civicrm')->initialize();
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $settings = &$config['webform_civicrm']['settings'];
+    foreach ($settings as $key => $val) {
+      if (substr($key, -9) == '_timepart') {
+        $dateKey = str_replace('_timepart', '', $key);
+        $dateElement = $webform->getElement($dateKey);
+        $timeElement = $webform->getElement($key);
+        if ($dateElement['#type'] == 'date') {
+          $dateElement['#type'] = 'datetime';
+          $dateElement['#date_time_step'] = '60';
+          $dateElement['#date_date_min'] = !empty($dateElement['#extra']['start_date']) ? $dateElement['#extra']['start_date'] : '-50 years';
+          $dateElement['#date_date_max'] = !empty($dateElement['#extra']['end_date']) ? $dateElement['#extra']['end_date'] : '+50 years';
+          unset($dateElement['#extra']);
+          if (!empty($timeElement['#extra']['hourformat']) && $timeElement['#extra']['hourformat'] == '24-hour') {
+            $dateElement['#date_time_element'] = 'timepicker';
+            $dateElement['#date_time_placeholder'] = 'hh:mm';
+            $dateElement['#date_time_format'] = 'H:i';
+          }
+          if (!empty($dateElement['#admin_title'])) {
+            $dateElement['#admin_title'] = str_replace(' - date', '', $dateElement['#admin_title']);
+          }
+          if (!empty($dateElement['#title'])) {
+            $dateElement['#title'] = str_replace(' - date', '', $dateElement['#title']);
+          }
+          unset($dateElement['#webform_plugin_id']);
+          unset($settings[$key]);
+          $webform->setElementProperties($dateKey, $dateElement);
+          $webform->deleteElement($key);
+        }
+      }
+    }
+    $handler->setConfiguration($config);
+    $webform->save();
+  }
+}

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -42,6 +42,25 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
 }
 
 /**
+ * Implements hook_element_info_alter().
+ */
+function webform_civicrm_element_info_alter(array &$types) {
+  $types['datetime']['#process'][] = 'webform_civicrm_datetime_set_format';
+}
+
+/**
+ * Remove seconds from the HTML5 datetime widget.
+ */
+function webform_civicrm_datetime_set_format($element) {
+  if (!empty($element['#date_time_element']) && $element['#date_time_element'] == 'time' && !empty($element['time']['#value'])) {
+    $parts = explode(':', $element['time']['#value']);
+    $parts = array_splice($parts, 0, 2);
+    $element['time']['#value'] = implode(':', $parts);
+  }
+  return $element;
+}
+
+/**
  * Implements hook_form_alter().
  */
 function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {


### PR DESCRIPTION
Overview
----------------------------------------
Use drupal 8 datetime widget for civi datetime fields

Before
----------------------------------------
Time displayed as a separate field on the webform. Both date and time field values are fused after the webform is submitted.

![image](https://user-images.githubusercontent.com/5929648/112853772-d0742c00-90ca-11eb-9065-0dae1c8ad89d.png)

After
----------------------------------------
Use the new d8 widget for date/time.

![image](https://user-images.githubusercontent.com/5929648/112854277-509a9180-90cb-11eb-954d-16b4361f9e74.png)

The custom field is a 24-hour format so is displayed using timepicker widget. The default HTML 5 type isn't able to render a 24 hour format it seems.

Comments
----------------------------------------
@KarinG 