### PR TITLE
Up CiviCRM rc to 5.39.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - drupal: '^9.1'
             civicrm: '~5.36'
           - drupal: '^9.1'
-            civicrm: '5.38.x-dev'
+            civicrm: '5.39.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:


### PR DESCRIPTION
Overview
----------------------------------------
CiviCRM RC is now 5.39
