### PR TITLE
D8/9 - Move civi tab from inside 'Settings' to the top level

### DIFF
--- a/webform_civicrm.links.task.yml
+++ b/webform_civicrm.links.task.yml
@@ -1,5 +1,5 @@
 entity.webform.settings_civicrm:
   title: 'CiviCRM'
   route_name: entity.webform.civicrm
-  parent_id: entity.webform.settings
+  base_route: entity.webform.canonical
   weight: 50


### PR DESCRIPTION
Overview
----------------------------------------
Move civi tab from inside 'Settings' to the top level

Before
----------------------------------------
Civi tab available under settings.

![image](https://user-images.githubusercontent.com/5929648/121875626-4b420000-cd26-11eb-98ca-c2ec13ac39d3.png)


After
----------------------------------------
CiviCRM setting tab is moved to the base route similar to what we had in D7.

![image](https://user-images.githubusercontent.com/5929648/121875534-31a0b880-cd26-11eb-918a-9b32e4ae4675.png)

Comments
----------------------------------------
@KarinG Seems valid? Not sure why it was sitting under the settings tab. It always required an extra click to arrive at the civi config form.