### PR TITLE
D8/9 - Fix issues with 'Existing Contact' element

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -2,8 +2,11 @@
   D.behaviors.webform_civicrm_contact = {
     attach: function (context) {
       $('[data-civicrm-contact]', context).once('webform_civicrm_contact').each(function (i, el) {
-        var toHide = []
-        var field = $(el)
+        var field = $(el);
+        var toHide = [];
+        if (field.data('hide-fields')) {
+          toHide = field.data('hide-fields').split(', ');
+        }
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));
         var isSelect = field.data('is-select');
         if (!isSelect) {

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -171,12 +171,11 @@ var wfCivi = (function ($, D, drupalSettings) {
         var type = (n[6] === 'name') ? 'name' : n[4];
         if ($.inArray(type, toHide) >= 0) {
           var fn = (op === 'hide' && (!showEmpty || !isFormItemBlank($el))) ? 'hide' : 'show';
-          // What is webformProp?
-          // $(':input', $el).webformProp('disabled', fn === 'hide');
-          // $(':input', $el).webformProp('readonly', fn === 'hide');
+          $(':input', $el).prop('disabled', fn === 'hide');
+          $(':input', $el).prop('readonly', fn === 'hide');
           $('select.civicrm-enabled[name*="_address_state_province_id"]').each(function() {
-            // $(this).webformProp('disabled', fn === 'hide');
-            // $(this).webformProp('readonly', fn === 'hide');
+            $(this).prop('disabled', fn === 'hide');
+            $(this).prop('readonly', fn === 'hide');
           });
           if (hideOrDisable === 'hide') {
             $el[fn](speed, function() {$el[fn];});
@@ -234,7 +233,7 @@ var wfCivi = (function ($, D, drupalSettings) {
             $el.tokenInput('clear').tokenInput('add', {id: val, name: this.display});
           }
           else if ($el.is('[type=hidden]')) {
-            $el.siblings('.token-input-list').find('p').text(this.display);
+            $el.parents('.token-input-list').find('p').text(this.display);
           }
           $el.val(val).trigger('change', 'webform_civicrm:autofill');
         }
@@ -255,8 +254,7 @@ var wfCivi = (function ($, D, drupalSettings) {
           // Checkboxes & radios
           else {
             $.each($.makeArray(val), function(k, v) {
-              // What is webformProp?
-              // $(':input[value="'+v+'"]', $wrapper).webformProp('checked', true).trigger('change', 'webform_civicrm:autofill');
+              $(':input[value="'+v+'"]', $wrapper).prop('checked', true).trigger('change', 'webform_civicrm:autofill');
             });
           }
         }
@@ -275,8 +273,7 @@ var wfCivi = (function ($, D, drupalSettings) {
   }
 
   function populateStates(stateSelect, countryId) {
-    // What is webformProp?
-    // $(stateSelect).webformProp('disabled', true);
+    $(stateSelect).prop('disabled', true);
     var is_billing = stateSelect.attr('name').indexOf("billing_address") >= 0;
     if (!is_billing && stateProvinceCache[countryId]) {
       fillOptions(stateSelect, stateProvinceCache[countryId]);
@@ -338,8 +335,7 @@ var wfCivi = (function ($, D, drupalSettings) {
     var fields = $(item).parents('form.webform-submission-form').find('[name*="['+(name.replace('master_id', ''))+'"]').not('[name*=location_type_id]').not('[name*=master_id]').not('[type="hidden"]');
     if (action === 'hide') {
       fields.parent().hide(speed, function() {$(this).css('display', 'none');});
-      // What is webformProp?
-      // fields.webformProp('disabled', true);
+      fields.prop('disabled', true);
     }
     else {
       fields.removeAttr('disabled');
@@ -418,9 +414,8 @@ var wfCivi = (function ($, D, drupalSettings) {
         populateStates($el, countryVal);
 
         if (readOnly) {
-          // What is webformProp?
-          // $el.webformProp('readonly', true);
-          // $el.webformProp('disabled', true);
+          $el.prop('readonly', true);
+          $el.prop('disabled', true);
         }
       });
 

--- a/src/WebformAjax.php
+++ b/src/WebformAjax.php
@@ -154,7 +154,7 @@ class WebformAjax extends WebformCivicrmBase implements WebformAjaxInterface {
           // Populate related contacts
           elseif ($i > $c && $field == 'existing') {
             $related_component = $this->getComponent($fid);
-            if (wf_crm_aval($related_component['extra'], 'default') == 'relationship') {
+            if (isset($related_component['#default']) && $related_component['#default'] == 'relationship') {
               $old_related_cid = wf_crm_aval($this->ent, "contact:$i:id");
               // Don't be fooled by old data
               $related_component['extra']['allow_url_autofill'] = FALSE;

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -567,7 +567,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             }
           }
           if ($name == 'existing') {
-            CivicrmContact::wf_crm_fill_contact_value($this->node, $component, $element, $this->ent);
+            CivicrmContact::wf_crm_fill_contact_value($this->node, $element, $this->ent);
           }
         }
       }

--- a/templates/webform-civicrm-contact.html.twig
+++ b/templates/webform-civicrm-contact.html.twig
@@ -12,8 +12,20 @@
  * @ingroup themeable
  */
 #}
-<ul class="token-input-list">
-  <li class="token-input-input-token">
-    <input{{ attributes }} />{{ children }}
-  </li>
-</ul>
+{% if attributes['type'] == 'hidden' and attributes['title'] %}
+  <b>{{ attributes['title'] }}</b>
+{% endif %}
+
+{# Static contact widget with no contact id loaded on the webform. #}
+{% if attributes['cid'] is empty %}
+  <ul class="token-input-list">
+    <li class="token-input-token">
+      {% if attributes['value'] is empty and attributes['type'] == 'hidden' and attributes['data-civicrm-name'] %}
+        <p>{{attributes['data-civicrm-name']}}</p>
+      {% endif %}
+      <input{{ attributes }} />{{ children }}
+    </li>
+  </ul>
+{% else %}
+  <input{{ attributes }} />{{ children }}
+{% endif %}

--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -36,8 +36,12 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
 
     //Edit contact element and remove default section.
     $this->drupalGet($this->webform->toUrl('edit-form'));
-
-    $this->editContactElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
+    $editContact = [
+      'selector' => "edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations",
+      'widget' => 'Autocomplete',
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
 
     $caseSubject = "Test Case" . substr(sha1(rand()), 0, 7);
     $this->submitCaseAndVerifyResult($caseSubject);

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -258,7 +258,12 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $this->editContactElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations', 'Static', 'Current User');
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Static',
+      'default' => 'Current User',
+    ];
+    $this->editContactElement($editContact);
     $this->assertSession()->pageTextContains('Existing Contact has been updated');
     $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-contact-preferred-communication-method-operations', FALSE);
 

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -216,7 +216,12 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
       $params = ['household_name' => "HH{$c}"];
       $this->_hh[$c] = $this->createHousehold($params);
       $this->drupalGet($this->webform->toUrl('edit-form'));
-      $this->editContactElement("edit-webform-ui-elements-civicrm-{$c}-contact-1-contact-existing-operations", 'Select', '- None -');
+      $editContact = [
+        'selector' => "edit-webform-ui-elements-civicrm-{$c}-contact-1-contact-existing-operations",
+        'widget' => 'Select',
+        'default' => '- None -',
+      ];
+      $this->editContactElement($editContact);
     }
     $this->htmlOutput();
 
@@ -273,9 +278,20 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $this->editContactElement('edit-webform-ui-elements-civicrm-2-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-2-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
+
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $this->editContactElement('edit-webform-ui-elements-civicrm-3-contact-1-contact-existing-operations', 'Autocomplete', '- None -');
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-3-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
 
     //Create 2 contacts to fill on the webform.
     $this->_contact1 = $this->createIndividual();


### PR DESCRIPTION
Overview
----------------------------------------
Fix issues with 'Existing Contact' element

Details
----------------------------------------
### **Problem 1.** 

If `Display Contact Name` is set to Yes for the Existing Contact Element and `Static` Form widget - The label of the field is missing - 

**Before** - 

![image](https://user-images.githubusercontent.com/5929648/121007078-440f7500-c7af-11eb-9b16-761c59ccfbb7.png)

**After** -

![image](https://user-images.githubusercontent.com/5929648/121007147-5689ae80-c7af-11eb-9835-22a798ab0df7.png)

It works fine for other widgets like Select, autocomplete etc.

----------------------------------------
### **Problem 2**

For `Form Widget` = Static - If no contact is loaded on the webform, the static widget loads as empty even if it is set to Show in config (`Display Contact Name ` = Yes). It does NOT show the no result text but is just blank (and missing the title) so doesn't look like it's there.

**Before** -

![image](https://user-images.githubusercontent.com/5929648/121007732-c9932500-c7af-11eb-8236-9529800c3770.png)


**After** -

![image](https://user-images.githubusercontent.com/5929648/121007829-e4fe3000-c7af-11eb-8097-f8e3dde15154.png)

----------------------------------------
### **Problem 3**

Related Contact is not loaded if main contact is selected via autocomplete (works fine via URL load).

To replicate 

- Set default on contact 3 element to load as the child contact of main contact 1.

![image](https://user-images.githubusercontent.com/5929648/121008359-88e7db80-c7b0-11eb-825f-44dbc73def68.png)

- Remove default load on primary contact.

Load the webform. Select Primary contact via autocomplete -

![image](https://user-images.githubusercontent.com/5929648/121008707-eaa84580-c7b0-11eb-8d3e-9a681ab6c1ca.png)

Related Contact is not filled with ajax response.

**After**

Immediately after selecting the primary contact - the child contact is loaded -

![image](https://user-images.githubusercontent.com/5929648/121009049-512d6380-c7b1-11eb-9dd4-c85a960d69fa.png)

----------------------------------------

### **Problem 4** -

**Before** - No options are loaded to hide/lock fields on contact element.

![image](https://user-images.githubusercontent.com/5929648/121009197-81750200-c7b1-11eb-9767-d3b3eba44ad3.png)

**After -**

![image](https://user-images.githubusercontent.com/5929648/121009505-dfa1e500-c7b1-11eb-94c5-ab23993368b3.png)


Comments
----------------------------------------
Here's a [test form](https://gist.githubusercontent.com/jitendrapurohit/670e6829bc26e07cfd7cff3aee3858c1/raw/1b6104def299a8560e21f36ffcc38f2126f193ea/webform_contact_element.yml) to replicate all the above issues on a single webform.