### PR TITLE
D8/9 - Fix pagebreaks on webforms

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -85,9 +85,6 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
 
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
@@ -200,9 +197,6 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->enableBillingSection();
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
-
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -126,9 +126,6 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->saveCiviCRMSettings();
 
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $edit = [
@@ -233,9 +230,6 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
-
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/EventTest.php
+++ b/tests/src/FunctionalJavascript/EventTest.php
@@ -66,9 +66,6 @@ final class EventTest extends WebformCivicrmTestBase {
     $this->saveCiviCRMSettings();
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $edit = [

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -66,9 +66,6 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
 
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     // $this->createScreenshot($this->htmlOutputDirectory . '/membership_page1.png');

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -72,9 +72,6 @@ final class StripeTest extends WebformCivicrmTestBase {
 
     $this->saveCiviCRMSettings();
 
-    // Setup contact information wizard page.
-    $this->configureContactInformationWizardPage();
-
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $edit = [

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -95,35 +95,6 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
-   * Configures contact information fieldset into its own wizard page.
-   */
-  protected function configureContactInformationWizardPage() {
-    $this->drupalGet($this->webform->toUrl('edit-form'));
-
-    // Add the "Contact information" wizard page.
-    $this->getSession()->getPage()->clickLink('Add page');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $element_form = $this->getSession()->getPage()->findById('webform-ui-element-form-ajax');
-    $element_form->fillField('Title', 'Contact information');
-    $this->assertSession()->waitForElementVisible('css', '.machine-name-value');
-    $element_form->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->pageTextContains('Contact information has been created.');
-    $this->getSession()->wait(2000);
-
-    // Put contact elements into new page.
-    $contact_information_page_row_handle = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-contact-information"] a.tabledrag-handle');
-    // Move up twice to be the top-most element.
-    $this->sendKeyPress($contact_information_page_row_handle, 38);
-    $this->sendKeyPress($contact_information_page_row_handle, 38);
-    $this->sendKeyPress($contact_information_page_row_handle, 38);
-    $contact_fieldset_row_handle = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-fieldset-fieldset"] a.tabledrag-handle');
-    $this->sendKeyPress($contact_fieldset_row_handle, 39);
-    $this->getSession()->getPage()->pressButton('Save elements');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-  }
-
-  /**
    * Send a key press to an element.
    *
    * @var \Behat\Mink\Element\NodeElement $element


### PR DESCRIPTION
Overview
----------------------------------------
Properly inject page breaks when contribution is enabled.

Before
----------------------------------------
When the contribution is enabled, the page break is added for payment section, but the contact elements remain as it is. Webform Build page looks like - 

![image](https://user-images.githubusercontent.com/5929648/116807271-ddfc5600-ab4f-11eb-9609-df9d224fb13f.png)

No page is available for contact elements, so when webform is viewed, it all renders on a single page -

![image](https://user-images.githubusercontent.com/5929648/116807296-071ce680-ab50-11eb-8724-3eb81fc5fbe4.png)

There's an easy workaround to create a page manually for contact element, but it should be automized.


After
----------------------------------------
Fixed. Root page added and all other elements are nested on save.

![image](https://user-images.githubusercontent.com/5929648/116807530-4566d580-ab51-11eb-832c-76a0e64ede1e.png)

Webform is loaded as -

![image](https://user-images.githubusercontent.com/5929648/116807541-57487880-ab51-11eb-8d37-caaa50d8e1e8.png)

Comments
----------------------------------------
Works on webforms created after this PR is added. @KarinG 