### PR TITLE
D8/9 Replace CiviCRM billing fields with Webform fields.

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -277,11 +277,12 @@ var wfCivi = (function ($, D, drupalSettings) {
   function populateStates(stateSelect, countryId) {
     // What is webformProp?
     // $(stateSelect).webformProp('disabled', true);
-    if (stateProvinceCache[countryId]) {
+    var is_billing = stateSelect.attr('name').indexOf("billing_address") >= 0;
+    if (!is_billing && stateProvinceCache[countryId]) {
       fillOptions(stateSelect, stateProvinceCache[countryId]);
     }
     else {
-      $.getJSON(setting.callbackPath+'/stateProvince/'+countryId, function(data) {
+      $.getJSON(setting.callbackPath+'/stateProvince/' + countryId + '/' + is_billing, function(data) {
         fillOptions(stateSelect, data);
         stateProvinceCache[countryId] = data;
       });

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -35,6 +35,7 @@ cj(function($) {
               $(this).closest('form').find('input.webform-submit.button-primary').click();
             })
           }
+          $('fieldset.billing_name_address-group').remove();
         }
       });
     }
@@ -42,6 +43,7 @@ cj(function($) {
       $('#billing-payment-block').html('');
     }
   }
+  $('fieldset.billing_name_address-group').remove();
   $processorFields.on('change', function() {
     setting.billingSubmission || (setting.billingSubmission = {});
     $('#billing-payment-block').find('input:visible, select').each(function() {
@@ -135,5 +137,5 @@ cj(function($) {
   }
 
   $('.webform-submission-form #edit-actions').detach().appendTo('.webform-submission-form');
-    
+
 });

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -39,7 +39,7 @@ class AdminForm implements AdminFormInterface {
   /**
    * @var array
    */
-  public static $fieldset_entities = ['contact', 'activity', 'case', 'grant'];
+  public static $fieldset_entities = ['contact', 'billing_1_number_of_billing', 'activity', 'case', 'grant'];
 
   /**
    * Initialize and set form variables.
@@ -2168,6 +2168,9 @@ class AdminForm implements AdminFormInterface {
     if ($field['type'] == 'hidden' && !empty($field['expose_list']) && !empty($settings[$field['form_key']])) {
       $field['value'] = $settings[$field['form_key']];
     }
+    if (!empty($field['set']) && $field['set'] == 'billing_1_number_of_billing') {
+      $ent = 'billing_1_number_of_billing';
+    }
     // Create fieldsets for multivalued entities
     if (empty($enabled[$field['form_key']]) && ($ent !== 'contribution' &&
       ($ent !== 'participant' || wf_crm_aval($settings['data'], 'participant_reg_type') === 'separate'))
@@ -2228,6 +2231,9 @@ class AdminForm implements AdminFormInterface {
         // 'weight' => $c,
       ];
       $sets = $utils->wf_crm_get_fields('sets');
+      if ($type == 'billing_1_number_of_billing') {
+        $new_set['parent'] = 'contribution_pagebreak';
+      }
       if (isset($isCustom, $customGroupKey)) {
         $new_set['title'] = $sets[$customGroupKey]['label'];
         // @todo We cannot define a default weight.

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1955,41 +1955,50 @@ class AdminForm implements AdminFormInterface {
       $handler_configuration['settings'] = $this->settings;
       $handler->setConfiguration($handler_configuration);
 
-      $webform_element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
-      foreach ($enabled as $enabled_key => $enabled_element) {
-        if (!is_array($enabled_element)) {
-          // If this is a string, it is not a new element. However, this
-          // probably needs to be revisited.
-          continue;
-        }
-        // Webform uses YAML dump, which dies on FormattableMarkup.
-        $enabled_element = array_map([$this, 'stringifyFormattableMarkup'], $enabled_element);
-        $element_plugin = $webform_element_manager->getElementInstance([
-          '#type' => $enabled_element['type'],
-        ]);
-
-        $stub_form = [];
-        $stub_form_state = new FormState();
-        $stub_form_state->set('default_properties', $element_plugin->getDefaultProperties());
-        if (!isset($enabled_element['title']) && isset($enabled_element['name'])) {
-          $enabled_element['title'] = $enabled_element['name'];
-        }
-        unset($enabled_element['name']);
-        $stub_form_state->setValues($enabled_element);
-        $properties = $element_plugin->getConfigurationFormProperties($stub_form, $stub_form_state);
-
-        $parent_key = '';
-        if (isset($enabled_element['parent'])) {
-          $parent_key = $enabled_element['parent'];
-        }
-        $this->webform->setElementProperties($enabled_key, $properties, $parent_key);
-      }
+      $this->addEnabledElements($enabled);
       // Update existing contact fields
       foreach ($existing as $fid => $id) {
         if (substr($fid, -8) === 'existing') {
           $stop = null;
         }
       }
+    }
+  }
+
+  /**
+   * Add enabled elements to the webform.
+   *
+   * @param array $enabled
+   */
+  public function addEnabledElements($enabled) {
+    $webform_element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
+    foreach ($enabled as $enabled_key => $enabled_element) {
+      if (!is_array($enabled_element)) {
+        // If this is a string, it is not a new element. However, this
+        // probably needs to be revisited.
+        continue;
+      }
+      // Webform uses YAML dump, which dies on FormattableMarkup.
+      $enabled_element = array_map([$this, 'stringifyFormattableMarkup'], $enabled_element);
+      $element_plugin = $webform_element_manager->getElementInstance([
+        '#type' => $enabled_element['type'],
+      ]);
+
+      $stub_form = [];
+      $stub_form_state = new FormState();
+      $stub_form_state->set('default_properties', $element_plugin->getDefaultProperties());
+      if (!isset($enabled_element['title']) && isset($enabled_element['name'])) {
+        $enabled_element['title'] = $enabled_element['name'];
+      }
+      unset($enabled_element['name']);
+      $stub_form_state->setValues($enabled_element);
+      $properties = $element_plugin->getConfigurationFormProperties($stub_form, $stub_form_state);
+
+      $parent_key = '';
+      if (isset($enabled_element['parent'])) {
+        $parent_key = $enabled_element['parent'];
+      }
+      $this->webform->setElementProperties($enabled_key, $properties, $parent_key);
     }
   }
 

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1106,6 +1106,40 @@ class AdminForm implements AdminFormInterface {
       '#required' => TRUE,
     ];
 
+    // Billing Address
+    $n = wf_crm_aval($this->data, "billing:number_number_of_billing", 0);
+    $this->form['contribution']['sets']["billing_1_number_of_billing"] = [
+      '#type' => 'select',
+      '#title' => t('Enable Billing Address?'),
+      '#default_value' => $n,
+      '#options' => [t('No'), t('Yes')],
+      '#prefix' => '<div class="number-of">',
+      '#suffix' => '</div>',
+      '#description' => t('Enable this section if you want billing address to be sent to the payment processor.'),
+    ];
+    $this->addAjaxItem("contribution:sets", "billing_1_number_of_billing", "billing");
+
+    if ($n) {
+      // Add contribution fields
+      foreach ($this->sets as $sid => $set) {
+        if ($sid == 'billing_1_number_of_billing') {
+          $fs = "contribution_sets_billing_{$n}_fieldset";
+          $this->form['contribution']['sets']['billing'][$fs] = [
+            '#type' => 'fieldset',
+            '#title' => t('Billing Address'),
+            '#attributes' => ['id' => $fs, 'class' => ['web-civi-checkbox-set']],
+            'js_select' => $this->addToggle($fs),
+          ];
+          if (isset($set['fields'])) {
+            foreach ($set['fields'] as $fid => $field) {
+              $fid = "civicrm_1_contribution_1_$fid";
+              $this->form['contribution']['sets']['billing'][$fs][$fid] = $this->addItem($fid, $field);
+            }
+          }
+        }
+      }
+    }
+
     // LineItem
     $num = wf_crm_aval($this->data, "lineitem:number_number_of_lineitem", 0);
     $this->form['contribution']['sets']["lineitem_1_number_of_lineitem"] = [
@@ -1660,7 +1694,7 @@ class AdminForm implements AdminFormInterface {
           $this->data[$ent][$c][$key] = $val;
         }
         // Standalone entities keep their own count independent of contacts
-        elseif ($ent == 'grant' || $ent == 'activity' || $ent == 'case' || $ent == 'lineitem' || $ent == 'receipt') {
+        elseif (in_array($ent, ['grant', 'activity', 'case', 'lineitem', 'receipt', 'billing'])) {
           $this->data[$ent]["number_$key"] = $val;
         }
       }

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -167,9 +167,16 @@ class AdminForm implements AdminFormInterface {
         'website' => 'url',
         'im' => 'name',
         'address' => ['street_address', 'city', 'state_province_id', 'postal_code'],
+        'billing' => ['first_name', 'last_name', 'street_address', 'city', 'postal_code', 'state_province_id', 'country_id'],
       ];
       foreach ($defaults as $ent => $fields) {
         if (strpos($_POST['_triggering_element_name'], "_number_of_$ent")) {
+          if ($ent == 'billing') {
+            foreach ((array) $fields as $field) {
+              $this->settings["civicrm_1_contribution_1_contribution_{$ent}_address_{$field}"] = 1;
+            }
+            continue;
+          }
           list(, $c) = explode('_', $_POST['_triggering_element_name']);
           for ($n = 1; $n <= $this->data['contact'][$c]["number_of_$ent"]; ++$n) {
             foreach ((array) $fields as $field) {

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -41,12 +41,14 @@ class AjaxController implements ContainerInjectionInterface {
    *   The operation to perform: stateProvince or county
    */
   public function handle($key, $input = '', $isBilling = FALSE) {
-    if ($key === 'stateProvince' || $key === 'county') {
-      $this->civicrm->initialize();
-      return $this->$key($input, $isBilling);
+    $this->civicrm->initialize();
+    if ($key === 'stateProvince') {
+      return $this->stateProvince($input, $isBilling);
+    }
+    elseif ($key === 'county') {
+      return $this->county($input);
     }
     else {
-      $this->civicrm->initialize();
       $processor = \Drupal::service('webform_civicrm.webform_ajax');
       return new JsonResponse($processor->contactAjax($key, $input));
     }
@@ -64,7 +66,7 @@ class AjaxController implements ContainerInjectionInterface {
     return new JsonResponse($data);
   }
 
-  protected function county($input, $isBilling = FALSE) {
+  protected function county($input) {
     $data = [];
     $utils = \Drupal::service('webform_civicrm.utils');
     if (strpos($input, '-') !== FALSE) {

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -40,10 +40,10 @@ class AjaxController implements ContainerInjectionInterface {
    * @param string $operation
    *   The operation to perform: stateProvince or county
    */
-  public function handle($key, $input = '') {
+  public function handle($key, $input = '', $isBilling = FALSE) {
     if ($key === 'stateProvince' || $key === 'county') {
       $this->civicrm->initialize();
-      return $this->$key($input);
+      return $this->$key($input, $isBilling);
     }
     else {
       $this->civicrm->initialize();
@@ -52,30 +52,31 @@ class AjaxController implements ContainerInjectionInterface {
     }
   }
 
-    protected function stateProvince($input) {
-        if (!$input || ((int) $input != $input && $input != 'default')) {
-            $data = ['' => t('- first choose a country')];
-        }
-        else {
-            $data = \Drupal::service('webform_civicrm.utils')->wf_crm_get_states($input);
-        }
-
-        // @todo use Drupal's cacheable response?
-        return new JsonResponse($data);
+  protected function stateProvince($input, $isBilling = FALSE) {
+    if (!$input || ((int) $input != $input && $input != 'default')) {
+      $data = ['' => t('- first choose a country')];
+    }
+    else {
+      $data = \Drupal::service('webform_civicrm.utils')->wf_crm_get_states($input, $isBilling);
     }
 
-    protected function county($input) {
-        $data = [];
-        $utils = \Drupal::service('webform_civicrm.utils');
-        if (strpos($input, '-') !== FALSE) {
-            list($state, $country) = explode('-', $input);
-            $params = [
-              'field' => 'county_id',
-              'state_province_id' => $utils->wf_crm_state_abbr($state, 'id', $country)
-            ];
-            $data = $utils->wf_crm_apivalues('address', 'getoptions', $params);
-        }
-        // @todo use Drupal's cacheable response?
-        return new JsonResponse($data);
+    // @todo use Drupal's cacheable response?
+    return new JsonResponse($data);
+  }
+
+  protected function county($input, $isBilling = FALSE) {
+    $data = [];
+    $utils = \Drupal::service('webform_civicrm.utils');
+    if (strpos($input, '-') !== FALSE) {
+      list($state, $country) = explode('-', $input);
+      $params = [
+        'field' => 'county_id',
+        'state_province_id' => $utils->wf_crm_state_abbr($state, 'id', $country)
+      ];
+      $data = $utils->wf_crm_apivalues('address', 'getoptions', $params);
     }
+    // @todo use Drupal's cacheable response?
+    return new JsonResponse($data);
+  }
+
 }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -99,6 +99,10 @@ class FieldOptions implements FieldOptionsInterface {
         if ($table == 'contribution' && strpos($name, 'frequency_') === 0) {
           $table = 'contribution_recur';
         }
+        if ($table == 'contribution' && strpos($name, 'billing_address_') === 0) {
+          $table = 'address';
+          $params['field'] = str_replace('billing_address_', '', $params['field']);
+        }
         // Use the Contribution table to pull up financial type id-s
         if ($table == 'membership' && $name == 'financial_type_id') {
           $table = 'contribution';

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -287,7 +287,8 @@ class Fields implements FieldsInterface {
         'name' => t('Country'),
         'type' => 'select',
         'civicrm_live_options' => 1,
-        'value' => $utils->wf_crm_get_civi_setting('defaultContactCountry', 1228),
+        'extra' => ['aslist' => 1],
+        'default_value' => $utils->wf_crm_get_civi_setting('defaultContactCountry', 1228),
       ];
       $fields['address_state_province_id'] = [
         'name' => t('State/Province'),
@@ -581,6 +582,16 @@ class Fields implements FieldsInterface {
         'type' => 'textarea',
       ];
       if (isset($sets['contribution'])) {
+        $fields['contribution_enable_contribution'] = [
+          'name' => ts('Enable Contribution?'),
+          'type' => 'hidden',
+          'expose_list' => TRUE,
+          'empty_option' => 'None',
+          'extra' => [
+            'hidden_type' => 'hidden',
+          ],
+          'parent' => 'contribution_pagebreak',
+        ];
         // @todo moved in order since we can't pass `weight`.
         $fields['contribution_total_amount'] = [
             'name' => 'Contribution Amount',
@@ -606,16 +617,6 @@ class Fields implements FieldsInterface {
           'expose_list' => TRUE,
           'value' => 0,
           'weight' => 9996,
-        ];
-        $fields['contribution_enable_contribution'] = [
-          'name' => ts('Enable Contribution?'),
-          'type' => 'hidden',
-          'expose_list' => TRUE,
-          'empty_option' => 'None',
-          'extra' => [
-            'hidden_type' => 'hidden',
-          ],
-          'parent' => 'contribution_pagebreak',
         ];
         $fields['contribution_note'] = [
           'name' => t('Contribution Note'),
@@ -689,6 +690,51 @@ class Fields implements FieldsInterface {
           'min' => '0',
           'step' => '1',
           'set' => 'contributionRecur',
+        ];
+        $sets['billing_1_number_of_billing'] = ['entity_type' => 'contribution', 'label' => t('Billing Address')];
+        $billingFields = [
+          'first_name' => t('Billing First Name'),
+          'middle_name' => t('Billing Middle Name'),
+          'last_name' => t('Billing Last Name'),
+          'street_address' => t('Street Address'),
+          'postal_code' => t('Postal Code'),
+          'city' => t('City'),
+        ];
+        foreach ($billingFields as $key => $label) {
+          $width = 60;
+          if ($key == 'city') {
+            $width = 20;
+          }
+          if ($key == 'postal_code') {
+            $width = 7;
+          }
+          $fields["contribution_billing_address_{$key}"] = [
+            'name' => $label,
+            'type' => 'textfield',
+            'extra' => ['width' => $width],
+            'set' => 'billing_1_number_of_billing',
+            'parent' => 'contribution_pagebreak',
+          ];
+        }
+        $fields['contribution_billing_address_country_id'] = [
+          'name' => t('Country'),
+          'type' => 'select',
+          'civicrm_live_options' => 1,
+          'extra' => ['aslist' => 1],
+          'default_value' => $utils->wf_crm_get_civi_setting('defaultContactCountry', 1228),
+          'set' => 'billing_1_number_of_billing',
+          'parent' => 'contribution_pagebreak',
+        ];
+        $fields['contribution_billing_address_state_province_id'] = [
+          'name' => t('State/Province'),
+          'type' => 'textfield',
+          'extra' => [
+            'maxlength' => 5,
+            'width' => 4,
+          ],
+          'data_type' => 'state_province_abbr',
+          'set' => 'billing_1_number_of_billing',
+          'parent' => 'contribution_pagebreak',
         ];
       }
       if (isset($sets['participant'])) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -63,8 +63,9 @@ class Utils implements UtilsInterface {
   /**
    * Get list of states, keyed by abbreviation rather than ID.
    * @param null|int|string $param
+   * @param bool $isBilling
    */
-  public function wf_crm_get_states($param = NULL) {
+  public function wf_crm_get_states($param = NULL, $isBilling = FALSE) {
     $ret = [];
     if (!$param || $param == 'default') {
       $settings = $this->wf_civicrm_api('Setting', 'get', [
@@ -92,7 +93,8 @@ class Utils implements UtilsInterface {
       'country_id' => ['IN' => $param],
     ]);
     foreach ($states as $state) {
-      $ret[strtoupper($state['abbreviation'])] = $state['name'];
+      $key = $isBilling ? 'id' : 'abbreviation';
+      $ret[strtoupper($state[$key])] = $state['name'];
     }
     // Localize the state/province names if in an non-en_US locale
     $tsLocale = \CRM_Utils_System::getUFLocale();

--- a/src/WebformAjax.php
+++ b/src/WebformAjax.php
@@ -142,6 +142,15 @@ class WebformAjax extends WebformCivicrmBase implements WebformAjaxInterface {
               }
             }
           }
+          elseif ($i == 1 && strpos($field, 'billing_address_') !== false && isset($contact['contact'][$n]['contact_id'])) {
+            $billingAddress = $this->loadBillingAddress($contact['contact'][$n]['contact_id']);
+            if (isset($billingAddress[$field])) {
+              $data[] = [
+                'val' => $billingAddress[$field],
+                'fid' => $fid,
+              ];
+            }
+          }
           // Populate related contacts
           elseif ($i > $c && $field == 'existing') {
             $related_component = $this->getComponent($fid);

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -79,6 +79,36 @@ abstract class WebformCivicrmBase {
   }
 
   /**
+   * Load Billing Address for contact.
+   */
+  protected function loadBillingAddress($cid) {
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $billingFields = ["street_address", "city", "postal_code", "country_id", "state_province_id"];
+    $billingAddress = $utils->wf_civicrm_api('Address', 'get', [
+      'contact_id' => $cid,
+      'location_type_id' => 'Billing',
+      'return' => $billingFields,
+      'options' => [
+        'limit' => 1,
+        'sort' => 'is_primary DESC',
+      ],
+    ]);
+    if (!empty($billingAddress['values'])) {
+      $address = array_pop($billingAddress['values']);
+      foreach ($address as $key => $value) {
+        if (in_array($key, $billingFields)) {
+          $address['billing_address_' . $key] = $value;
+        }
+        unset($address[$key]);
+      }
+    }
+    foreach (['first_name', 'middle_name', 'last_name'] as $name) {
+      $address["billing_address_{$name}"] = $this->loadedContacts[1]['contact'][1][$name] ?? NULL;
+    }
+    return $address;
+  }
+
+  /**
    * Fetch all relevant data for a given contact
    * Used to load contacts for pre-filling a webform, and also to fill in a contact via ajax
    *

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1773,7 +1773,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $fields = \CRM_Utils_Array::crmArrayMerge($processor->getPaymentFormFieldsMetadata(), $billingAddressFieldsMetadata);
 
     $request = \Drupal::request();
-    foreach ($request->request->all() as $field => $value) {
+    $form_values = array_merge($request->request->all(), $this->form_state->getValues());
+    foreach ($form_values as $field => $value) {
       if (empty($value) && isset($fields[$field]) && $fields[$field]['is_required'] !== FALSE) {
         $this->form_state->setErrorByName($field, t(':name field is required.', [':name' => $fields[$field]['title']]));
         $valid = FALSE;

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1797,7 +1797,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
 
     // Validate billing details
-    \CRM_Core_Payment_Form::validatePaymentInstrument($payment_processor_id, $params, $card_errors, NULL);
+    if (!empty($this->data['billing']['number_number_of_billing'])) {
+      \CRM_Core_Payment_Form::validatePaymentInstrument($payment_processor_id, $params, $card_errors, NULL);
+    }
     foreach ($card_errors as $field => $msg) {
       $this->form_state->setErrorByName($field, $msg);
       $valid = FALSE;

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -160,7 +160,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           $this->loadMemberships($c, $contact['id']);
         }
         if ($c == 1 && !empty($this->data['billing']['number_number_of_billing'])) {
-          $this->loadBillingAddress($contact['id']);
+          $this->info['contribution'][1]['contribution'][1] = $this->loadBillingAddress($contact['id']);
         }
       }
       // Load events from url if enabled, this will override loadParticipants
@@ -406,36 +406,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $this->info['participant'][$c]['participant'][$e]['event_id'] = $event_ids;
       }
     }
-  }
-
-  /**
-   * Load Billing Address for contact.
-   */
-  private function loadBillingAddress($cid) {
-    $utils = \Drupal::service('webform_civicrm.utils');
-    $billingFields = ["street_address", "city", "postal_code", "country_id", "state_province_id"];
-    $billingAddress = $utils->wf_civicrm_api('Address', 'get', [
-      'contact_id' => $cid,
-      'location_type_id' => 'Billing',
-      'return' => $billingFields,
-      'options' => [
-        'limit' => 1,
-        'sort' => 'is_primary DESC',
-      ],
-    ]);
-    if (!empty($billingAddress['values'])) {
-      $address = array_pop($billingAddress['values']);
-      foreach ($address as $key => $value) {
-        if (in_array($key, $billingFields)) {
-          $address['billing_address_' . $key] = $value;
-        }
-        unset($address[$key]);
-      }
-    }
-    foreach (['first_name', 'middle_name', 'last_name'] as $name) {
-      $address["billing_address_{$name}"] = $this->info['contact'][1]['contact'][1][$name] ?? NULL;
-    }
-    $this->info['contribution'][1]['contribution'][1] = $address;
   }
 
   /**

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -205,11 +205,12 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     $utils = \Drupal::service('webform_civicrm.utils');
 
     $default_country = $utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
+    $billingAddress = wf_crm_aval($this->data, "billing:number_number_of_billing", FALSE);
     // Variables to push to the client-side
     $js_vars = [];
     // JS Cache eliminates the need for most ajax state/province callbacks
     foreach ($this->data['contact'] as $c) {
-      if (!empty($c['number_of_address'])) {
+      if (!empty($c['number_of_address']) || !empty($billingAddress)) {
         $js_vars += [
           'defaultCountry' => $default_country,
           'defaultStates' => $utils->wf_crm_get_states($default_country),

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -159,6 +159,9 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         if (!empty($this->data['membership'][$c]['number_of_membership'])) {
           $this->loadMemberships($c, $contact['id']);
         }
+        if ($c == 1 && !empty($this->data['billing']['number_number_of_billing'])) {
+          $this->loadBillingAddress($contact['id']);
+        }
       }
       // Load events from url if enabled, this will override loadParticipants
       if (!empty($this->data['reg_options']['allow_url_load'])) {
@@ -403,6 +406,36 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $this->info['participant'][$c]['participant'][$e]['event_id'] = $event_ids;
       }
     }
+  }
+
+  /**
+   * Load Billing Address for contact.
+   */
+  private function loadBillingAddress($cid) {
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $billingFields = ["street_address", "city", "postal_code", "country_id", "state_province_id"];
+    $billingAddress = $utils->wf_civicrm_api('Address', 'get', [
+      'contact_id' => $cid,
+      'location_type_id' => 'Billing',
+      'return' => $billingFields,
+      'options' => [
+        'limit' => 1,
+        'sort' => 'is_primary DESC',
+      ],
+    ]);
+    if (!empty($billingAddress['values'])) {
+      $address = array_pop($billingAddress['values']);
+      foreach ($address as $key => $value) {
+        if (in_array($key, $billingFields)) {
+          $address['billing_address_' . $key] = $value;
+        }
+        unset($address[$key]);
+      }
+    }
+    foreach (['first_name', 'middle_name', 'last_name'] as $name) {
+      $address["billing_address_{$name}"] = $this->info['contact'][1]['contact'][1][$name] ?? NULL;
+    }
+    $this->info['contribution'][1]['contribution'][1] = $address;
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -71,6 +71,13 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     }, $opts)));
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
 
+    $this->getSession()->getPage()->selectFieldOption('Enable Billing Address?', 'Yes');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->assertSession()->checkboxChecked("Billing First Name");
+    $this->assertSession()->checkboxChecked("Billing Last Name");
+
     $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -71,13 +71,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     }, $opts)));
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
 
-    $this->getSession()->getPage()->selectFieldOption('Enable Billing Address?', 'Yes');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-
-    $this->assertSession()->checkboxChecked("Billing First Name");
-    $this->assertSession()->checkboxChecked("Billing Last Name");
-
+    $this->enableBillingSection();
     $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
@@ -115,24 +109,17 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
     $this_year = date('Y');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
 
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
@@ -210,6 +197,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
     $this->htmlOutput();
 
+    $this->enableBillingSection();
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
 
@@ -235,24 +223,16 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
     $this_year = date('Y');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -116,14 +116,14 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');
@@ -236,14 +236,14 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -122,6 +122,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     // throw new \Exception(var_export($this->getOptions('Payment Processor'), TRUE));
     $this->assertCount(4, $this->getOptions('Payment Processor'));
     $this->getSession()->getPage()->selectFieldOption('Payment Processor',  $this->payment_processor_faps['id']);
+    $this->enableBillingSection();
 
     $this->saveCiviCRMSettings();
 
@@ -143,25 +144,16 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
 
     $this->filliATSCryptogram();
-
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -228,6 +220,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertCount(4, $this->getOptions('Payment Processor'));
     $this->getSession()->getPage()->selectFieldOption('Payment Processor',  $this->payment_processor_legacy['id']);
 
+    $this->enableBillingSection();
     $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
@@ -265,24 +258,16 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
     $this_year = date('Y');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
 

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -152,14 +152,14 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
 
@@ -273,14 +273,14 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/EventTest.php
+++ b/tests/src/FunctionalJavascript/EventTest.php
@@ -61,6 +61,7 @@ final class EventTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
 
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
+    $this->enableBillingSection();
 
     $this->saveCiviCRMSettings();
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -89,24 +90,16 @@ final class EventTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
     $this_year = date('Y');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/EventTest.php
+++ b/tests/src/FunctionalJavascript/EventTest.php
@@ -97,14 +97,14 @@ final class EventTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -99,14 +99,14 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     // Select2 is being difficult; unhide the country and state/province select.
     $driver = $this->getSession()->getDriver();
     assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('billing_country_id-5').style.display = 'block';");
-    $driver->executeScript("document.getElementById('billing_state_province_id-5').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
+    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
 
-    $this->getSession()->getPage()->fillField('billing_country_id-5', '1228');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
     // Wait for select2's AJAX request.
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("billing_state_province_id-5").options.length > 1');
-    $this->getSession()->getPage()->fillField('billing_state_province_id-5', '1048');
+    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
+    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
 
     $this->getSession()->getPage()->fillField('Postal Code', '53177');
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -61,6 +61,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
     // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page_settings_before_save.png');
+    $this->enableBillingSection();
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
@@ -90,25 +91,16 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
     $this_year = date('Y');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
-    $this->getSession()->getPage()->fillField('Billing First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Billing Last Name', 'Pabst');
-    $this->getSession()->getPage()->fillField('Street Address', '123 Milwaukee Ave');
-    $this->getSession()->getPage()->fillField('City', 'Milwaukee');
-    // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page2.png');
-
-    // Select2 is being difficult; unhide the country and state/province select.
-    $driver = $this->getSession()->getDriver();
-    assert($driver instanceof DrupalSelenium2Driver);
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-country-id').style.display = 'block';");
-    $driver->executeScript("document.getElementById('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id').style.display = 'block';");
-
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-country-id', '1228');
-    // Wait for select2's AJAX request.
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->wait(1000, 'document.getElementById("edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id").options.length > 1');
-    $this->getSession()->getPage()->fillField('edit-civicrm-1-contribution-1-contribution-billing-address-state-province-id', '1048');
-
-    $this->getSession()->getPage()->fillField('Postal Code', '53177');
+    $billingValues = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'street_address' => '123 Milwaukee Ave',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '53177',
+    ];
+    $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -108,6 +108,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->waitForElementVisible('css', '.machine-name-value');
     $element_form->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->pageTextContains('Contact information has been created.');
+    $this->getSession()->wait(2000);
 
     // Put contact elements into new page.
     $contact_information_page_row_handle = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-contact-information"] a.tabledrag-handle');
@@ -115,10 +117,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->sendKeyPress($contact_information_page_row_handle, 38);
     $this->sendKeyPress($contact_information_page_row_handle, 38);
     $this->sendKeyPress($contact_information_page_row_handle, 38);
-    $contact_information_page_row_handle->blur();
     $contact_fieldset_row_handle = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-fieldset-fieldset"] a.tabledrag-handle');
     $this->sendKeyPress($contact_fieldset_row_handle, 39);
-    $contact_fieldset_row_handle->blur();
     $this->getSession()->getPage()->pressButton('Save elements');
     $this->assertSession()->assertWaitOnAjaxRequest();
   }
@@ -136,6 +136,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   protected function sendKeyPress(NodeElement $element, $char, $modifier = '') {
     $element->keyDown($char, $modifier);
     $element->keyUp($char, $modifier);
+    $element->blur();
   }
 
   /**
@@ -341,6 +342,41 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->utils->wf_civicrm_api('Setting', 'create', [
       'enable_components' => $enabledComponents,
     ]);
+  }
+
+  /**
+   * Enable Billing Section on the contribution tab.
+   */
+  protected function enableBillingSection() {
+    $this->getSession()->getPage()->selectFieldOption('Enable Billing Address?', 'Yes');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+    $this->assertSession()->checkboxChecked("Billing First Name");
+    $this->assertSession()->checkboxNotChecked("Billing Middle Name");
+    $this->assertSession()->checkboxChecked("Billing Last Name");
+    $this->assertSession()->checkboxChecked("Street Address");
+    $this->assertSession()->checkboxChecked("Postal Code");
+    $this->assertSession()->checkboxChecked("City");
+    $this->assertSession()->checkboxChecked("Country");
+    $this->assertSession()->checkboxChecked("State/Province");
+  }
+
+  /**
+   * Insert values in billing fields.
+   *
+   * @param array $params
+   */
+  protected function fillBillingFields($params) {
+    $this->getSession()->getPage()->fillField('Billing First Name', $params['first_name']);
+    $this->getSession()->getPage()->fillField('Billing Last Name', $params['last_name']);
+    $this->getSession()->getPage()->fillField('Street Address', $params['street_address']);
+    $this->getSession()->getPage()->fillField('City', $params['city']);
+
+    $this->getSession()->getPage()->selectFieldOption('Country', $params['country']);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('State/Province', $params['state_province']);
+
+    $this->getSession()->getPage()->fillField('Postal Code', $params['postal_code']);
   }
 
 }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -114,6 +114,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     // Move up twice to be the top-most element.
     $this->sendKeyPress($contact_information_page_row_handle, 38);
     $this->sendKeyPress($contact_information_page_row_handle, 38);
+    $this->sendKeyPress($contact_information_page_row_handle, 38);
     $contact_information_page_row_handle->blur();
     $contact_fieldset_row_handle = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-fieldset-fieldset"] a.tabledrag-handle');
     $this->sendKeyPress($contact_fieldset_row_handle, 39);

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -5,9 +5,8 @@
  * Webform CiviCRM module's install, uninstall and upgrade code.
  */
 
-use Drupal\webform_civicrm\Utils;
-use Drupal\node\Entity\Node;
 use Drupal\webform\Entity\Webform;
+use Drupal\Core\Form\FormState;
 
 /**
  * Implements hook_requirements().
@@ -228,6 +227,77 @@ function webform_civicrm_update_8002() {
         }
       }
     }
+    $handler->setConfiguration($config);
+    $webform->save();
+  }
+}
+
+/**
+ * Add Billing fields to the webforms
+ */
+function webform_civicrm_update_8003() {
+  \Drupal::service('civicrm')->initialize();
+  $utils = \Drupal::service('webform_civicrm.utils');
+  $fields = \Drupal::service('webform_civicrm.fields');
+  $fieldOptions = \Drupal::service('webform_civicrm.field_options');
+  $adminForm = \Drupal::service('webform_civicrm.admin_form');
+  $billingFields = ['first_name', 'middle_name', 'last_name', 'street_address', 'postal_code', 'city', 'country_id', 'state_province_id'];
+
+  $ppFormKey = 'civicrm_1_contribution_1_contribution_payment_processor_id';
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    $settings = &$config['webform_civicrm']['settings'] ?? [];
+    $data = $settings['data'] ?? [];
+    $element = $webform->getElement($ppFormKey);
+    $options = [];
+    if (!empty($element)) {
+      $options = $element['#options'] ?? [];
+      if (!empty($element['#civicrm_live_options']) && empty($options)) {
+        $options = $fieldOptions->get(['form_key' => $ppFormKey], 'create', $data);
+      }
+    }
+    if (empty($options) && is_numeric($data['contribution'][1]['contribution'][1]['payment_processor_id'])) {
+      $options[$data['contribution'][1]['contribution'][1]['payment_processor_id']] = '';
+    }
+    if (empty($options)) {
+      continue;
+    }
+    //If any of the payment processor allow billing fields, enable billing on the form.
+    $addBilling = FALSE;
+    foreach ($options as $ppID => $ppName) {
+      $processor = civicrm_api3('PaymentProcessor', 'get', [
+        'id' => $ppID,
+        'billing_mode' => ['IN' => [1, 3]],
+      ]);
+      if (!empty($processor['count'])) {
+        $addBilling = TRUE;
+        break;
+      }
+    }
+    if (!$addBilling || isset($settings['billing_1_number_of_billing'])) {
+      continue;
+    }
+    $enabled = $utils->wf_crm_enabled_fields($webform, NULL, TRUE);
+    $settings['billing_1_number_of_billing'] = 1;
+    $settings['data']['billing']['number_number_of_billing'] = 1;
+    //Fill required keys in settings.
+    foreach ($billingFields as $fld) {
+      $key = "civicrm_1_contribution_1_contribution_billing_address_{$fld}";
+      $settings[$key] = 'create_civicrm_webform_element';
+    }
+    //Insert components in the webform.
+    foreach ($billingFields as $fld) {
+      $field = $fields->get()["contribution_billing_address_{$fld}"] ?? '';
+      $field['form_key'] = "civicrm_1_contribution_1_contribution_billing_address_{$fld}";
+      $adminForm::insertComponent($field, $enabled, $settings, TRUE);
+    }
+    $stub_form = [];
+    $stub_form_state = new FormState();
+    $adminForm->initialize($stub_form, $stub_form_state, $webform);
+    $adminForm->addEnabledElements($enabled);
+
     $handler->setConfiguration($config);
     $webform->save();
   }

--- a/webform_civicrm.routing.yml
+++ b/webform_civicrm.routing.yml
@@ -16,6 +16,7 @@ webform_civicrm.ajax:
   defaults:
     _controller: 'Drupal\webform_civicrm\Controller\AjaxController::handle'
     input: ''
+    isBilling: ''
   requirements:
     _access: 'TRUE'
     _format: 'json'

--- a/webform_civicrm.routing.yml
+++ b/webform_civicrm.routing.yml
@@ -12,7 +12,7 @@ entity.webform.civicrm:
     _permission: 'access CiviCRM'
 
 webform_civicrm.ajax:
-  path: webform-civicrm/js/{key}/{input}
+  path: webform-civicrm/js/{key}/{input}/{isBilling}
   defaults:
     _controller: 'Drupal\webform_civicrm\Controller\AjaxController::handle'
     input: ''


### PR DESCRIPTION
Overview
----------------------------------------
Replace billing fields with webform fields.

Before
----------------------------------------
Billing fields are loaded using ajax call.

After
----------------------------------------

Billing fields are webform fields. Can be modified to use additional webform benefits, eg layout, conditionals, etc.

![image](https://user-images.githubusercontent.com/5929648/115991989-e3561f80-a5e8-11eb-9667-032651b8bf53.png)


