### PR TITLE
Update outdated link to Webform CiviCRM documentation

### DIFF
--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -24,7 +24,7 @@ class AdminHelp implements AdminHelpInterface {
       '<li>' . t('Enable fields for one or more contacts.') . '</li>' .
       '<li>' . t('Arrange and configure those fields on the "Webform" tab.') . '</li>' .
       '<li>' . t('Click the blue help icons to learn more.') . '</li>' .
-      '<li><a href="https://docs.civicrm.org/sysadmin/en/latest/integration/drupal/webform/" target="_blank">' . t('Read the instructions.') . '</a></li>' .
+      '<li><a href="https://docs.civicrm.org/webform-civicrm/en/latest/" target="_blank">' . t('Read the instructions.') . '</a></li>' .
       '</ul>';
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Drupal issue -> https://www.drupal.org/project/webform_civicrm/issues/3223087

Before
----------------------------------------
In the settings form of Webform CiviCRM, when hovering over “?” beside “Enable CiviCRM Processing”, the hyperlink “Read the instructions” in the pop up help text points to old Drupal 7 documentation. The old link being:
https://docs.civicrm.org/sysadmin/en/latest/integration/drupal/webform/.

After
----------------------------------------
Since this old link is outdated, it has been updated to the link of the current documentation --> https://docs.civicrm.org/webform-civicrm/en/latest/.
After this change, if the user clicks "Read the instructions" in the pop up help text, the user will be redirected to the current documentation.

