### PR TITLE
[Test only] - AddiATS1stpaytest

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -143,6 +143,16 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
 
     $this->filliATSCryptogram();
+
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    // $this->assertPageNoErrorMessages();
+    $this->createScreenshot($this->htmlOutputDirectory . '/iatsfaps_cryptogram.png');
+    $this->htmlOutput();
+
+    $this->assertSession()->waitForElementVisible('css', '.webform-confirmation');
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    $this->assertPageNoErrorMessages();
   }
 
   /**
@@ -150,17 +160,14 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
    */
   private function filliATSCryptogram() {
     $this->htmlOutput();
-    // $this->createScreenshot($this->htmlOutputDirectory . '/faps_cryptogram.png');
-
     $expYear = date('y') + 1;
     // Wait for the credit card form to load in.
 
-    $cryptogram = $this->assertSession()->waitForElementVisible('xpath', '//div[contains(@id, "firstpay-iframe")]/iframe');
+    $this->getSession()->wait(5000);
+    $this->getSession()->wait(5000);
+    $this->getSession()->wait(5000);
 
-    $this->assertSession()->waitForElementVisible('css','text-card-number');
-
-    $this->assertNotEmpty($cryptogram);
-    $this->getSession()->switchToIFrame($cryptogram->getAttribute('name'));
+    $this->getSession()->switchToIFrame('firstpay-iframe');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
     $this->assertSession()->waitForElementVisible('css', 'input[name="text-card-number"]');
@@ -173,7 +180,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('select-expiration-year', $expYear);
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    // $this->getSession()->switchToIFrame();
+    $this->getSession()->switchToIFrame();
   }
 
 /*public function testSubmitContribution() {

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -147,16 +147,26 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Calgary');
-    $this->getSession()->getPage()->fillField('Country', 'Canada');
-    $this->getSession()->getPage()->fillField('Postal Code', 'T2N 1N4');
-    $this->getSession()->getPage()->fillField('State/Province', 'Alberta');
+    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
 
+    // Select2 is being difficult; unhide the country and state/province select.
+    $driver = $this->getSession()->getDriver();
+    assert($driver instanceof DrupalSelenium2Driver);
+    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+
+    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    // Wait for select2's AJAX request.
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
+    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+
+    $this->getSession()->getPage()->fillField('Postal Code', '53177');
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
     // $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . '/iatsfaps_cryptogram.png');
+    $this->createScreenshot($this->htmlOutputDirectory . 'iatsfaps_cryptogram.png');
     $this->htmlOutput();
 
     $this->assertSession()->waitForElementVisible('css', '.webform-confirmation');
@@ -177,7 +187,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->switchToIFrame('firstpay-iframe');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    $this->getSession()->getPage()->fillField('Cryptogram', 'cryptogram');
+    // $this->getSession()->getPage()->fillField('Cryptogram', 'cryptogram');
 
     $this->assertSession()->waitForElementVisible('css', 'input[name="text-card-number"]');
     $this->getSession()->getPage()->fillField('text-card-number', '4222222222222220');
@@ -272,7 +282,9 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');
-    $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
+    // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
+
+    $this->createScreenshot($this->htmlOutputDirectory . 'iats_webform.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -13,7 +13,10 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
  */
 final class ContributionIatsTest extends WebformCivicrmTestBase {
 
-  private function setUp() {
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
     parent::setUp();
 
     // Download installs and enables!

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -284,7 +284,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
 
-    $this->createScreenshot($this->htmlOutputDirectory . 'iats_webform.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -247,14 +247,14 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-    $this->getSession()->getPage()->fillField('Line Item Amount', '20.00');
-    $this->getSession()->getPage()->fillField('Line Item Amount 2', '29.50');
+    $this->getSession()->getPage()->fillField('Line Item Amount', '1.75');
+    $this->getSession()->getPage()->fillField('Line Item Amount 2', '5.00');
 
     $this->getSession()->getPage()->pressButton('Next >');
-    $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
+    $this->getSession()->getPage()->fillField('Contribution Amount', '3.00');
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
     $this->htmlOutput();
-    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '60.98');
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '10.00');
 
     // Wait for the credit card form to load in.
     $this->assertSession()->waitForField('credit_card_number');
@@ -300,7 +300,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertContains(':', $contribution['trxn_id']);
     $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
     $this->assertEquals('Donation', $contribution['financial_type']);
-    $this->assertEquals('60.98', $contribution['total_amount']);
+    $this->assertEquals('10.00', $contribution['total_amount']);
     $contribution_total_amount = $contribution['total_amount'];
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
@@ -316,7 +316,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
       'label' => "Credit Card",
       'option_group_id' => "payment_instrument",
     ]);
-    $this->assertEquals('1.48', $contribution['tax_amount']);
+    $this->assertEquals('0.25', $contribution['tax_amount']);
     $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
     $tax_total_amount = $contribution['tax_amount'];
 
@@ -324,15 +324,16 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
       'sequential' => 1,
     ]);
 
-    $this->assertEquals('10.00', $api_result['values'][0]['line_total']);
+    // throw new \Exception(var_export($api_result, TRUE));
+
+    $this->assertEquals('3.00', $api_result['values'][0]['line_total']);
     $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
-    $this->assertEquals('20.00', $api_result['values'][1]['line_total']);
+    $this->assertEquals('1.75', $api_result['values'][1]['line_total']);
     $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
-    $this->assertEquals('29.50', $api_result['values'][2]['line_total']);
-    $this->assertEquals('1.48', $api_result['values'][2]['tax_amount']);
+    $this->assertEquals('5.00', $api_result['values'][2]['line_total']);
+    $this->assertEquals('0.25', $api_result['values'][2]['tax_amount']);
     $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
 
-    // throw new \Exception(var_export($api_result, TRUE));
     $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
     $sum_tax_amount = $api_result['values'][2]['tax_amount'];
     $this->assertEquals($tax_total_amount, $sum_tax_amount);

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -165,8 +165,8 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    // $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . 'iatsfaps_cryptogram.png');
+    $this->assertPageNoErrorMessages();
+    $this->createScreenshot($this->htmlOutputDirectory . 'faps169.png');
     $this->htmlOutput();
 
     $this->assertSession()->waitForElementVisible('css', '.webform-confirmation');
@@ -198,6 +198,8 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->fillField('select-expiration-year', $expYear);
     $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->getSession()->wait(5000);
 
     $this->getSession()->switchToIFrame();
   }
@@ -284,7 +286,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
 
-    $this->createScreenshot($this->htmlOutputDirectory . '/errord8535.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/legacy289.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -144,6 +144,15 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->filliATSCryptogram();
 
+    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
+    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
+    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
+    $this->getSession()->getPage()->fillField('City', 'Calgary');
+    $this->getSession()->getPage()->fillField('Country', 'Canada');
+    $this->getSession()->getPage()->fillField('Postal Code', 'T2N 1N4');
+    $this->getSession()->getPage()->fillField('State/Province', 'Alberta');
+
+
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
     // $this->assertPageNoErrorMessages();
@@ -164,11 +173,11 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     // Wait for the credit card form to load in.
 
     $this->getSession()->wait(5000);
-    $this->getSession()->wait(5000);
-    $this->getSession()->wait(5000);
 
     $this->getSession()->switchToIFrame('firstpay-iframe');
     $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->getSession()->getPage()->fillField('Cryptogram', 'cryptogram');
 
     $this->assertSession()->waitForElementVisible('css', 'input[name="text-card-number"]');
     $this->getSession()->getPage()->fillField('text-card-number', '4222222222222220');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -150,11 +150,15 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
    */
   private function filliATSCryptogram() {
     $this->htmlOutput();
-    $this->createScreenshot($this->htmlOutputDirectory . '/faps_cryptogram.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/faps_cryptogram.png');
 
     $expYear = date('y') + 1;
     // Wait for the credit card form to load in.
-    $cryptogram = $this->assertSession()->waitForElementVisible('xpath', '//div[contains(@id, "firstpay-iframe")]/div/iframe');
+
+    $cryptogram = $this->assertSession()->waitForElementVisible('xpath', '//div[contains(@id, "firstpay-iframe")]/iframe');
+
+    $this->assertSession()->waitForElementVisible('css','text-card-number');
+
     $this->assertNotEmpty($cryptogram);
     $this->getSession()->switchToIFrame($cryptogram->getAttribute('name'));
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -164,7 +168,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->fillField('text-cvv', '123');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->fillField('select-expiration-month', '11 / ');
+    $this->getSession()->getPage()->fillField('select-expiration-month', '11');
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->fillField('select-expiration-year', $expYear);
     $this->assertSession()->assertWaitOnAjaxRequest();

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -192,140 +192,139 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->switchToIFrame();
   }
 
-/*public function testSubmitContribution() {
-  $financialAccount = $this->setupSalesTax(2, $accountParams = []);
+  public function testSubmitContribution() {
+    $financialAccount = $this->setupSalesTax(2, $accountParams = []);
 
-  $this->drupalLogin($this->adminUser);
-  $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
-    'webform' => $this->webform->id(),
-  ]));
-  // The label has a <div> in it which can cause weird failures here.
-  $this->assertSession()->waitForText('Enable CiviCRM Processing');
-  $this->assertSession()->waitForField('nid');
-  $this->getSession()->getPage()->checkField('nid');
-  $this->getSession()->getPage()->clickLink('Contribution');
-  $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
-  $this->assertSession()->assertWaitOnAjaxRequest();
-  $this->assertSession()->pageTextContains('You must enable an email field for Contact 1 in order to process transactions.');
-  $this->getSession()->getPage()->pressButton('Enable It');
-  $this->assertSession()->assertWaitOnAjaxRequest();
-  $this->getSession()->getPage()->checkField('Contribution Amount');
-  $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
-  $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
+    $this->drupalLogin($this->adminUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    // The label has a <div> in it which can cause weird failures here.
+    $this->assertSession()->waitForText('Enable CiviCRM Processing');
+    $this->assertSession()->waitForField('nid');
+    $this->getSession()->getPage()->checkField('nid');
+    $this->getSession()->getPage()->clickLink('Contribution');
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->pageTextContains('You must enable an email field for Contact 1 in order to process transactions.');
+    $this->getSession()->getPage()->pressButton('Enable It');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->checkField('Contribution Amount');
+    $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
+    $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
 
-  $this->assertCount(3, $this->getOptions('Payment Processor'));
-  // ToDo - KG
-  $this->getSession()->getPage()->selectFieldOption('Payment Processor',  $this->payment_processor_legacy['id']);
+    $this->assertCount(4, $this->getOptions('Payment Processor'));
+    $this->getSession()->getPage()->selectFieldOption('Payment Processor',  $this->payment_processor_legacy['id']);
 
-  $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
-  $this->assertSession()->assertWaitOnAjaxRequest();
-  $this->htmlOutput();
-  $this->getSession()->getPage()->checkField("civicrm_1_lineitem_1_contribution_line_total");
-  $this->assertSession()->checkboxChecked("civicrm_1_lineitem_1_contribution_line_total");
-  $this->getSession()->getPage()->checkField("civicrm_1_lineitem_2_contribution_line_total");
-  $this->assertSession()->checkboxChecked("civicrm_1_lineitem_2_contribution_line_total");
-  // Set the Financial Type for the second line item to Member Dues (which has Sales Tax on it).
-  $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
+    $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->getSession()->getPage()->checkField("civicrm_1_lineitem_1_contribution_line_total");
+    $this->assertSession()->checkboxChecked("civicrm_1_lineitem_1_contribution_line_total");
+    $this->getSession()->getPage()->checkField("civicrm_1_lineitem_2_contribution_line_total");
+    $this->assertSession()->checkboxChecked("civicrm_1_lineitem_2_contribution_line_total");
+    // Set the Financial Type for the second line item to Member Dues (which has Sales Tax on it).
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
 
-  $this->getSession()->getPage()->pressButton('Save Settings');
-  $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->getSession()->getPage()->pressButton('Save Settings');
+    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
 
-  // Setup contact information wizard page.
-  $this->configureContactInformationWizardPage();
+    // Setup contact information wizard page.
+    $this->configureContactInformationWizardPage();
 
-  $this->drupalGet($this->webform->toUrl('canonical'));
-  $this->assertPageNoErrorMessages();
-  $this->getSession()->getPage()->fillField('First Name', 'Frederick');
-  $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
-  $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-  $this->getSession()->getPage()->fillField('Line Item Amount', '20.00');
-  $this->getSession()->getPage()->fillField('Line Item Amount 2', '29.50');
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
+    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+    $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+    $this->getSession()->getPage()->fillField('Line Item Amount', '20.00');
+    $this->getSession()->getPage()->fillField('Line Item Amount 2', '29.50');
 
-  $this->getSession()->getPage()->pressButton('Next >');
-  $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
-  $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
-  $this->htmlOutput();
-  $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '60.98');
+    $this->getSession()->getPage()->pressButton('Next >');
+    $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
+    $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
+    $this->htmlOutput();
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '60.98');
 
-  // Wait for the credit card form to load in.
-  $this->assertSession()->waitForField('credit_card_number');
-  $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
-  $this->getSession()->getPage()->fillField('Security Code', '123');
-  $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
-  $this_year = date('Y');
-  $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-  $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-  $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-  $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-  $this->getSession()->getPage()->fillField('City', 'Milwaukee');
+    // Wait for the credit card form to load in.
+    $this->assertSession()->waitForField('credit_card_number');
+    $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
+    $this->getSession()->getPage()->fillField('Security Code', '123');
+    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
+    $this_year = date('Y');
+    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
+    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
+    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
+    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
+    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
 
-  // Select2 is being difficult; unhide the country and state/province select.
-  $driver = $this->getSession()->getDriver();
-  assert($driver instanceof DrupalSelenium2Driver);
-  $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-  $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    // Select2 is being difficult; unhide the country and state/province select.
+    $driver = $this->getSession()->getDriver();
+    assert($driver instanceof DrupalSelenium2Driver);
+    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
 
-  $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
-  // Wait for select2's AJAX request.
-  $this->assertSession()->assertWaitOnAjaxRequest();
-  $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-  $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    // Wait for select2's AJAX request.
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
+    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
 
-  $this->getSession()->getPage()->fillField('Postal Code', '53177');
-  $this->getSession()->getPage()->pressButton('Submit');
-  $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
-  $this->htmlOutput();
-  $this->assertPageNoErrorMessages();
-  $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
-  $utils = \Drupal::service('webform_civicrm.utils');
-  $api_result = $utils->wf_civicrm_api('contribution', 'get', [
-    'sequential' => 1,
-  ]);
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+      'sequential' => 1,
+    ]);
 
-  $this->assertEquals(1, $api_result['count']);
-  $contribution = reset($api_result['values']);
-  $this->assertNotEmpty($contribution['trxn_id']);
-  $this->assertContains(':', $contribution['trxn_id']);
-  $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
-  $this->assertEquals('Donation', $contribution['financial_type']);
-  $this->assertEquals('60.98', $contribution['total_amount']);
-  $contribution_total_amount = $contribution['total_amount'];
-  $this->assertEquals('Completed', $contribution['contribution_status']);
-  $this->assertEquals('USD', $contribution['currency']);
+    $this->assertEquals(1, $api_result['count']);
+    $contribution = reset($api_result['values']);
+    $this->assertNotEmpty($contribution['trxn_id']);
+    $this->assertContains(':', $contribution['trxn_id']);
+    $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
+    $this->assertEquals('Donation', $contribution['financial_type']);
+    $this->assertEquals('60.98', $contribution['total_amount']);
+    $contribution_total_amount = $contribution['total_amount'];
+    $this->assertEquals('Completed', $contribution['contribution_status']);
+    $this->assertEquals('USD', $contribution['currency']);
 
-  // Also retrieve tax_amount (have to ask for it to be returned):
-  $api_result = $utils->wf_civicrm_api('contribution', 'get', [
-    'sequential' => 1,
-    'return' => ['tax_amount', 'payment_instrument_id'],
-  ]);
-  $contribution = reset($api_result['values']);
-  $creditCardID = $utils->wf_civicrm_api('OptionValue', 'getvalue', [
-    'return' => "value",
-    'label' => "Credit Card",
-    'option_group_id' => "payment_instrument",
-  ]);
-  $this->assertEquals('1.48', $contribution['tax_amount']);
-  $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
-  $tax_total_amount = $contribution['tax_amount'];
+    // Also retrieve tax_amount (have to ask for it to be returned):
+    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+      'sequential' => 1,
+      'return' => ['tax_amount', 'payment_instrument_id'],
+    ]);
+    $contribution = reset($api_result['values']);
+    $creditCardID = $utils->wf_civicrm_api('OptionValue', 'getvalue', [
+      'return' => "value",
+      'label' => "Credit Card",
+      'option_group_id' => "payment_instrument",
+    ]);
+    $this->assertEquals('1.48', $contribution['tax_amount']);
+    $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
+    $tax_total_amount = $contribution['tax_amount'];
 
-  $api_result = $utils->wf_civicrm_api('line_item', 'get', [
-    'sequential' => 1,
-  ]);
+    $api_result = $utils->wf_civicrm_api('line_item', 'get', [
+      'sequential' => 1,
+    ]);
 
-  $this->assertEquals('10.00', $api_result['values'][0]['line_total']);
-  $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
-  $this->assertEquals('20.00', $api_result['values'][1]['line_total']);
-  $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
-  $this->assertEquals('29.50', $api_result['values'][2]['line_total']);
-  $this->assertEquals('1.48', $api_result['values'][2]['tax_amount']);
-  $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
+    $this->assertEquals('10.00', $api_result['values'][0]['line_total']);
+    $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
+    $this->assertEquals('20.00', $api_result['values'][1]['line_total']);
+    $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
+    $this->assertEquals('29.50', $api_result['values'][2]['line_total']);
+    $this->assertEquals('1.48', $api_result['values'][2]['tax_amount']);
+    $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
 
-  // throw new \Exception(var_export($api_result, TRUE));
-  $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
-  $sum_tax_amount = $api_result['values'][2]['tax_amount'];
-  $this->assertEquals($tax_total_amount, $sum_tax_amount);
-  $this->assertEquals($contribution_total_amount, $sum_line_total + $sum_tax_amount);
-}*/
+    // throw new \Exception(var_export($api_result, TRUE));
+    $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
+    $sum_tax_amount = $api_result['values'][2]['tax_amount'];
+    $this->assertEquals($tax_total_amount, $sum_tax_amount);
+    $this->assertEquals($contribution_total_amount, $sum_line_total + $sum_tax_amount);
+  }
 
 }

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -284,7 +284,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
 
-    $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/errord8535.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -11,7 +11,7 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
  *
  * @group webform_civicrm
  */
-/*final class ContributionIatsTest extends WebformCivicrmTestBase {
+final class ContributionIatsTest extends WebformCivicrmTestBase {
 
   private function setUp() {
     parent::setUp();
@@ -20,7 +20,9 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
     $result = civicrm_api3('Extension', 'download', [
       'key' => "com.iatspayments.civicrm",
     ]);
-   $params = [
+
+    // Legacy
+    $params = [
       'domain_id' => 1,
       'name' => 'iATS Credit Card - TE4188',
       'payment_processor_type_id' => 'iATS Payments Credit Card',
@@ -42,6 +44,32 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
     $this->payment_processor = current($result['values']);
+
+    // 1st Pay
+    $params = [
+      'domain_id' => 1,
+      'name' => 'iATS Credit Card - 098',
+      'payment_processor_type_id' => 'iATS Payments 1stPay Credit Card',
+      'financial_account_id' => 12,
+      'is_test' => FALSE,
+      'is_active' => 1,
+      'user_name' => '300098',
+      'password' => '216142',
+      'signature' => '1b3b0c7b-38ba-4b5a-bc45-d06f952c6a42',
+      'url_site' => 'https://secure.1stpaygateway.net/secure/RestGW/Gateway/Transaction/',
+      'class_name' => 'Payment_Faps',
+      'is_recur' => 1,
+      'sequential' => 1,
+      'payment_type' => 1,
+      'payment_instrument_id' => 'Credit Card',
+    ];
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $result = $utils->wf_civicrm_api('payment_processor', 'create', $params);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+    $this->payment_processor = current($result['values']);
+
+    drupal_flush_all_caches();
   }
 
   private function setupSalesTax(int $financialTypeId, $accountParams = []) {
@@ -72,139 +100,144 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
     return \CRM_Financial_BAO_FinancialTypeAccount::add($entityParams);
   }
 
-  public function testSubmitContribution() {
-    $financialAccount = $this->setupSalesTax(2, $accountParams = []);
+  public function testSubmit1stPayContribution() {
 
-    $this->drupalLogin($this->adminUser);
-    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
-      'webform' => $this->webform->id(),
-    ]));
-    // The label has a <div> in it which can cause weird failures here.
-    $this->assertSession()->waitForText('Enable CiviCRM Processing');
-    $this->assertSession()->waitForField('nid');
-    $this->getSession()->getPage()->checkField('nid');
-    $this->getSession()->getPage()->clickLink('Contribution');
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->pageTextContains('You must enable an email field for Contact 1 in order to process transactions.');
-    $this->getSession()->getPage()->pressButton('Enable It');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->checkField('Contribution Amount');
-    $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
-    $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
-
-    $this->assertCount(3, $this->getOptions('Payment Processor'));
-    $this->getSession()->getPage()->selectFieldOption('Payment Processor', $this->payment_processor['id']);
-
-    $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-    $this->getSession()->getPage()->checkField("civicrm_1_lineitem_1_contribution_line_total");
-    $this->assertSession()->checkboxChecked("civicrm_1_lineitem_1_contribution_line_total");
-    $this->getSession()->getPage()->checkField("civicrm_1_lineitem_2_contribution_line_total");
-    $this->assertSession()->checkboxChecked("civicrm_1_lineitem_2_contribution_line_total");
-    // Set the Financial Type for the second line item to Member Dues (which has Sales Tax on it).
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
-
-    $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
-
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
-    $this->drupalGet($this->webform->toUrl('canonical'));
-    $this->assertPageNoErrorMessages();
-    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-    $this->getSession()->getPage()->fillField('Line Item Amount', '20.00');
-    $this->getSession()->getPage()->fillField('Line Item Amount 2', '29.50');
-
-    $this->getSession()->getPage()->pressButton('Next >');
-    $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
-    $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
-    $this->htmlOutput();
-    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '60.98');
-
-    // Wait for the credit card form to load in.
-    $this->assertSession()->waitForField('credit_card_number');
-    $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
-    $this->getSession()->getPage()->fillField('Security Code', '123');
-    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
-    $this_year = date('Y');
-    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
-    $this->getSession()->getPage()->pressButton('Submit');
-    $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
-    $this->htmlOutput();
-    $this->assertPageNoErrorMessages();
-    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
-
-    $utils = \Drupal::service('webform_civicrm.utils');
-    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
-      'sequential' => 1,
-    ]);
-
-    $this->assertEquals(1, $api_result['count']);
-    $contribution = reset($api_result['values']);
-    $this->assertNotEmpty($contribution['trxn_id']);
-    $this->assertContains(':', $contribution['trxn_id']);
-    $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
-    $this->assertEquals('Donation', $contribution['financial_type']);
-    $this->assertEquals('60.98', $contribution['total_amount']);
-    $contribution_total_amount = $contribution['total_amount'];
-    $this->assertEquals('Completed', $contribution['contribution_status']);
-    $this->assertEquals('USD', $contribution['currency']);
-
-    // Also retrieve tax_amount (have to ask for it to be returned):
-    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
-      'sequential' => 1,
-      'return' => ['tax_amount', 'payment_instrument_id'],
-    ]);
-    $contribution = reset($api_result['values']);
-    $creditCardID = $utils->wf_civicrm_api('OptionValue', 'getvalue', [
-      'return' => "value",
-      'label' => "Credit Card",
-      'option_group_id' => "payment_instrument",
-    ]);
-    $this->assertEquals('1.48', $contribution['tax_amount']);
-    $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
-    $tax_total_amount = $contribution['tax_amount'];
-
-    $api_result = $utils->wf_civicrm_api('line_item', 'get', [
-      'sequential' => 1,
-    ]);
-
-    $this->assertEquals('10.00', $api_result['values'][0]['line_total']);
-    $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
-    $this->assertEquals('20.00', $api_result['values'][1]['line_total']);
-    $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
-    $this->assertEquals('29.50', $api_result['values'][2]['line_total']);
-    $this->assertEquals('1.48', $api_result['values'][2]['tax_amount']);
-    $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
-
-    // throw new \Exception(var_export($api_result, TRUE));
-    $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
-    $sum_tax_amount = $api_result['values'][2]['tax_amount'];
-    $this->assertEquals($tax_total_amount, $sum_tax_amount);
-    $this->assertEquals($contribution_total_amount, $sum_line_total + $sum_tax_amount);
   }
 
+/*public function testSubmitContribution() {
+  $financialAccount = $this->setupSalesTax(2, $accountParams = []);
+
+  $this->drupalLogin($this->adminUser);
+  $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+    'webform' => $this->webform->id(),
+  ]));
+  // The label has a <div> in it which can cause weird failures here.
+  $this->assertSession()->waitForText('Enable CiviCRM Processing');
+  $this->assertSession()->waitForField('nid');
+  $this->getSession()->getPage()->checkField('nid');
+  $this->getSession()->getPage()->clickLink('Contribution');
+  $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
+  $this->assertSession()->assertWaitOnAjaxRequest();
+  $this->assertSession()->pageTextContains('You must enable an email field for Contact 1 in order to process transactions.');
+  $this->getSession()->getPage()->pressButton('Enable It');
+  $this->assertSession()->assertWaitOnAjaxRequest();
+  $this->getSession()->getPage()->checkField('Contribution Amount');
+  $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
+  $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
+
+  $this->assertCount(3, $this->getOptions('Payment Processor'));
+  // ToDo - KG
+  $this->getSession()->getPage()->selectFieldOption('Payment Processor', $this->payment_processor['id']);
+
+  $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
+  $this->assertSession()->assertWaitOnAjaxRequest();
+  $this->htmlOutput();
+  $this->getSession()->getPage()->checkField("civicrm_1_lineitem_1_contribution_line_total");
+  $this->assertSession()->checkboxChecked("civicrm_1_lineitem_1_contribution_line_total");
+  $this->getSession()->getPage()->checkField("civicrm_1_lineitem_2_contribution_line_total");
+  $this->assertSession()->checkboxChecked("civicrm_1_lineitem_2_contribution_line_total");
+  // Set the Financial Type for the second line item to Member Dues (which has Sales Tax on it).
+  $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
+
+  $this->getSession()->getPage()->pressButton('Save Settings');
+  $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+
+  // Setup contact information wizard page.
+  $this->configureContactInformationWizardPage();
+
+  $this->drupalGet($this->webform->toUrl('canonical'));
+  $this->assertPageNoErrorMessages();
+  $this->getSession()->getPage()->fillField('First Name', 'Frederick');
+  $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+  $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+  $this->getSession()->getPage()->fillField('Line Item Amount', '20.00');
+  $this->getSession()->getPage()->fillField('Line Item Amount 2', '29.50');
+
+  $this->getSession()->getPage()->pressButton('Next >');
+  $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
+  $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
+  $this->htmlOutput();
+  $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '60.98');
+
+  // Wait for the credit card form to load in.
+  $this->assertSession()->waitForField('credit_card_number');
+  $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
+  $this->getSession()->getPage()->fillField('Security Code', '123');
+  $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
+  $this_year = date('Y');
+  $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
+  $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
+  $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
+  $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
+  $this->getSession()->getPage()->fillField('City', 'Milwaukee');
+
+  // Select2 is being difficult; unhide the country and state/province select.
+  $driver = $this->getSession()->getDriver();
+  assert($driver instanceof DrupalSelenium2Driver);
+  $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
+  $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+
+  $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+  // Wait for select2's AJAX request.
+  $this->assertSession()->assertWaitOnAjaxRequest();
+  $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
+  $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+
+  $this->getSession()->getPage()->fillField('Postal Code', '53177');
+  $this->getSession()->getPage()->pressButton('Submit');
+  $this->createScreenshot($this->htmlOutputDirectory . '/iats_webform.png');
+  $this->htmlOutput();
+  $this->assertPageNoErrorMessages();
+  $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+  $utils = \Drupal::service('webform_civicrm.utils');
+  $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+    'sequential' => 1,
+  ]);
+
+  $this->assertEquals(1, $api_result['count']);
+  $contribution = reset($api_result['values']);
+  $this->assertNotEmpty($contribution['trxn_id']);
+  $this->assertContains(':', $contribution['trxn_id']);
+  $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
+  $this->assertEquals('Donation', $contribution['financial_type']);
+  $this->assertEquals('60.98', $contribution['total_amount']);
+  $contribution_total_amount = $contribution['total_amount'];
+  $this->assertEquals('Completed', $contribution['contribution_status']);
+  $this->assertEquals('USD', $contribution['currency']);
+
+  // Also retrieve tax_amount (have to ask for it to be returned):
+  $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+    'sequential' => 1,
+    'return' => ['tax_amount', 'payment_instrument_id'],
+  ]);
+  $contribution = reset($api_result['values']);
+  $creditCardID = $utils->wf_civicrm_api('OptionValue', 'getvalue', [
+    'return' => "value",
+    'label' => "Credit Card",
+    'option_group_id' => "payment_instrument",
+  ]);
+  $this->assertEquals('1.48', $contribution['tax_amount']);
+  $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
+  $tax_total_amount = $contribution['tax_amount'];
+
+  $api_result = $utils->wf_civicrm_api('line_item', 'get', [
+    'sequential' => 1,
+  ]);
+
+  $this->assertEquals('10.00', $api_result['values'][0]['line_total']);
+  $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
+  $this->assertEquals('20.00', $api_result['values'][1]['line_total']);
+  $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
+  $this->assertEquals('29.50', $api_result['values'][2]['line_total']);
+  $this->assertEquals('1.48', $api_result['values'][2]['tax_amount']);
+  $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
+
+  // throw new \Exception(var_export($api_result, TRUE));
+  $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
+  $sum_tax_amount = $api_result['values'][2]['tax_amount'];
+  $this->assertEquals($tax_total_amount, $sum_tax_amount);
+  $this->assertEquals($contribution_total_amount, $sum_line_total + $sum_tax_amount);
 }*/
+
+}

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -249,7 +249,7 @@ function webform_civicrm_civicrm_postSave_civicrm_custom_field($dao) {
  *
  * Handles delete of a custom field.
  *
- * TODO: In theory, this could also handle save, and we don't need to impliment the above hook.
+ * TODO: In theory, this could also handle save, and we don't need to implement the above hook.
  * However, this hook dosen't support CustomField in CiviCRM < 4.7.14 (or LTS < 4.6.24).
  *
  * @param string $op


### PR DESCRIPTION
Overview
----------------------------------------
Adding iATS Test TE41 back in -> and with $ amount adjustment to bypass currently incorrect REJ:15 response.

Before
----------------------------------------
iATS Legacy Test was commented out.

After
----------------------------------------
iATS Legacy Test is back in.
First pass at iATS 1st pay Test

This passes on my local (which is a d8/5.35) - but on Github Actions I got:
![image](https://user-images.githubusercontent.com/5340555/113630398-02364700-9625-11eb-90a2-bd00f4f362eb.png)
and next run:
![image](https://user-images.githubusercontent.com/5340555/113630734-97394000-9625-11eb-98b0-400608b5c936.png)

Have added some screenshot output to see why...