### PR TITLE
D8/9 Allow type to be updated on civicrm_options element

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -5,7 +5,7 @@ namespace Drupal\webform_civicrm\Plugin\WebformElement;
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Markup;
-use Drupal\webform\Plugin\WebformElementBase;
+use Drupal\webform\Plugin\WebformElement\OptionsBase;
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
@@ -23,7 +23,7 @@ use Drupal\webform\WebformSubmissionInterface;
  * @see \Drupal\webform\Plugin\WebformElementInterface
  * @see \Drupal\webform\Annotation\WebformElement
  */
-class CivicrmOptions extends WebformElementBase {
+class CivicrmOptions extends OptionsBase {
 
   /**
    * {@inheritdoc}
@@ -235,10 +235,34 @@ class CivicrmOptions extends WebformElementBase {
    * {@inheritdoc}
    */
   public function hasMultipleValues(array $element) {
-    if (!empty($element['#extra']['multiple']) || (!empty($element['#options']) && count($element['#options']) === 1)) {
+    if (!empty($element['#extra']['multiple']) ||
+      (empty($element['#civicrm_live_options']) && !empty($element['#options']) && count($element['#options']) === 1)) {
       return TRUE;
     }
     return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRelatedTypes(array $element) {
+    $types = [];
+    $has_multiple_values = $this->hasMultipleValues($element);
+
+    $supportedTypes = ['checkboxes', 'radios', 'select'];
+    $elements = $this->elementManager->getInstances();
+    foreach ($elements as $element_name => $element_instance) {
+      if (!in_array($element_name, $supportedTypes)) {
+        continue;
+      }
+      if ($has_multiple_values !== $element_instance->hasMultipleValues($element)) {
+        continue;
+      }
+      $types[$element_name] = $element_instance->getPluginLabel();
+    }
+
+    asort($types);
+    return $types;
   }
 
 }

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -530,22 +530,9 @@ abstract class WebformCivicrmBase {
       return $exposed;
     }
 
-    if ($field && $field['#type'] == 'civicrm_options') {
-      return $field['#options'] ? array_diff_key($field['#options'], $exclude) : [];
-    }
-    if ($field && $field['#type'] == 'select') {
-      // Fetch static options
-      if (empty($field['civicrm_live_options'])) {
-        $exposed = $utils->wf_crm_str2array($field['#extra']['items']);
-      }
-      // Fetch live options
-      else {
-        $exposed = $utils->wf_crm_field_options(['form_key' => $field['#form_key']], 'civicrm_live_options', $this->data);
-      }
-      foreach ($exclude as $i) {
-        unset($exposed[$i]);
-      }
-      return $exposed;
+    $supportedTypes = ['civicrm_options', 'checkboxes', 'radios', 'select'];
+    if (isset($field['#options']) && in_array($field['#type'], $supportedTypes)) {
+      return array_diff_key($field['#options'], array_flip($exclude));
     }
     return [];
   }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -155,12 +155,21 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    * @param bool $enableStatic
    *   TRUE if static radio option should be enabled.
    * @param bool $default
+   * @param string $type
+   *  possible values - checkboxes, radios, select, civicrm-options
    */
-  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL) {
+  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL) {
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
     $checkbox_edit_button->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
+    if ($type) {
+      $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-change-type"]')->click();
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-elements-{$type}-operation']")->click();
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-cancel']");
+    }
 
     if ($enableStatic) {
       $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
@@ -170,10 +179,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if ($default) {
       $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);
     }
-    $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
-    $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
-    $this->htmlOutput();
-
+    if (!$type || $type == 'civicrm-options') {
+      $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
+      $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
+      $this->htmlOutput();
+    }
     if ($multiple) {
       $this->getSession()->getPage()->checkField('properties[extra][multiple]');
       $this->assertSession()->checkboxChecked('properties[extra][multiple]');

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -71,7 +71,7 @@ function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
   //Do not load civicrm elements on the "Add element" form.
   if ($form_id == 'webform_ui_element_type_select_form') {
     foreach ($form as $k => $fieldset) {
-      if (!empty($fieldset['#title']) && strtolower($fieldset['#title']) == 'civicrm') {
+      if (is_array($fieldset) && !empty($fieldset['#title']) && strtolower($fieldset['#title']) == 'civicrm') {
         unset($form[$k]);
         return;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Allow retyping on civicrm_options element

Before
----------------------------------------
Cannot change `#type` on civicrm_option elements. You need to modify the yaml in order to use the feature like  conditionals, etc.

![image](https://user-images.githubusercontent.com/5929648/113505221-0a29b480-955b-11eb-8255-ca56962f4c18.png)


After
----------------------------------------
`#type` can be changed via UI. This provides additional bits like  a) make conditionals via ui possible + layout options (columns) , etc.

![image](https://user-images.githubusercontent.com/5929648/113505020-ddc16880-9559-11eb-991c-6c18bb0bc7d6.png)

The list of elements depends on the config set on the `civicrm_options` form, so if multiple checkbox is enabled for eg Groups, will load only checkboxes. Similarly for fields like Gender, where `multiple` is disabled, will load radios, select element on the form -

![image](https://user-images.githubusercontent.com/5929648/113505039-09445300-955a-11eb-8f47-ed91bb4ed3f3.png)
 

Technical Details
----------------------------------------
CiviCRM Options element now extends OptionsBase so it belongs to the family of other option elements, eg checkbox, select, radio, tableselect, etc.

Comments
----------------------------------------
@KarinG 