### PR TITLE
[Test only] - Update the test Matrix + relax time comparison in activity data-time submission testing/comparison

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,7 @@ jobs:
             civicrm: '~5.33'
           - drupal: '^8.9'
             civicrm: '~5.35'
-          - drupal: '^8.9'
-            civicrm: '5.36.x-dev'
-          - drupal: '^9.0'
+          - drupal: '^9.1'
             civicrm: '5.36.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -127,7 +127,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     // CiviCRM Activity Type 1 -> Meeting (default)
     $this->assertEquals('1', $activity['activity_type_id']);
     $today = date('Y-m-d H:i:s');
-    $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 60);
+    $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 120);
     $this->assertEquals(90, $activity['duration']);
 
     $api_result = $this->utils->wf_civicrm_api('ActivityContact', 'get', [
@@ -169,7 +169,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     // Everything else should have remained the same:
     $this->assertEquals('Awesome Activity', $activity['subject']);
     $this->assertEquals('1', $activity['activity_type_id']);
-    $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 60);
+    $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 120);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Reduce by -25% -> to:

```
      matrix:
        include:
          - drupal: '^8.9'
            civicrm: '~5.33'
          - drupal: '^8.9'
            civicrm: '~5.35'
          - drupal: '^9.1'
            civicrm: '5.36.x-dev'
```

Technical Details
----------------------------------------
Branch push failed on: we're seeing this regularly (but intermittently) now. This test needs a look:

```
1) Drupal\Tests\webform_civicrm\FunctionalJavascript\ActivitySubmissionTest::testMultipleAssignees
Failed asserting that false is true.

Error: /home/runner/drupal/web/core/tests/Drupal/TestTools/PhpUnitCompatibility/PhpUnit6/TestCompatibilityTrait.php:18
/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/ActivitySubmissionTest.php:130
/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/ActivitySubmissionTest.php:38
```
