### PR TITLE
Use text_format type.

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -920,7 +920,7 @@ class Utils implements UtilsInterface {
       'CheckBox' => ['type' => 'select', 'extra' => ['multiple' => 1]],
       'Text'  => ['type' => 'textfield'],
       'TextArea' => ['type' => 'textarea'],
-      'RichTextEditor' => ['type' => \Drupal::moduleHandler()->moduleExists('webform_html_textarea') ? 'html_textarea' : 'textarea'],
+      'RichTextEditor' => ['type' => 'text_format'],
       'Select Date' => ['type' => 'date'],
       'Link'  => ['type' => 'textfield'],
       'Select Country' => ['type' => 'select'],


### PR DESCRIPTION
Overview
----------------------------------------
It seems to be an artifact of the D7 version. It mentions a module named `webform_html_textarea` which I think isn't needed anymore for data types with `RichTextEditor`. It might've been an autofix of a tool.

Before
----------------------------------------
Data type of `RichTextEditor` is always a plain textarea despite its data type.

After
----------------------------------------
Makes data type of `RichTextEditor` use the webform element for `text_format`.

Technical Details
----------------------------------------
_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
