### PR TITLE
D8/9 - Allow existing relationships to expire on webform submission.

### DIFF
--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -312,6 +312,16 @@ class AdminHelp implements AdminHelpInterface {
     $this->fee();
   }
 
+  protected function relationship_relationship_type_id() {
+    return '<p>' .
+      t('Click the + button to select more than one option.') .
+      '</p><p>' .
+      t('You may set options here and/or add this element to the webform ("User Select"). Options chosen here will be applied automatically and will not appear on the form.') .
+      '</p><p>' .
+      t('If relationship types are added as "-User Select-", un-selected options from the webform will expire the existing relationship on the contact.') .
+      '</p>';
+  }
+
   protected function multiselect_options() {
     return '<p>' .
       t('Click the + button to select more than one option.') .

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -494,11 +494,15 @@ abstract class WebformCivicrmBase {
    *   Contact id
    * @param $cid2
    *   Contact id
+   * @param $active_only
+   *   if TRUE - only active relationships are returned.
    * @return array
    */
-  protected function getRelationship($r_types, $cid1, $cid2) {
+  protected function getRelationship($r_types, $cid1, $cid2, $active_only = FALSE) {
     $found = [];
-    $active_only = !empty($this->settings['create_new_relationship']);
+    if (!$active_only) {
+      $active_only = !empty($this->settings['create_new_relationship']);
+    }
     $utils = \Drupal::service('webform_civicrm.utils');
 
     if ($r_types && $cid1 && $cid2) {


### PR DESCRIPTION
Overview
----------------------------------------
Allow existing relationships to expire on webform submission.

Before
----------------------------------------
In a webform where Contact 2 is e.g. Emergency Contact -> everything works great -> except for the part that if I want to remove a relationship (User Select on the webform) -> e.g. Melanie is no longer my Partner -> if I uncheck the box Partner off -> that Relationship continues to exist and will continue to prefill when the form is loaded -> so I can add checkboxes but can’t remove any. 

After
----------------------------------------
On submit, unselected relationship types are expired.

Comments
----------------------------------------
@KarinG 