### PR TITLE
dedupe with postal address when sharing is enabled

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -675,7 +675,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         $m = $contact['address'][1]['master_id'];
         // If master address is exposed to the form, use it
         if (!empty($this->data['contact'][$m]['address'][1])) {
-          $contact['address'][1] = $this->data['contact']['address'][1];
+          $contact['address'][1] = $this->data['contact'][$m]['address'][1];
         }
         // Else look up the master contact's address
         elseif (!empty($this->existing_contacts[$m])) {


### PR DESCRIPTION
Overview
----------------------------------------
The postal address is not passed to the Civi dedupe function if "Use shared address" is enabled, and the shared address is present on the form.

Before
----------------------------------------
False positives on dedupe (depending on your dedupe rule of course)

After
----------------------------------------
Address is passed correctly.

Comments
----------------------------------------
This is a pretty obvious fix if you look at the line directly preceding the one I've changed.