### PR TITLE
Changed "Additional Options" tab into "Additional Settings"

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1318,7 +1318,7 @@ class AdminForm implements AdminFormInterface {
     $this->form['additional_options'] = [
       '#type' => 'details',
       '#group' => 'webform_civicrm',
-      '#title' => t('Additional Options'),
+      '#title' => t('Additional Settings'),
       '#attributes' => ['class' => ['civi-icon-prefs']],
     ];
     $this->form['additional_options']['checksum_text'] = [

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -138,7 +138,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
 
     // The label has a <div> in it which can cause weird failures here.
     $this->enableCivicrmOnWebform();
-    $this->getSession()->getPage()->clickLink('Additional Options');
+    $this->getSession()->getPage()->clickLink('Additional Settings');
     $this->assertSession()->elementTextContains('css', '#edit-checksum-text', 'To have this form auto-filled for anonymous users, enable the "Existing Contact" field for Contact 1 and send the following link from CiviMail');
     $this->saveCiviCRMSettings();
 

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -55,7 +55,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("Contribution Amount");
     $this->assertSession()->checkboxChecked("Contribution Amount");
 
-    $this->getSession()->getPage()->clickLink('Additional Options');
+    $this->getSession()->getPage()->clickLink('Additional Settings');
     $this->getSession()->getPage()->checkField("Disable Contact Paging");
     $this->assertSession()->checkboxChecked("Disable Contact Paging");
 


### PR DESCRIPTION
Overview
----------------------------------------
In the webform CiviCRM settings form, the tab named "Additional Options" was renamed to "Additional Settings" as required to resolve an issue in the Webform CiviCRM issue queue assigned to me.

Link of the issue: 
https://www.drupal.org/project/webform_civicrm/issues/3223112 

Before
----------------------------------------
The bottom most tab in the CiviCRM settings form that allows admin users to access additional settings for the webform is named "Additional Options".
![image](https://user-images.githubusercontent.com/60020431/125170969-ec2daa80-e16e-11eb-8be5-ff5c69473ef4.png)

After
----------------------------------------
The bottom most tab in the CiviCRM settings form has now been renamed to "Additional Settings" to make it more clear to the admin user what features that tab provides.
<img width="1123" alt="Screen Shot 2021-07-10 at 11 07 39 AM" src="https://user-images.githubusercontent.com/60020431/125171003-0f585a00-e16f-11eb-982b-89d55cd8db4a.png">


Technical Details
----------------------------------------
This fix involved a simple label change in the AdminForm.php file in the source folder for this project. Where the title of the bottom most tab was renamed from "Additional Options" to "Additional Settings".

Comments
----------------------------------------
_Anything else you would like the reviewer to note_
