### PR TITLE
show backend payment processor name on backend

### DIFF
--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -88,7 +88,12 @@ class FieldOptions implements FieldOptionsInterface {
         $paymentProcessors = $utils->wf_crm_apivalues('PaymentProcessor', 'get', ['is_test' => $params['is_test'] ?? 0, 'is_active' => 1]);
         $paymentProcessors[0]['name'] = $field['exposed_empty_option'];
         foreach ($paymentProcessors as $paymentProcessorID => $paymentProcessor) {
-          $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
+          if ($context === 'config_form') {
+            $ret[$paymentProcessorID] = $paymentProcessor['name'];
+          }
+          else {
+            $ret[$paymentProcessorID] = $paymentProcessor['title'] ?? $paymentProcessor['name'];
+          }
         }
         return $ret;
       }


### PR DESCRIPTION
Overview
----------------------------------------
Payment processors have a backend name and an optional frontend title.  We always display the title if it exists, even on the backend.

Before
----------------------------------------
![Selection_1147](https://user-images.githubusercontent.com/1796012/125838969-930c7bc7-0873-4565-9a15-d3f7c327b9f9.png)


After
----------------------------------------
![Selection_1148](https://user-images.githubusercontent.com/1796012/125839211-e11b453f-bb19-432f-8cd8-72edc3f0bb97.png)


Technical Details
----------------------------------------
The `$context` variable limits this change to the backend.