### PR TITLE
D8/9 - Fix missing #options in civicrm_options element

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2223,11 +2223,12 @@ class AdminForm implements AdminFormInterface {
     }
     // Retrieve option list
     if ($field['type'] === 'select') {
+      //To-do: Make this as a default type in src/Fields.php.
+      $field['type'] = 'civicrm_options';
       if ($options = $utils->wf_crm_field_options($field, 'component_insert', $settings['data'])) {
         $field['options'] = $options;
         $field['extra']['items'] = $utils->wf_crm_array2str($options);
         $field['extra']['aslist'] = $field['extra']['aslist'] ?? FALSE;
-        $field['type'] = 'civicrm_options';
       }
     }
     if ($field['type'] === 'civicrm_contact') {

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -146,6 +146,10 @@ class CivicrmOptions extends OptionsBase {
     if (!isset($properties['#civicrm_live_options'])) {
       $properties['#civicrm_live_options'] = $form_state->getValues()['civicrm_live_options'] ?? 0;
     }
+    // Make sure options are available on the element.
+    if (!isset($properties['#options'])) {
+      $properties['#options'] = $this->getFieldOptions($properties);
+    }
     return $properties;
   }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -218,14 +218,14 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
       $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
       $this->htmlOutput();
+      if (!$multiple) {
+        $this->getSession()->getPage()->uncheckField('properties[extra][multiple]');
+        $this->assertSession()->checkboxNotChecked('properties[extra][multiple]');
+      }
     }
     if ($multiple) {
       $this->getSession()->getPage()->checkField('properties[extra][multiple]');
       $this->assertSession()->checkboxChecked('properties[extra][multiple]');
-    }
-    elseif (!$type || $type == 'civicrm-options') {
-      $this->getSession()->getPage()->uncheckField('properties[extra][multiple]');
-      $this->assertSession()->checkboxNotChecked('properties[extra][multiple]');
     }
     $this->htmlOutput();
     $this->getSession()->getPage()->pressButton('Save');


### PR DESCRIPTION
Overview
----------------------------------------
Fix missing #options in civicrm_options element

Before
----------------------------------------
To replicate

- Create a form with a CRM Options element
- Add a Visible conditional to that field
- Remove that conditional
- The edit buttons on the form can then no longer be accessed.

Another way to replicate - 

- Add a new custom field of type select with no options.
- Add this custom field on the webform from the settings page.
- Try to edit any element => Error.

It replicates for any option element. Eg if a user adds an event dropdown but there are no existing events in civicrm, the webform would lead to an error. Similarly for campaign_id dropdown, etc.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
The change ensures #options are always set on the civicrm_option element.

Comments
----------------------------------------
@KarinG 