### PR TITLE
D8/9 Fix fatal error on preferred communication element

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -518,7 +518,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date'
               && empty($element['#multiple']) && is_array($val)) {
               // If there's more than one value for a non-multi field, pick the most appropriate
-              if (!empty($element['#options'])) {
+              if (!empty($element['#options']) && !empty(array_filter($val))) {
                 foreach ($element['#options'] as $k => $v) {
                   if (in_array($k, $val)) {
                     $val = $k;

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -239,31 +239,22 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked('Existing Contact');
     $this->assertSession()->checkboxChecked('First Name');
     $this->assertSession()->checkboxChecked('Last Name');
+    $this->getSession()->getPage()->checkField('Preferred Communication Method(s)');
+    $this->assertSession()->checkboxChecked('Preferred Communication Method(s)');
 
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
-    $contactElementEdit->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
-
-    $this->assertSession()->waitForField('properties[widget]');
-    $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Static');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption('Set default contact from', 'Current User');
-    $this->getSession()->getPage()->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->editContactElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations', 'Static', 'Current User');
     $this->assertSession()->pageTextContains('Existing Contact has been updated');
+    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-preferred-communication-method-operations', FALSE);
 
     $this->drupalLogout();
     $this->drupalLogin($this->adminUser);
 
     $currentUserUF = $this->getUFMatchRecord($this->adminUser->id());
-    // throw new \Exception(var_export($currentUserUF, TRUE));
 
-    $apiResult = $this->utils->wf_civicrm_api('contact', 'create', [
+    $this->utils->wf_civicrm_api('contact', 'create', [
       'id' => $currentUserUF['contact_id'],
       'first_name' => "Admin",
       'last_name' => "User",
@@ -275,6 +266,9 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('First Name');
     $this->assertSession()->fieldValueEquals('First Name','Admin');
     $this->assertSession()->fieldValueEquals('Last Name', 'User');
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    $this->assertPageNoErrorMessages();
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -33,15 +33,8 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
       'webform' => $this->webform->id(),
     ]));
     // The label has a <div> in it which can cause weird failures here.
-    $this->assertSession()->waitForText('Enable CiviCRM Processing');
-    $this->assertSession()->waitForField('nid');
-    $this->getSession()->getPage()->checkField('nid');
-
-    $this->assertSession()->assertWaitOnAjaxRequest();
-
-    $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
-    $this->assertPageNoErrorMessages();
+    $this->enableCivicrmOnWebform();
+    $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -187,8 +187,12 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if ($multiple) {
       $this->getSession()->getPage()->checkField('properties[extra][multiple]');
       $this->assertSession()->checkboxChecked('properties[extra][multiple]');
-      $this->htmlOutput();
     }
+    elseif (!$type || $type == 'civicrm-options') {
+      $this->getSession()->getPage()->uncheckField('properties[extra][multiple]');
+      $this->assertSession()->checkboxNotChecked('properties[extra][multiple]');
+    }
+    $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on preferred communication element

Before
----------------------------------------
Preferred communication returns a fatal error when submitted without any value. To replicate -

- Enable `Preferred Communication Method(s)` on the webform.
- Disable multiple checkbox for the element.

![image](https://user-images.githubusercontent.com/5929648/114265802-7a7b7e80-9a10-11eb-8d9d-24da973509a5.png)

- Submit the webform without selecting any value for the radio


![image](https://user-images.githubusercontent.com/5929648/114265825-93842f80-9a10-11eb-9a11-ef65328a5282.png)


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
When webform retrieves the value from civi, Preferred Communication Method(s) is returned as an array if not already set on the contact. This is set as a default value on the element even if the element is of type radio. An empty array isn't a valid value for radio element, hence we should avoid it to set during preprocessing.

Comments
----------------------------------------
@KarinG :)