### PR TITLE
D8/9 - Fix amount calculation for radio_other widget

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -469,6 +469,9 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             'cid' => '@todo what is the CID?'
           ];
           $element['#attributes']['class'][] = 'civicrm-enabled';
+          if ($element['#type'] == 'webform_radios_other') {
+            $element['other']['#attributes']['class'][] = 'civicrm-enabled';
+          }
           $dt = NULL;
           if (!empty($field['data_type'])) {
             $dt = $element['#civicrm_data_type'] = $field['data_type'];

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -36,6 +36,11 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->changeTypeOfAmountElement('radios');
     $this->submitWebform('radios');
     $this->verifyResult();
+
+    // Change widget of Amount element to radio + other.
+    $this->changeTypeOfAmountElement('webform_radios_other');
+    $this->submitWebform('webform_radios_other');
+    $this->verifyResult();
   }
 
   /**
@@ -55,6 +60,11 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
     if ($amountType == 'radios') {
       $this->getSession()->getPage()->selectFieldOption("civicrm_1_contribution_1_contribution_total_amount", 30);
+    }
+    elseif ($amountType == 'webform_radios_other') {
+      $this->getSession()->getPage()->selectFieldOption("civicrm_1_contribution_1_contribution_total_amount[radios]", '_other_');
+      $this->assertSession()->waitForField('civicrm_1_contribution_1_contribution_total_amount[other]');
+      $this->getSession()->getPage()->fillField('civicrm_1_contribution_1_contribution_total_amount[other]', '30');
     }
     else {
       $this->getSession()->getPage()->checkField('10');


### PR DESCRIPTION
Overview
----------------------------------------
Fix amount calculation for radio_other widget

Before
----------------------------------------
Contribution Amount radio + other doesn't populate the total amount.

![image](https://user-images.githubusercontent.com/5929648/122675327-8648a580-d1f6-11eb-823c-20b47c5b6fd5.png)

After
----------------------------------------
Fixed -

![image](https://user-images.githubusercontent.com/5929648/122675346-952f5800-d1f6-11eb-84e7-833b2a72cfe2.png)


Comments
----------------------------------------
@KarinG 