### PR TITLE
D8/9 - Do not save setting data before confirmation

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1813,6 +1813,7 @@ class AdminForm implements AdminFormInterface {
       $this->form_state->set('msg', $msg);
       $this->form_state->set('vals', $this->settings);
       $this->form_state->setRebuild(TRUE);
+      $this->confirmPage = TRUE;
       return;
     }
 

--- a/src/Form/WebformCiviCRMSettingsForm.php
+++ b/src/Form/WebformCiviCRMSettingsForm.php
@@ -117,9 +117,10 @@ class WebformCiviCRMSettingsForm extends FormBase {
     $handler->setConfiguration($handler_configuration);
 
     $admin_form->postProcess();
-    $webform->save();
-
-    $this->messenger()->addMessage('Saved CiviCRM settings');
+    if (empty($admin_form->confirmPage)) {
+      $webform->save();
+      $this->messenger()->addMessage('Saved CiviCRM settings');
+    }
   }
 
   /**

--- a/tests/src/FunctionalJavascript/SaveSettingsTest.php
+++ b/tests/src/FunctionalJavascript/SaveSettingsTest.php
@@ -43,12 +43,35 @@ final class SaveSettingsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Activity Type', 'Meeting');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    $this->saveCiviCRMSettings();
+    $this->saveCiviCRMSettings(TRUE);
     $this->assertSession()->waitForField('edit-delete');
 
     $this->assertSession()->pageTextContains('These existing fields are no longer needed for CiviCRM processing based on your new form settings');
     $this->assertSession()->pageTextContains('Contact 1 Activity 1: Activity Type');
+    $this->assertSession()->pageTextNotContains('Saved CiviCRM settings');
+
+    // Cancel this action.
+    $this->getSession()->getPage()->pressButton('edit-cancel');
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->waitForField('nid');
+    $this->htmlOutput();
+
+    // Ensure the action was cancelled and activity type is still - User Select -
+    $this->assertSession()->pageTextContains('Cancelled');
+    $this->assertOptionSelected('edit-civicrm-1-activity-1-activity-activity-type-id', '- User Select -');
+    $this->assertOptionSelected('number_of_contacts', 1);
+
+    // Repeat the step and delete activity type element from the page.
+    $this->getSession()->getPage()->selectFieldOption('number_of_contacts', 2);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->getSession()->getPage()->clickLink('Activities');
+    $this->getSession()->getPage()->selectFieldOption('Activity Type', 'Meeting');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->saveCiviCRMSettings(TRUE);
+    $this->assertSession()->waitForField('edit-delete');
 
     $this->getSession()->getPage()->pressButton('edit-delete');
     $this->assertSession()->assertWaitOnAjaxRequest();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -268,10 +268,14 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
   /**
    * Save the settings configured on the civicrm tab.
+   *
+   * @param boolean $fieldDeleted
    */
-  public function saveCiviCRMSettings() {
+  public function saveCiviCRMSettings($fieldDeleted = FALSE) {
     $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    if (!$fieldDeleted) {
+      $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    }
     $this->assertPageNoErrorMessages();
   }
 
@@ -356,6 +360,23 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
     $page->find('xpath', '//li[contains(@class, "token-input-dropdown")][1]')->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
+   * Asserts that a select option in the current page is checked.
+   *
+   * @param string $id
+   *   ID of select field to assert.
+   * @param string $option
+   *   Option to assert.
+   * @param string $message
+   *   (optional) A message to display with the assertion. Do not translate
+   *   messages with t(). If left blank, a default message will be displayed.
+   */
+  protected function assertOptionSelected($id, $option, $message = NULL) {
+    $option_field = $this->assertSession()->optionExists($id, $option);
+    $message = $message ?: "Option $option for field $id is selected.";
+    $this->assertTrue($option_field->hasAttribute('selected'), $message);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix saving setting data before confirmation

Before
----------------------------------------
The data on the setting page is saved before the confirmation page is submitted. To replicate -

- Create a webform and navigate to civicrm settings page.
- Select first name, last name, gender => Save.
- Uncheck Gender checkbox and submit.
- A confirmation page is loaded as shown below -

![image](https://user-images.githubusercontent.com/5929648/124386648-042da600-dcf9-11eb-91b5-531d2509c3b6.png)

Note the status message says, the civicrm setting was saved. Click on Cancel button.

- Gender setting is removed from the page -

Expectation - Gender should remain checked.

After
----------------------------------------
Works fine. The data is only saved when the confirmation page is submitted. 


