### PR TITLE
D8/9 - Multi-record custom fields are recorded twice when contributions are enabled

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -137,7 +137,7 @@ class ContactComponent implements ContactComponentInterface {
     }
     // Select results
     else {
-      if ($element['#allow_create']) {
+      if (!empty($element['#allow_create'])) {
         $ret['-'] = Xss::filter($element['#none_prompt']);
       }
       foreach (wf_crm_aval($result, 'values', []) as $contact) {

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -519,12 +519,10 @@ class CivicrmContact extends WebformElementBase {
       $filters = $contactComponent->wf_crm_search_filters($node, $element);
       $element['#options'] = $contactComponent->wf_crm_contact_search($node, $element, $filters, wf_crm_aval($ids, 'contact', []));
       // Display empty option unless there are no results
-      if (!$element['#allow_create'] || count($element['#options']) > 1) {
+      if (empty($element['#allow_create']) || count($element['#options']) > 1) {
         $element['#empty_option'] = Xss::filter($element[$element['#options'] ? '#search_prompt' : '#none_prompt']);
       }
     }
   }
-
-
 
 }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1857,6 +1857,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     ];
     if (!$cid) {
       $cid = $this->createContact($contact);
+      $this->billing_contact = $cid;
     }
     else {
       foreach (['address', 'email'] as $loc) {
@@ -2750,6 +2751,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * @return string $name
    */
   private function getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n): string {
+    // Multi value fields are already saved while creating the billing contact.
+    if ($c == 1 && !empty($this->billing_contact)) {
+      return '';
+    }
+
     $existingValue = NULL;
     if (empty($multivaluesCreateMode) && !empty($this->existing_contacts[$c])) {
       $existingValue = $this->getCustomData($this->existing_contacts[$c], NULL, FALSE)[$table] ?? NULL;

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -372,7 +372,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     }
 
     foreach ($params as $key => $val) {
-      $this->getSession()->getPage()->fillField($key, $val);
+      $this->getSession()->getPage()->replaceFieldValue($key, $val);
       if (strpos($key, 'custom_2') !== false) {
         $this->getSession()->getPage()->selectFieldOption($key, $val);
       }

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -95,11 +95,80 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->_customFields['consultant'] = $result['id'];
   }
 
+  public function testAnonymousSubmitWithContribution() {
+    $payment_processor = $this->createPaymentProcessor();
+
+    $this->_totalMV = 1;
+    $this->createMultiValueCustomFields();
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->enableCustomFields(1, TRUE);
+    $this->htmlOutput();
+
+    //Configure Contribution tab.
+    $this->configureContributionTab();
+    $this->getSession()->getPage()->checkField('Contribution Amount');
+    $this->assertSession()->checkboxChecked('Contribution Amount');
+
+    $this->getSession()->getPage()->selectFieldOption('Payment Processor', $payment_processor['id']);
+
+    $this->saveCiviCRMSettings();
+
+    $this->drupalLogout();
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    $params = [
+      'First Name' => 'Anonymous' . substr(sha1(rand()), 0, 4),
+      'Last Name' => 'Contact' . substr(sha1(rand()), 0, 4),
+      'Email' => 'anonymous' . substr(sha1(rand()), 0, 4) . "@example.com",
+      'Month' => 'January',
+      'civicrm_1_contact_1_cg1_custom_2' => 200,
+    ];
+    $this->submitWebform($params, 'Next >');
+    $this->htmlOutput();
+    $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
+    $this->getSession()->getPage()->fillField('Contribution Amount', 20);
+
+    // Wait for the credit card form to load in.
+    $this->assertSession()->waitForField('credit_card_number');
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '20.00');
+
+    $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
+    $this->getSession()->getPage()->fillField('Security Code', '123');
+    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
+    $this_year = date('Y');
+    $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[Y]', $this_year + 1);
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->htmlOutput();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+
+    $cid = $this->utils->wf_civicrm_api('Contact', 'getsingle', [
+      'first_name' => $params['First Name'],
+      'last_name' => $params['Last Name'],
+    ])['contact_id'];
+
+    $customValues = $this->utils->wf_civicrm_api('CustomValue', 'get', [
+      'entity_id' => $cid,
+    ])['values'];
+    //Assert only 1 multivalue record is created.
+    unset($customValues[$this->_customFields['month']]['latest'], $customValues[$this->_customFields['data']]['latest']);
+    $monthValueCount = array_count_values($customValues[$this->_customFields['month']]);
+    $dataValueCount = array_count_values($customValues[$this->_customFields['data']]);
+    $this->assertEquals($monthValueCount["January"], 1);
+    $this->assertEquals($dataValueCount["200"], 1);
+  }
+
   /**
    * Test submitting Custom Fields
    */
   public function testSubmitWebform() {
-    $totalMV = 5;
+    $this->_totalMV = 5;
     $this->createMultiValueCustomFields();
     $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
@@ -108,41 +177,30 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
 
     $this->enableCivicrmOnWebform();
 
-    $this->getSession()->getPage()->selectFieldOption("number_of_contacts", $totalMV);
+    $this->getSession()->getPage()->selectFieldOption("number_of_contacts", $this->_totalMV);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
 
-    $this->getSession()->getPage()->selectFieldOption("contact_1_number_of_cg{$this->_cgID}", $totalMV);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-
-    // Enable custom fields.
-    foreach ($this->_customFields as $id) {
-      for ($i = 1; $i <= $totalMV; $i++) {
-        $fldName = "civicrm_1_contact_{$i}_cg{$this->_cgID}_custom_{$id}";
-        if ($id == $this->_customFields['consultant']) {
-          $this->getSession()->getPage()->selectFieldOption($fldName, "Contact {$i}");
-        }
-        else {
-          $this->getSession()->getPage()->checkField($fldName);
-          $this->assertSession()->checkboxChecked($fldName);
-        }
-      }
-    }
+    $this->enableCustomFields(1);
     $this->htmlOutput();
 
     $this->getSession()->getPage()->clickLink('Contact 2');
+    $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->checkField('civicrm_2_contact_1_contact_existing');
     $this->assertSession()->checkboxChecked('civicrm_2_contact_1_contact_existing');
+    $this->enableCustomFields(2);
 
     $this->getSession()->getPage()->clickLink('Contact 3');
+    $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->checkField('civicrm_3_contact_1_contact_existing');
     $this->assertSession()->checkboxChecked('civicrm_3_contact_1_contact_existing');
+    $this->enableCustomFields(3);
 
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->editContactElement('edit-webform-ui-elements-civicrm-2-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
+    $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->editContactElement('edit-webform-ui-elements-civicrm-3-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
 
     //Create 2 contacts to fill on the webform.
@@ -154,22 +212,24 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertPageNoErrorMessages();
 
     //Enter values for the custom fields and save.
-    $params = [
-      'Month' => 'Jan',
-      'Month 2' => 'Feb',
-      'Month 3' => 'March',
-      'Month 4' => 'April',
-      'Month 5' => 'May',
-    ];
+    $months = ['Jan', 'Feb', 'March', 'April', 'May'];
     $data = [100, 200];
-    for ($i = 1; $i <= $totalMV; $i++) {
-      $params["civicrm_1_contact_{$i}_cg1_custom_2"] = $data[array_rand($data)];
-      $params["civicrm_{$i}_contact_1_contact_first_name"] = substr(sha1(rand()), 0, 7);
-      $params["civicrm_{$i}_contact_1_contact_last_name"] = substr(sha1(rand()), 0, 7);
+    $params = [];
+    for ($c = 1; $c <= $this->_totalMV; $c++) {
+      if ($c < 4) {
+        for ($i = 1; $i <= $this->_totalMV; $i++) {
+          $params["civicrm_{$c}_contact_{$i}_cg1_custom_1"] = $months[array_rand($months)];
+          $params["civicrm_{$c}_contact_{$i}_cg1_custom_2"] = $data[array_rand($data)];
+        }
+      }
+      else {
+        $params["civicrm_{$c}_contact_1_contact_first_name"] = substr(sha1(rand()), 0, 7);
+        $params["civicrm_{$c}_contact_1_contact_last_name"] = substr(sha1(rand()), 0, 7);
+      }
     }
     $this->submitWebform($params);
 
-    $this->verifyCustomValues($params, $totalMV);
+    $this->verifyCustomValues($params);
 
     //Visit the webform again.
     $this->drupalGet($this->webform->toUrl('canonical'));
@@ -178,32 +238,63 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
 
     // Verify if field values are loaded on the webform.
     foreach ($params as $key => $val) {
-      if (strpos($key, 'Month') !== false) {
-        $this->assertSession()->fieldValueEquals('Month', 'Jan');
-      }
-      elseif (strpos($key, 'custom_') !== false) {
-        $this->assertSession()->elementExists('css', '[name="' . $key . '"][value=' . $val . ']')->isChecked();
+      if (strpos($key, 'civicrm_1_contact') !== false) {
+        if (strpos($key, 'custom_1') !== false) {
+          $this->assertSession()->fieldValueEquals($key, $val);
+        }
+        elseif (strpos($key, 'custom_2') !== false) {
+          $this->assertSession()->elementExists('css', '[name="' . $key . '"][value=' . $val . ']')->isChecked();
+        }
       }
     }
 
     //Update values for the custom fields and save.
-    $params = [
-      'Month' => 'JanEdited',
-      'Month 2' => 'FebEdited',
-      'Month 3' => 'MarchEdited',
-      'Month 4' => 'AprilEdited',
-      'Month 5' => 'MayEdited',
-    ];
+    $months = ['JanEdited', 'FebEdited', 'MarchEdited', 'AprilEdited', 'MayEdited'];
     $data = [100, 200];
-    for ($i = 1; $i <= $totalMV; $i++) {
-      $params["civicrm_1_contact_{$i}_cg1_custom_2"] = $data[array_rand($data)];
-      $params["civicrm_{$i}_contact_1_contact_first_name"] = substr(sha1(rand()), 0, 7);
-      $params["civicrm_{$i}_contact_1_contact_last_name"] = substr(sha1(rand()), 0, 7);
+    $params = [];
+    for ($c = 1; $c <= $this->_totalMV; $c++) {
+      if ($c < 4) {
+        for ($i = 1; $i <= $this->_totalMV; $i++) {
+          $params["civicrm_{$c}_contact_{$i}_cg1_custom_1"] = $months[array_rand($months)];
+          $params["civicrm_{$c}_contact_{$i}_cg1_custom_2"] = $data[array_rand($data)];
+        }
+      }
+      else {
+        $params["civicrm_{$c}_contact_1_contact_first_name"] = substr(sha1(rand()), 0, 7);
+        $params["civicrm_{$c}_contact_1_contact_last_name"] = substr(sha1(rand()), 0, 7);
+      }
     }
     $this->submitWebform($params);
 
     // Check if updated values are stored on the contact.
-    $this->verifyCustomValues($params, $totalMV);
+    $this->verifyCustomValues($params);
+  }
+
+  /**
+   * Enable Custom Fields
+   */
+  private function enableCustomFields($c, $createOnly = FALSE) {
+    $this->getSession()->getPage()->selectFieldOption("contact_{$c}_number_of_cg{$this->_cgID}", $this->_totalMV);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    // Enable custom fields.
+    foreach ($this->_customFields as $id) {
+      for ($i = 1; $i <= $this->_totalMV; $i++) {
+        if ($createOnly) {
+          $this->getSession()->getPage()->selectFieldOption("civicrm_{$c}_contact_{$i}_cg{$this->_cgID}_createmode", "Create Only");
+        }
+
+        $fldName = "civicrm_{$c}_contact_{$i}_cg{$this->_cgID}_custom_{$id}";
+        if ($id == $this->_customFields['consultant']) {
+          $this->getSession()->getPage()->selectFieldOption($fldName, "Contact {$i}");
+        }
+        else {
+          $this->getSession()->getPage()->checkField($fldName);
+          $this->assertSession()->checkboxChecked($fldName);
+        }
+      }
+    }
   }
 
   /**
@@ -211,25 +302,30 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
    *
    * @param array $params
    */
-  private function submitWebform($params) {
+  private function submitWebform($params, $submit = 'Submit') {
+    if (!empty($this->_contact1)) {
+      $this->fillContactAutocomplete('token-input-edit-civicrm-2-contact-1-contact-existing', $this->_contact1['first_name']);
+      $this->fillContactAutocomplete('token-input-edit-civicrm-3-contact-1-contact-existing', $this->_contact2['first_name']);
+    }
+
     foreach ($params as $key => $val) {
       $this->getSession()->getPage()->fillField($key, $val);
-      if (strpos($key, 'custom_') !== false) {
+      if (strpos($key, 'custom_2') !== false) {
         $this->getSession()->getPage()->selectFieldOption($key, $val);
       }
     }
-    $this->fillContactAutocomplete('token-input-edit-civicrm-2-contact-1-contact-existing', $this->_contact1['first_name']);
-    $this->fillContactAutocomplete('token-input-edit-civicrm-3-contact-1-contact-existing', $this->_contact2['first_name']);
 
-    $this->getSession()->getPage()->pressButton('Submit');
+    $this->getSession()->getPage()->pressButton($submit);
     $this->assertPageNoErrorMessages();
-    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    if ($submit == 'Submit') {
+      $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+    }
   }
 
   /**
    * Verify stored values.
    */
-  private function verifyCustomValues($params, $totalMV) {
+  private function verifyCustomValues($params) {
     $customValues = $this->utils->wf_civicrm_api('CustomValue', 'get', [
       'entity_id' => $this->rootUserCid,
     ])['values'];
@@ -237,30 +333,49 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $dataValues = $customValues[$this->_customFields['data']];
     $contactRefValues = $customValues[$this->_customFields['consultant']];
     // Assert if submitted params are present in the custom values.
-    $this->assertEquals($params['Month'], $monthValues[1]);
     $this->assertTrue(in_array($this->_contact1['id'], $contactRefValues));
     $this->assertTrue(in_array($this->_contact2['id'], $contactRefValues));
 
-    for ($i = 1; $i <= $totalMV; $i++) {
-      if ($i != 1) {
-        $this->assertEquals($params["Month {$i}"], $monthValues[$i]);
-      }
-      $this->assertEquals($params["civicrm_1_contact_{$i}_cg1_custom_2"], $dataValues[$i]);
-
+    for ($c = 1; $c <= $this->_totalMV; $c++) {
       $contact = current($this->utils->wf_civicrm_api('Contact', 'get', [
-        'id' => $contactRefValues[$i],
+        'id' => $contactRefValues[$c],
       ])['values']);
-      if ($i == 2) {
-        $this->assertEquals($this->_contact1["first_name"], $contact['first_name']);
-        $this->assertEquals($this->_contact1["last_name"], $contact['last_name']);
-      }
-      elseif ($i == 3) {
-        $this->assertEquals($this->_contact2["first_name"], $contact['first_name']);
-        $this->assertEquals($this->_contact2["last_name"], $contact['last_name']);
+
+      //We have entered multi value fields for only first 3 contacts.
+      if ($c < 4) {
+        for ($i = 1; $i <= $this->_totalMV; $i++) {
+          if ($c == 2) {
+            $cid = $this->_contact1['id'];
+            $this->assertEquals($this->_contact1["first_name"], $contact['first_name']);
+            $this->assertEquals($this->_contact1["last_name"], $contact['last_name']);
+          }
+          elseif ($c == 3) {
+            $cid = $this->_contact2['id'];
+            $this->assertEquals($this->_contact2["first_name"], $contact['first_name']);
+            $this->assertEquals($this->_contact2["last_name"], $contact['last_name']);
+          }
+          $key = $i;
+          if (!empty($cid)) {
+            //Assert custom values stored on 2nd and 3rd contact.
+            $customValues = $this->utils->wf_civicrm_api('CustomValue', 'get', [
+              'entity_id' => $cid,
+            ])['values'];
+            $monthValues = $customValues[$this->_customFields['month']];
+            $dataValues = $customValues[$this->_customFields['data']];
+            unset($monthValues['entity_id'], $monthValues['latest'], $monthValues['id']);
+            $monthValues = array_values($monthValues);
+
+            unset($dataValues['entity_id'], $dataValues['latest'], $dataValues['id']);
+            $dataValues = array_values($dataValues);
+            $key--;
+          }
+          $this->assertEquals($params["civicrm_{$c}_contact_{$i}_cg1_custom_1"], $monthValues[$key]);
+          $this->assertEquals($params["civicrm_{$c}_contact_{$i}_cg1_custom_2"], $dataValues[$key]);
+        }
       }
       else {
-        $this->assertEquals($params["civicrm_{$i}_contact_1_contact_first_name"], $contact['first_name']);
-        $this->assertEquals($params["civicrm_{$i}_contact_1_contact_last_name"], $contact['last_name']);
+        $this->assertEquals($params["civicrm_{$c}_contact_1_contact_first_name"], $contact['first_name']);
+        $this->assertEquals($params["civicrm_{$c}_contact_1_contact_last_name"], $contact['last_name']);
       }
     }
   }

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -139,6 +139,17 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('credit_card_number');
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '20.00');
 
+    $billingValues = [
+      'first_name' => 'The',
+      'last_name' => 'Weeknd',
+      'street_address' => '123 Juno Nominee',
+      'city' => 'Milwaukee',
+      'country' => '1228',
+      'state_province' => '1048',
+      'postal_code' => '12345',
+    ];
+    $this->fillBillingFields($billingValues);
+
     $this->getSession()->getPage()->fillField('Card Number', '4222222222222220');
     $this->getSession()->getPage()->fillField('Security Code', '123');
     $this->getSession()->getPage()->selectFieldOption('credit_card_exp_date[M]', '11');
@@ -147,7 +158,6 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->htmlOutput();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
-
 
     $cid = $this->utils->wf_civicrm_api('Contact', 'getsingle', [
       'first_name' => $params['First Name'],

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -373,7 +373,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     }
 
     foreach ($params as $key => $val) {
-      $this->getSession()->getPage()->addFieldValue($key, $val);
+      $this->addFieldValue($key, $val);
       if (strpos($key, 'custom_2') !== false) {
         $this->getSession()->getPage()->selectFieldOption($key, $val);
       }

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -123,9 +123,9 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertPageNoErrorMessages();
 
     $params = [
-      'First Name' => 'Anonymous' . substr(sha1(rand()), 0, 4),
-      'Last Name' => 'Contact' . substr(sha1(rand()), 0, 4),
-      'Email' => 'anonymous' . substr(sha1(rand()), 0, 4) . "@example.com",
+      'First Name' => 'Justin',
+      'Last Name' => 'Bieber',
+      'Email' => 'justinbieber@example.com',
       'Month' => 'January',
       'civicrm_1_contact_1_cg1_custom_2' => 200,
     ];
@@ -162,7 +162,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $customValues = $this->utils->wf_civicrm_api('CustomValue', 'get', [
       'entity_id' => $cid,
     ])['values'];
-    //Assert only 1 multivalue record is created.
+    // Assert only 1 multivalue record is created.
     unset($customValues[$this->_customFields['month']]['latest'], $customValues[$this->_customFields['data']]['latest']);
     $monthValueCount = array_count_values($customValues[$this->_customFields['month']]);
     $dataValueCount = array_count_values($customValues[$this->_customFields['data']]);

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -142,11 +142,11 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $billingValues = [
       'first_name' => 'The',
       'last_name' => 'Weeknd',
-      'street_address' => '123 Juno Nominee',
-      'city' => 'Milwaukee',
+      'street_address' => 'Raymond James Stadium',
+      'city' => 'Tampa',
       'country' => '1228',
-      'state_province' => '1048',
-      'postal_code' => '12345',
+      'state_province' => '1008',
+      'postal_code' => '33607',
     ];
     $this->fillBillingFields($billingValues);
 

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -109,7 +109,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     //Configure Contribution tab.
-    $this->configureContributionTab();
+    $this->configureContributionTab(TRUE);
     $this->getSession()->getPage()->checkField('Contribution Amount');
     $this->assertSession()->checkboxChecked('Contribution Amount');
 
@@ -152,6 +152,12 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
       'first_name' => $params['First Name'],
       'last_name' => $params['Last Name'],
     ])['contact_id'];
+
+    // Ensure contribution is created on the contact.
+    $contribution = $this->utils->wf_civicrm_api('Contribution', 'getsingle', [
+      'contact_id' => $cid,
+    ]);
+    $this->assertEquals($contribution["total_amount"], '20.00');
 
     $customValues = $this->utils->wf_civicrm_api('CustomValue', 'get', [
       'entity_id' => $cid,

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -123,12 +123,13 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertPageNoErrorMessages();
 
     $params = [
-      'First Name' => 'Justin',
-      'Last Name' => 'Bieber',
-      'Email' => 'justinbieber@example.com',
+      'First Name' => 'The',
+      'Last Name' => 'Weeknd',
+      'Email' => 'theweeknd@example.com',
       'Month' => 'January',
       'civicrm_1_contact_1_cg1_custom_2' => 200,
     ];
+
     $this->submitWebform($params, 'Next >');
     $this->htmlOutput();
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
@@ -372,7 +373,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     }
 
     foreach ($params as $key => $val) {
-      $this->getSession()->getPage()->replaceFieldValue($key, $val);
+      $this->getSession()->getPage()->addFieldValue($key, $val);
       if (strpos($key, 'custom_2') !== false) {
         $this->getSession()->getPage()->selectFieldOption($key, $val);
       }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -312,12 +312,23 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   /**
    * Create test contact of type individual.
    */
-  protected function createIndividual() {
-    $params = [
+  protected function createIndividual($params = []) {
+    $params = array_merge([
       'contact_type' => 'Individual',
       'first_name' => substr(sha1(rand()), 0, 7),
       'last_name' => substr(sha1(rand()), 0, 7),
-    ];
+    ], $params);
+    return current($this->utils->wf_civicrm_api('contact', 'create', $params)['values']);
+  }
+
+  /**
+   * Create test contact of type individual.
+   */
+  protected function createHousehold($params = []) {
+    $params = array_merge([
+      'contact_type' => 'Household',
+      'household_name' => substr(sha1(rand()), 0, 7),
+    ], $params);
     return current($this->utils->wf_civicrm_api('contact', 'create', $params)['values']);
   }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -105,7 +105,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->getSession()->resizeWindow(1440, 900);
   }
 
-  protected function configureContributionTab() {
+  /**
+   * Enable contribution on the webform.
+   */
+  protected function configureContributionTab($disableReceipt = FALSE) {
     //Configure Contribution tab.
     $this->getSession()->getPage()->clickLink('Contribution');
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
@@ -115,6 +118,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
     $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
+
+    if ($disableReceipt) {
+      $this->getSession()->getPage()->selectFieldOption('Enable Billing Address?', 'No');
+      $this->assertSession()->assertWaitOnAjaxRequest();
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix duplicate multivalue records for billing contact

Before
----------------------------------------
Duplicate multi-value records are created for billing contact.

After
----------------------------------------
No duplicates created.


Comments
----------------------------------------
Fixes https://www.drupal.org/project/webform_civicrm/issues/3214105. 