### PR TITLE
D8/9 - Ensure default value is not overwritten with contact load via ajax

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -32,7 +32,7 @@
             field.data('no-hide-blank'),
             $(this).val(),
             true,
-            []
+            field.data('form-defaults'),
           );
         });
       });

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -12,6 +12,8 @@ var wfCivi = (function ($, D, drupalSettings) {
 
   pub.existingSelect = function (num, nid, path, toHide, hideOrDisable, showEmpty, cid, fetch, defaults) {
     var formClass = getFormClass(nid);
+    var defaults = $(formClass).data('form-defaults') || {};
+
     if (cid.charAt(0) === '-') {
       resetFields(num, nid, true, 'show', toHide, hideOrDisable, showEmpty, 500, defaults);
       // Fill name fields with name typed
@@ -149,7 +151,7 @@ var wfCivi = (function ($, D, drupalSettings) {
             $('select.civicrm-processed', this).val(setting.defaultCountry).trigger('change', 'webform_civicrm:reset');
           }
           //Set default value if it is specified in component settings.
-          else if ($el.hasClass('webform-component-date') && typeof defaults != "undefined" && defaults.hasOwnProperty(name)) {
+          else if ($el.hasClass('form-date') && typeof defaults != "undefined" && defaults.hasOwnProperty(name)) {
             var date = defaults[name].split('-');
             $el.find('select.year, input.year').val(+date[0]);
             $el.find('select.month').val(+date[1]);

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -356,22 +356,4 @@ class ContactComponent implements ContactComponentInterface {
     }
   }
 
-  /**
-   * Returns a default value for a component.
-   *
-   * @param object $node
-   *
-   * @return array
-   */
-  function wf_crm_get_defaults($node) {
-    $defaults = [];
-    foreach ($node->webform['components'] as $comp) {
-      if (!empty($comp['value'])) {
-        $key = str_replace('_', '-', $comp['form_key']);
-        $defaults[$key] = $comp['type'] == 'date' ? date('Y-m-d', strtotime($comp['value'])) : $comp['value'];
-      }
-    }
-    return $defaults;
-  }
-
 }

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -853,4 +853,23 @@ abstract class WebformCivicrmBase {
     return \CRM_Core_Key::get('CRM_Contribute_Controller_Contribution', TRUE);
   }
 
+  /**
+   * Returns a default value for a component.
+   *
+   * @param object $node
+   *
+   * @return array
+   */
+  function getDefaults() {
+    $defaults = [];
+    $elements = $this->node->getElementsDecodedAndFlattened();
+    foreach ($elements as $comp) {
+      if (!empty($comp['#default_value'])) {
+        $key = str_replace('_', '-', $comp['#form_key']);
+        $defaults[$key] = $comp['#type'] == 'date' ? date('Y-m-d', strtotime($comp['#default_value'])) : $comp['#default_value'];
+      }
+    }
+    return $defaults;
+  }
+
 }

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -84,6 +84,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $this->form['#attributes']['data-civicrm-ids'] = Json::encode($cid_data);
       }
     }
+    $this->form['#attributes']['data-form-defaults'] = Json::encode($this->getDefaults());
     // Early return if the form (or page) was already submitted
     $triggering_element = $this->form_state->getTriggeringElement();
     if ($triggering_element && $triggering_element['#id'] == 'edit-wizard-prev'

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -67,25 +67,16 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->enableCivicrmOnWebform();
     $this->saveCiviCRMSettings();
 
-    // Edit contact element and enable select widget.
     $this->drupalGet($this->webform->toUrl('edit-form'));
-    $contactElementEdit = $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations"] a.webform-ajax-link');
-    $contactElementEdit->click();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
-
-    $this->assertSession()->waitForField('properties[widget]');
-    $this->getSession()->getPage()->selectFieldOption('Form Widget', 'Select List');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-
-    // Filter on group.
-    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-filters"]')->click();
-    $this->getSession()->getPage()->selectFieldOption('Groups', $this->group['id']);
-    $this->getSession()->getPage()->pressButton('Save');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->pageTextContains('Existing Contact has been updated');
+    // Edit contact element and enable select widget.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Select List',
+      'filter' => [
+        'group' => $this->group['id'],
+      ],
+    ];
+    $this->editContactElement($editContact);
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -87,6 +87,10 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
         $this->getSession()->getPage()->selectFieldOption("{$c}_contact_type", 'Household');
         $this->assertSession()->assertWaitOnAjaxRequest();
       }
+      elseif ($c == 3) {
+        $this->getSession()->getPage()->checkField("edit-civicrm-{$c}-contact-1-contact-job-title");
+        $this->assertSession()->checkboxChecked("edit-civicrm-{$c}-contact-1-contact-job-title");
+      }
       $this->getSession()->getPage()->checkField("civicrm_{$c}_contact_1_contact_existing");
       $this->assertSession()->checkboxChecked("civicrm_{$c}_contact_1_contact_existing");
     }
@@ -117,7 +121,18 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     $this->editContactElement($editContact, FALSE);
 
     $this->drupalGet($this->webform->toUrl('edit-form'));
+    // Set a default value for Job title.
+    $this->assertSession()->elementExists('css', "[data-drupal-selector='edit-webform-ui-elements-civicrm-3-contact-1-contact-job-title-operations'] a.webform-ajax-link")->click();
+    $this->assertSession()->waitForElementVisible('xpath', '//a[contains(@id, "--advanced")]');
+    $this->assertSession()->elementExists('xpath', '//a[contains(@id, "--advanced")]')->click();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]')->click();
 
+    $this->getSession()->getPage()->fillField('properties[default_value]', 'Accountant');
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->pageTextContains('Job Title has been updated');
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
     // Edit contact element 4.
     $editContact = [
       'selector' => 'edit-webform-ui-elements-civicrm-4-contact-1-contact-existing-operations',
@@ -147,6 +162,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     // Enter contact 3.
     $this->fillContactAutocomplete('token-input-edit-civicrm-3-contact-1-contact-existing', 'Maarten');
     $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldValue('edit-civicrm-3-contact-1-contact-job-title', 'Accountant');
 
     // Check if related contact is loaded on c4.
     $this->htmlOutput();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -290,6 +290,19 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    * Edit contact element on the build form.
    *
    * @param array $params
+   *   Example Usage -
+   *    $params = [
+   *     'selector' => 'edit-webform-ui-elements-civicrm-4-contact-1-contact-existing-operations',
+   *     'widget' => 'Static',
+   *     'default' => 'relationship',
+   *     'filter' => [
+   *        'group' => group_id,
+   *      ],
+   *     'default_relationship' => [
+   *       'default_relationship_to' => 'Contact 3',
+   *       'default_relationship' => 'Child of Contact 3',
+   *     ],
+   *   ];
    */
   protected function editContactElement($params, $openWidget = TRUE) {
     $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector=\"{$params['selector']}\"] a.webform-ajax-link");
@@ -305,15 +318,17 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->getSession()->getPage()->fillField('title', $params['title']);
     }
 
-    $this->assertSession()->waitForField('properties[widget]');
-    $this->getSession()->getPage()->selectFieldOption('Form Widget', $params['widget']);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    if ($params['widget'] == 'Autocomplete') {
-      $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
-      $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
-    }
-    elseif ($params['widget'] == 'Static') {
+    $this->assertSession()->waitForElementVisible('xpath', '//select[@name="properties[widget]"]');
+    if ($params['widget'] == 'Static') {
       $this->getSession()->getPage()->selectFieldOption('properties[show_hidden_contact]', 1);
+    }
+    else {
+      $this->getSession()->getPage()->selectFieldOption('Form Widget', $params['widget']);
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      if ($params['widget'] == 'Autocomplete') {
+        $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-properties-search-prompt"]');
+        $this->getSession()->getPage()->fillField('Search Prompt', '- Select Contact -');
+      }
     }
     $this->htmlOutput();
 
@@ -326,6 +341,14 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
         $this->getSession()->getPage()->selectFieldOption('properties[default_relationship_to]', $params['default_relationship']['default_relationship_to']);
         $this->assertSession()->assertWaitOnAjaxRequest();
         $this->getSession()->getPage()->selectFieldOption('properties[default_relationship][]', $params['default_relationship']['default_relationship']);
+      }
+    }
+
+    // Apply contact filter.
+    if (!empty($params['filter'])) {
+      if (!empty($params['filter']['group'])) {
+        $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-filters"]')->click();
+        $this->getSession()->getPage()->selectFieldOption('Groups', $params['filter']['group']);
       }
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Ensure default value is not overwritten with contact load via ajax

Before
----------------------------------------
To replicate -

- Create a contact and enable `Job Title` field.
- Change the widget of Existing Contact element to `Autocomplete` and remove any default value from the element. 
- Add a default value to the job title field from the Build page.

![image](https://user-images.githubusercontent.com/5929648/124390587-e9aff880-dd09-11eb-9e92-d79266b0f118.png)

- Load the webform. The default value is correctly loaded on the Job title field.
- Select a contact in the autocomplete field.
- The Job Title field value is removed. Since the selected contact does not have a value in civi.

Expected outcome - The default value should remain unchanged.

After
----------------------------------------
Fixed. The default value is replaced only if the contact has a value stored in civicrm. If no value is returned from civi, the drupal default value is kept as it is. This works fine on d7.

