### PR TITLE
D8/9 - Fix duplicates in multi-contact ref records

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2375,19 +2375,20 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $createModeKey = 'civicrm_' . $c . '_contact_' . $n . '_' . $table . '_createmode';
           $multivaluesCreateMode = $this->data['config']['create_mode'][$createModeKey] ?? NULL;
           $cgMaxInstance = $this->all_sets[$table]['max_instances'] ?? 1;
+          $key = $n;
           if (substr($name, 0, 6) == 'custom' && $cgMaxInstance > 1) {
             // Retrieve name for multi value custom fields.
             $customName = $this->getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n);
-            $n = $c;
+            $key = 1;
           }
           if (!empty($this->ent['contact'][$val]['id'])) {
             unset($this->data[$ent][$c][$table][$n][$name]);
             $tableName = substr($name, 0, 6) == 'custom' ? $ent : $table;
             $fld = $customName ?? $name;
-            $this->data[$ent][$c][$tableName][$n][$fld] = $this->ent['contact'][$val]['id'];
+            $this->data[$ent][$c][$tableName][$key][$fld] = $this->ent['contact'][$val]['id'];
           }
           elseif (substr($name, 0, 6) == 'custom') {
-            $this->data[$ent][$c]['update_contact_ref'][] = $name;
+            $this->data[$ent][$c]['update_contact_ref'][$n][$name] = $val;
           }
         }
       }
@@ -2517,7 +2518,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
               // Is this a multi-value custom field?
               if ($cgMaxInstance > 1) {
                 $name = $this->getNameForMultiValueFields($multivaluesCreateMode, $name, $table, $c, $n);
-                $n = $c;
+                $n = 1;
               }
             }
             $this->data[$ent][$c][$ent][$n][$name] = $customValue ?? $val;
@@ -2778,11 +2779,27 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $updateParams = [
       'id' => $cid,
     ];
-    foreach ($params['update_contact_ref'] as $refKey) {
-      foreach ($params['contact'] as $contactParams) {
-        foreach ($contactParams as $key => $value) {
-          if (strpos($key, $refKey) === 0 && !isset($updateParams[$key])) {
-            $updateParams[$key] = $value;
+    $skipKeys = [];
+    foreach ($params['update_contact_ref'] as $n => $refKeys) {
+      foreach ($refKeys as $refKey => $val) {
+        // Skip contact ref that doesn't have a valid contact ids.
+        if (empty($this->ent['contact'][$val]['id'])) {
+          continue;
+        }
+        foreach ($params['contact'] as $contactParams) {
+          foreach ($contactParams as $key => $value) {
+            if (strpos($key, "{$refKey}_") === 0 && !isset($updateParams[$key]) && !in_array($key, $skipKeys)) {
+              //If this is an edit to an existing record, remove any matching keys that was previously set to 'create' new records.
+              if (strpos($key, "{$refKey}_-") !== 0) {
+                foreach ($updateParams as $k => $v) {
+                  if (strpos($k, "{$refKey}_-") === 0) {
+                    $skipKeys[] = $k;
+                    unset($updateParams[$k]);
+                  }
+                }
+              }
+              $updateParams[$key] = $value;
+            }
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix duplicates in multi-contact ref records

Before
----------------------------------------
Possible duplicate record inserted in multi-record custom contact reference fields. To replicate -

- Create custom fields in civi.
- Enable these fields on the webfom. Set the contact ref to any contact enabled on the form.

![image](https://user-images.githubusercontent.com/5929648/120062626-cea1f700-c080-11eb-82a0-d2424a9c656f.png)

- Submit the webform. Notice multiple entries made to civi when only 5 were selected in webfom config.

![image](https://user-images.githubusercontent.com/5929648/120062655-e8dbd500-c080-11eb-8766-f3a605f6348c.png)
 
After
----------------------------------------
Fixed.


Comments
----------------------------------------
@KarinG