### PR TITLE
[Test Only] D8/9 - Add test for radio and checkbox amount widget and address chromedriver 91 issues

### DIFF
--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -57,8 +57,8 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
 
     $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', $this->_caseContact['first_name']);
 
-    $this->assertSession()->fieldValueEquals('First Name', $this->_caseContact['first_name']);
-    $this->assertSession()->fieldValueEquals('Last Name', $this->_caseContact['last_name']);
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', $this->_caseContact['first_name']);
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', $this->_caseContact['last_name']);
 
     $this->getSession()->getPage()->fillField('Case Subject', $caseSubject);
     $this->getSession()->getPage()->pressButton('Submit');

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -145,24 +145,20 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contact['id']]]));
     $this->assertPageNoErrorMessages();
 
-    //Check if no autocomplete is present on the page.
+    // Check if no autocomplete is present on the page.
     $this->assertSession()->elementNotExists('css', '.token-input-list');
 
-    //Check if name fields are pre populated with existing values.
+    // Check if name fields are pre populated with existing values.
     $this->assertSession()->fieldValueEquals('First Name', $contact['first_name']);
     $this->assertSession()->fieldValueEquals('Last Name', $contact['last_name']);
 
-    //Update the name to some other value.
-    $params = [
-      'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
-      'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
-    ];
-    $this->addFieldValue('First Name', $params['first_name']);
-    $this->addFieldValue('Last Name', $params['last_name']);
+    // Update the name to some other value.
+    $this->addFieldValue('First Name', 'Alanis');
+    $this->addFieldValue('Last Name', 'Morissette');
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
-    //Verify if the modified value is updated for the contact.
+    // Verify if the modified value is updated for the contact.
     $contact_result = $this->utils->wf_civicrm_api('contact', 'get', [
       'sequential' => 1,
       'id' => $contact['id'],
@@ -171,12 +167,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
 
     $this->assertArrayHasKey('count', $contact_result, $result_debug);
     $this->assertEquals(1, $contact_result['count'], $result_debug);
-    $this->assertEquals($params['first_name'], $contact_result['values'][0]['first_name'], $result_debug);
-    $this->assertEquals($params['last_name'], $contact_result['values'][0]['last_name'], $result_debug);
+    $this->assertEquals('Alanis', $contact_result['values'][0]['first_name'], $result_debug);
+    $this->assertEquals('Morissette', $contact_result['values'][0]['last_name'], $result_debug);
 
-    //Enable Autocomplete on the contact Element.
+    // Enable Autocomplete on the contact Element.
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    //Assert civicrm elements are not loaded on Add Element form.
+    // Assert CiviCRM elements are not loaded on Add Element form.
     $this->assertSession()->elementExists('css', '#webform-ui-add-element')->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
@@ -205,7 +201,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
 
-    //Check if autocomplete is present on the page.
+    // Check if autocomplete is present on the page.
     $this->assertSession()->elementExists('css', '.token-input-list');
 
     $currentUserUF = $this->getUFMatchRecord($this->rootUser->id());
@@ -214,7 +210,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'return' => "display_name",
     ]);
     $this->assertSession()->elementTextContains('css', '.token-input-token', $currentUserDisplayName);
-    //Clear the existing selection.
+    // Clear the existing selection.
     $this->assertSession()->elementExists('css', '.token-input-delete-token')->click();
 
     $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', $contact_result['values'][0]['first_name']);
@@ -223,13 +219,13 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', $contact_result['values'][0]['first_name']);
     $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', $contact_result['values'][0]['last_name']);
 
-    //Update the name to some other value.
+    // Update the name to some other value.
     $this->addFieldValue('First Name', 'Frederick-Edited');
     $this->addFieldValue('Last Name', 'Pabst-Edited');
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
-    //Verify if the modified value is updated for the contact.
+    // Verify if the modified value is updated for the contact.
     $contact_result2 = $this->utils->wf_civicrm_api('contact', 'get', [
       'sequential' => 1,
       'id' => $contact_result['id'],

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -107,8 +107,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     }
     $this->getSession()->getPage()->selectFieldOption('Existing Contact', $this->contacts[1]['id']);
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+    $params = [
+      'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
+      'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
+    ];
+    $this->getSession()->getPage()->fillField('First Name', $params['first_name']);
+    $this->getSession()->getPage()->fillField('Last Name', $params['last_name']);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -120,8 +124,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $result_debug = var_export($contact_result, TRUE);
 
     $this->assertEquals(1, $contact_result['count'], $result_debug);
-    $this->assertEquals('Frederick', $contact_result['values'][0]['first_name'], $result_debug);
-    $this->assertEquals('Pabst', $contact_result['values'][0]['last_name'], $result_debug);
+    $this->assertEquals($params['first_name'], $contact_result['values'][0]['first_name'], $result_debug);
+    $this->assertEquals($params['last_name'], $contact_result['values'][0]['last_name'], $result_debug);
   }
 
   /**
@@ -151,8 +155,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->fieldValueEquals('Last Name', $contact['last_name']);
 
     //Update the name to some other value.
-    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
-    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+    $params = [
+      'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
+      'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
+    ];
+    $this->getSession()->getPage()->fillField('First Name', $params['first_name']);
+    $this->getSession()->getPage()->fillField('Last Name', $params['last_name']);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -165,8 +173,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
 
     $this->assertArrayHasKey('count', $contact_result, $result_debug);
     $this->assertEquals(1, $contact_result['count'], $result_debug);
-    $this->assertEquals('Frederick', $contact_result['values'][0]['first_name'], $result_debug);
-    $this->assertEquals('Pabst', $contact_result['values'][0]['last_name'], $result_debug);
+    $this->assertEquals($params['first_name'], $contact_result['values'][0]['first_name'], $result_debug);
+    $this->assertEquals($params['last_name'], $contact_result['values'][0]['last_name'], $result_debug);
 
     //Enable Autocomplete on the contact Element.
     $this->drupalGet($this->webform->toUrl('edit-form'));

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -56,7 +56,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
    * Test select contact widget for existingcontact element.
    */
   public function testSelectContactElement() {
-    //create sample contacts.
+    // Create sample contacts.
     $this->createGroupWithContacts();
 
     $this->drupalLogin($this->rootUser);
@@ -67,7 +67,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->enableCivicrmOnWebform();
     $this->saveCiviCRMSettings();
 
-    //Edit contact element and enable select widget.
+    // Edit contact element and enable select widget.
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
     $contactElementEdit->click();
@@ -80,7 +80,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Select List');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    //Filter on group.
+    // Filter on group.
     $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-filters"]')->click();
     $this->getSession()->getPage()->selectFieldOption('Groups', $this->group['id']);
     $this->getSession()->getPage()->pressButton('Save');
@@ -90,12 +90,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
 
-    //Check if no autocomplete is present on the page.
+    // Check if no autocomplete is present on the page.
     $this->assertSession()->elementNotExists('css', '.token-input-list');
-    //Asset if select element is rendered for contact element.
+    // Asset if select element is rendered for contact element.
     $this->assertSession()->elementExists('css', 'select#edit-civicrm-1-contact-1-contact-existing');
 
-    //Check if expected contacts are loaded in the select element.
+    // Check if expected contacts are loaded in the select element.
     $loadedContacts = $this->getOptions('Existing Contact');
     foreach ($this->contacts as $k => $value) {
       if ($k == 5) {
@@ -107,17 +107,14 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     }
     $this->getSession()->getPage()->selectFieldOption('Existing Contact', $this->contacts[1]['id']);
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $params = [
-      'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
-      'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
-    ];
 
-    $this->addFieldValue('First Name', $params['first_name']);
-    $this->addFieldValue('Last Name', $params['last_name']);
+    // Check if we can replace/overwrite the currently loaded values for First Name and Last Name
+    $this->addFieldValue('First Name', 'Jann');
+    $this->addFieldValue('Last Name', 'Arden');
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
-    //Verify if the modified value is updated for the contact.
+    // Verify if the modified value is updated for the contact.
     $contact_result = $this->utils->wf_civicrm_api('contact', 'get', [
       'sequential' => 1,
       'id' => $this->contacts[1]['id'],
@@ -125,8 +122,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $result_debug = var_export($contact_result, TRUE);
 
     $this->assertEquals(1, $contact_result['count'], $result_debug);
-    $this->assertEquals($params['first_name'], $contact_result['values'][0]['first_name'], $result_debug);
-    $this->assertEquals($params['last_name'], $contact_result['values'][0]['last_name'], $result_debug);
+    $this->assertEquals('Jann', $contact_result['values'][0]['first_name'], $result_debug);
+    $this->assertEquals('Arden', $contact_result['values'][0]['last_name'], $result_debug);
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -111,8 +111,9 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
       'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
     ];
-    $this->getSession()->getPage()->fillField('First Name', $params['first_name']);
-    $this->getSession()->getPage()->fillField('Last Name', $params['last_name']);
+
+    $this->addFieldValue('First Name', $params['first_name']);
+    $this->addFieldValue('Last Name', $params['last_name']);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -159,8 +160,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'first_name' => 'Frederick' . substr(sha1(rand()), 0, 7),
       'last_name' => 'Pabst' . substr(sha1(rand()), 0, 7),
     ];
-    $this->getSession()->getPage()->fillField('First Name', $params['first_name']);
-    $this->getSession()->getPage()->fillField('Last Name', $params['last_name']);
+    $this->addFieldValue('First Name', $params['first_name']);
+    $this->addFieldValue('Last Name', $params['last_name']);
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -198,7 +199,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Autocomplete');
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
-    $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
+    $this->addFieldValue('Search Prompt', '- Select Contact -');
 
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
@@ -222,12 +223,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', $contact_result['values'][0]['first_name']);
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    $this->assertSession()->fieldValueEquals('First Name', $contact_result['values'][0]['first_name']);
-    $this->assertSession()->fieldValueEquals('Last Name', $contact_result['values'][0]['last_name']);
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', $contact_result['values'][0]['first_name']);
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', $contact_result['values'][0]['last_name']);
 
     //Update the name to some other value.
-    $this->getSession()->getPage()->fillField('First Name', 'Frederick-Edited');
-    $this->getSession()->getPage()->fillField('Last Name', 'Pabst-Edited');
+    $this->addFieldValue('First Name', 'Frederick-Edited');
+    $this->addFieldValue('Last Name', 'Pabst-Edited');
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
 
@@ -360,13 +361,13 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
         if (is_array($field_value)) {
           foreach ($field_value as $key => $value) {
             $selector = "civicrm_1_contact_1_{$entity_type}_{$key}";
-            $this->getSession()->getPage()->fillField($selector, $value);
+            $this->addFieldValue($selector, $value);
             $this->assertSession()->assertWaitOnAjaxRequest();
           }
         }
         else {
           $selector = "civicrm_1_contact_1_{$entity_type}_{$field_name}";
-          $this->getSession()->getPage()->fillField($selector, $field_value);
+          $this->addFieldValue($selector, $field_value);
         }
       }
     }

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
+
+use Drupal\Core\Url;
+use Drupal\webform\Entity\Webform;
+
+/**
+ * Tests submitting a Webform with CiviCRM: Contribution with Pay later
+ *
+ * @group webform_civicrm
+ */
+final class ContributionPayLaterTest extends WebformCivicrmTestBase {
+
+
+  public function testSubmitContribution() {
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    $this->configureContributionTab(TRUE, 'Pay Later');
+    $this->getSession()->getPage()->checkField('Contribution Amount');
+
+    $this->saveCiviCRMSettings();
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    $this->assertPageNoErrorMessages();
+
+    // Change widget of Amount element to checkbox.
+    $this->changeTypeOfAmountElement('checkboxes');
+    $this->submitWebform('checkboxes');
+    $this->verifyResult();
+
+    // Change widget of Amount element to radios.
+    $this->changeTypeOfAmountElement('radios');
+    $this->submitWebform('radios');
+    $this->verifyResult();
+  }
+
+  /**
+   * Submit the form
+   *
+   * @param string $amountType
+   */
+  protected function submitWebform($amountType) {
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
+    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+    $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+
+    $this->getSession()->getPage()->pressButton('Next >');
+    $this->assertSession()->waitForField('civicrm_1_contribution_1_contribution_total_amount');
+
+    if ($amountType == 'radios') {
+      $this->getSession()->getPage()->selectFieldOption("civicrm_1_contribution_1_contribution_total_amount", 30);
+    }
+    else {
+      $this->getSession()->getPage()->checkField('10');
+      $this->getSession()->getPage()->checkField('20');
+    }
+
+    $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
+    $this->htmlOutput();
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '30.00');
+    $this->getSession()->getPage()->pressButton('Submit');
+
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+  }
+
+  private function verifyResult() {
+    $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
+      'sequential' => 1,
+    ]);
+
+    $this->assertEquals(1, $api_result['count']);
+    $contribution = reset($api_result['values']);
+    $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
+    $this->assertEquals('30.00', $contribution['total_amount']);
+    $this->assertEquals('Pending', $contribution['contribution_status']);
+    $this->assertEquals('USD', $contribution['currency']);
+    $this->utils->wf_civicrm_api('contribution', 'delete', [
+      'id' => $contribution['id'],
+    ]);
+  }
+
+  /**
+   * Change contribution amount widget
+   * to radio or checkbox.
+   */
+  private function changeTypeOfAmountElement($type) {
+    $webform = Webform::load('civicrm_webform_test');
+    $elements = $webform->getElementsInitialized();
+    $elements['contribution_pagebreak']['civicrm_1_contribution_1_contribution_total_amount']['#type'] = $type;
+    $elements['contribution_pagebreak']['civicrm_1_contribution_1_contribution_total_amount']['#webform_plugin_id'] = $type;
+    $elements['contribution_pagebreak']['civicrm_1_contribution_1_contribution_total_amount']['#options'] = [
+      10 => 10,
+      20 => 20,
+      30 => 30,
+    ];
+    $webform->setElements($elements);
+    $webform->save();
+  }
+
+}

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -4,6 +4,7 @@ namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
 
 use Behat\Mink\Element\NodeElement;
 use Drupal\Tests\webform\Traits\WebformBrowserTestTrait;
+use Behat\Mink\Exception\ElementNotFoundException;
 
 abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
@@ -145,6 +146,40 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertCount(0, $error_messages, implode(', ', array_map(static function(NodeElement $el) {
       return $el->getValue();
     }, $error_messages)));
+  }
+
+  /**
+   * Copy of TraversableElement::fillField, but it replaces the existing value on the element rather than appending to it.
+   *
+   * Fills in field (input, textarea, select) with specified locator.
+   *
+   * @param string $locator input id, name or label
+   * @param string $value   value
+   *
+   * @throws ElementNotFoundException
+   *
+   * @see NodeElement::setValue
+   */
+  public function addFieldValue($locator, $value) {
+    $field = $this->getSession()->getPage()->findField($locator);
+    if (null === $field) {
+      throw new ElementNotFoundException($this->getDriver(), 'form field', 'id|name|label|value|placeholder', $locator);
+    }
+    $field->doubleClick();
+    $field->setValue($value);
+  }
+
+  /**
+   * Assert populated values on the field.
+   * fieldValueEquals() fails for populated values on chromedriver > 91
+   *
+   * @param $id
+   * @param $value
+   */
+  public function assertFieldValue($id, $value) {
+    $driver = $this->getSession()->getDriver();
+    $fieldVal = $driver->evaluateScript("document.getElementById('{$id}').value;");
+    $this->assertEquals($fieldVal, $value);
   }
 
   /**

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -105,7 +105,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->getSession()->resizeWindow(1440, 900);
   }
 
-  protected function configureContributionTab() {
+  protected function configureContributionTab($disableReceipt = FALSE, $pp = NULL) {
     //Configure Contribution tab.
     $this->getSession()->getPage()->clickLink('Contribution');
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
@@ -115,6 +115,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
     $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
+
+    if ($pp) {
+      $this->getSession()->getPage()->selectFieldOption('Payment Processor', $pp);
+    }
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add test to verify payments with radio and checkbox widget for contribution amount field.

Before
----------------------------------------
No test.

After
----------------------------------------
Test added.

Comments
----------------------------------------
This needed an extra fix in D7 - https://github.com/colemanw/webform_civicrm/pull/398 and https://github.com/colemanw/webform_civicrm/pull/555. But works fine in D8 without any extra handling since the fieldset holds the `civicrm-field-key` by default.

@KarinG 