### PR TITLE
support filling textareas from 'Existing Contact'

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -206,7 +206,7 @@ var wfCivi = (function ($, D) {
         return;
       }
       // First try to find a single element - works for textfields and selects
-      var $el = $('.webform-client-form-'+nid+' :input.civicrm-enabled[name$="'+fid+']"]').not(':checkbox, :radio');
+      var $el = $('.webform-client-form-'+nid+' :input.civicrm-enabled[data-civicrm-field-key="'+fid+'"]').not(':checkbox, :radio');
       if ($el.length) {
         // For chain-select fields, store value for later if it's not available
         if ((fid.substr(fid.length - 9) === 'county_id' || fid.substr(fid.length - 11) === 'province_id') && !$('option[value='+val+']', $el).length) {
@@ -218,6 +218,10 @@ var wfCivi = (function ($, D) {
           }
           else if ($el.is('[type=hidden]')) {
             $el.siblings('.token-input-list').find('p').text(this.display);
+          }
+          // If this is overlaid by a CKEditor textarea, set the CKEditor textarea value.
+          else if ($el.is('textarea.ckeditor-mod.civicrm-enabled')) {
+            CKEDITOR.instances[$el[0].id].setData(val);
           }
           $el.val(val).trigger('change', 'webform_civicrm:autofill');
         }


### PR DESCRIPTION
Overview
----------------------------------------
When you have an "Existing Contact" widget that loads CiviCRM data via AJAX, the `fillValues()` function that populates the form ignores textareas.

Before
----------------------------------------
Textareas are ignored.

After
----------------------------------------
Textareas are populated like other fields.

Technical Details
----------------------------------------
There are two components to this:
* Use `data-civicrm-field-key` instead of `name` to identify elements, the `name` has all sorts of quirks, including with textareas.
* That solved the issue for textareas, but not "HTML Textarea" fields, because we need to feed the data into the WYSIWYG.  So I detect if this is a WYSIWYG field and populate that as well.

Comments
----------------------------------------
I was surprised this worked on D8 - I figured I'd have to patch that then backport - but D8 has a much saner naming convention for elements that avoids this problem.