### PR TITLE
D8/9 - Fix incorrect validation error when non US country is selected

### DIFF
--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -43,6 +43,7 @@ class AjaxController implements ContainerInjectionInterface {
   public function handle($key, $input = '', $isBilling = FALSE) {
     $this->civicrm->initialize();
     if ($key === 'stateProvince') {
+      $isBilling = ($isBilling === 'false') ? FALSE : $isBilling;
       return $this->stateProvince($input, $isBilling);
     }
     elseif ($key === 'county') {

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -20,6 +20,12 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     ]));
     $this->enableCivicrmOnWebform();
 
+    //Enable Address fields.
+    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_address', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->checkField('Country');
+    $this->assertSession()->checkboxChecked('Country');
+
     $this->configureContributionTab(TRUE, 'Pay Later');
     $this->getSession()->getPage()->checkField('Contribution Amount');
 
@@ -54,9 +60,13 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+    $this->getSession()->getPage()->selectFieldOption("Country", 'United Kingdom');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('State/Province', 'Newport');
 
     $this->getSession()->getPage()->pressButton('Next >');
     $this->assertSession()->waitForField('civicrm_1_contribution_1_contribution_total_amount');
+    $this->assertPageNoErrorMessages();
 
     if ($amountType == 'radios') {
       $this->getSession()->getPage()->selectFieldOption("civicrm_1_contribution_1_contribution_total_amount", 30);
@@ -94,6 +104,18 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->utils->wf_civicrm_api('contribution', 'delete', [
       'id' => $contribution['id'],
     ]);
+
+    $address = $this->utils->wf_civicrm_api('Address', 'get', [
+      'sequential' => 1,
+    ])['values'][0];
+    $country = $this->utils->wf_civicrm_api('Country', 'get', [
+      'name' => "United Kingdom",
+    ]);
+    $state = $this->utils->wf_civicrm_api('StateProvince', 'get', [
+      'name' => "Newport",
+    ]);
+    $this->assertEquals($country['id'], $address['country_id']);
+    $this->assertEquals($state['id'], $address['state_province_id']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix validation error on submitting the webform with Country != US.

Before
----------------------------------------
Validation error when country = UK or any value except the default US -

![image](https://user-images.githubusercontent.com/5929648/123506815-b1fade00-d683-11eb-8b67-1e98953da044.png)

After
----------------------------------------
Fixed.


Comments
----------------------------------------
@KarinG 