### PR TITLE
require any email for contact 1 for billing, not just email 1

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -522,7 +522,7 @@ var wfCiviAdmin = (function ($, D) {
       function billingMessages() {
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_enable_contribution]');
         // Warning about contribution page with no email
-        if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
+        if ($pageSelect.val() !== '0' && ($('[name^=civicrm_1_contact_][name$=_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
           var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(1)});
           if (!$('.wf-crm-billing-email-alert').length) {
             $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
@@ -547,7 +547,7 @@ var wfCiviAdmin = (function ($, D) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $('[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_1_contact_1_email_email]', context).once('email-alert').change(billingMessages);
+      $('[name=civicrm_1_contribution_1_contribution_enable_contribution], [name^=civicrm_1_contact_][name$=_email_email]', context).once('email-alert').change(billingMessages);
       billingMessages();
 
       // Handlers for submit-limit & tracking-mode mini-forms


### PR DESCRIPTION
Overview
----------------------------------------
Currently, if you have this configuration on contact 1:
![Selection_1099](https://user-images.githubusercontent.com/1796012/118683845-b3590100-b7cf-11eb-9d24-dd7828f98be5.png)

You get this error: `You must enable an email field for :contact in order to process transactions.`  However, the forms works if you have *any* email present for contact 1.

This configuration is necessary because email 1 is always set as primary.  In order to keep an existing record's primary email (assuming a dupe is found), you must uncheck "Email 1" and use "Email 2" instead.

Before
----------------------------------------
Configuration above works, but throws an error on every save.


After
----------------------------------------
No error unless ALL email checkboxes are unchecked.
