### PR TITLE
D8/9 - Issues with Contact Element

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -16,8 +16,8 @@
             field.data('form-id'),
             autocompleteUrl,
             toHide, {
-            hintText: "- Choose existing -",
-            noResultsText: "+ Create new +",
+            hintText: field.data('search-prompt'),
+            noResultsText: field.data('none-prompt'),
             searchingText: "Searching..."
           });
         }

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -87,6 +87,9 @@ var wfCivi = (function ($, D, drupalSettings) {
           });
         }
       }
+      if ($field.is('[type=hidden]') && !showHiddenContact) {
+        return;
+      }
       if (tokenInputSettings) {
         tokenInputSettings.queryParam = 'str';
         tokenInputSettings.tokenLimit = 1;

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -101,8 +101,13 @@ class CivicrmContact extends WebformElementBase {
       'hiddenFields' => [],
     ];
     $element['#type'] = $element['#widget'] === 'autocomplete' ? 'textfield' : $element['#widget'];
+    $element['#attributes']['data-hide-fields'] = implode(', ', $this->getElementProperty($element, 'hide_fields'));
+    $element['#attributes']['data-hide-method'] = $this->getElementProperty($element, 'hide_method');
+    $element['#attributes']['data-no-hide-blank'] = (int) $this->getElementProperty($element, 'no_hide_blank');
     $cid = $this->getElementProperty($element, 'default_value');
     list(, $c, ) = explode('_', $element['#form_key'], 3);
+    $element['#attributes']['data-civicrm-contact'] = $c;
+    $element['#attributes']['data-form-id'] = $webform_submission ? $webform_submission->getWebform()->id() : NULL;
     if ($element['#type'] === 'hidden') {
       // User may not change this value for hidden fields
       $element['#value'] = $cid;
@@ -115,11 +120,8 @@ class CivicrmContact extends WebformElementBase {
       $element['#options'] = [];
       $element['#attributes']['data-is-select'] = 1;
     }
-    $element['#attributes']['data-civicrm-contact'] = $c;
-    $element['#attributes']['data-form-id'] = $webform_submission ? $webform_submission->getWebform()->id() : NULL;
-    $element['#attributes']['data-hide-fields'] = implode(', ', $this->getElementProperty($element, 'hide_fields'));
-    $element['#attributes']['data-hide-method'] = $this->getElementProperty($element, 'hide_method');
-    $element['#attributes']['data-no-hide-blank'] = (int) $this->getElementProperty($element, 'no_hide_blank');
+    $element['#attributes']['data-search-prompt'] = $this->getElementProperty($element, 'search_prompt') ?? '- Choose existing -';
+    $element['#attributes']['data-none-prompt'] = $this->getElementProperty($element, 'none_prompt') ?? '+ Create new +';
     if (!empty($cid)) {
       $webform = $webform_submission->getWebform();
       $contactComponent = \Drupal::service('webform_civicrm.contact_component');

--- a/templates/webform-civicrm-contact.html.twig
+++ b/templates/webform-civicrm-contact.html.twig
@@ -6,14 +6,25 @@
  * Available variables:
  * - attributes: A list of HTML attributes for the input element.
  * - children: Optional additional rendered elements.
+ * - description.
+ * - description_display.
+ * - title.
+ * - title_display.
  *
  * @see template_preprocess_input()
  *
  * @ingroup themeable
  */
 #}
+<div{{ title_attributes }}>
 {% if attributes['type'] == 'hidden' and attributes['title'] %}
-  <b>{{ attributes['title'] }}</b>
+  <label><b>{{ attributes['title'] }}</b></label>
+{% endif %}
+
+{% if description_display == 'before' and description.content %}
+  <div{{ description.attributes }}>
+    {{ description.content }}
+  </div>
 {% endif %}
 
 {# Static contact widget with no contact id loaded on the webform. #}
@@ -29,3 +40,11 @@
 {% else %}
   <input{{ attributes }} />{{ children }}
 {% endif %}
+
+{% if description_display == 'after' and description.content %}
+  <div{{ description.attributes }}>
+    {{ description.content }}
+  </div>
+{% endif %}
+
+</div>

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -78,6 +78,9 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     ]));
     // The label has a <div> in it which can cause weird failures here.
     $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_email', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
     $this->getSession()->getPage()->selectFieldOption("number_of_contacts", 4);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
@@ -106,6 +109,8 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
       'title' => 'Primary Contact',
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Static',
+      'description' => 'Description of the static contact element.',
+      'hide_fields' => 'Email',
     ];
     $this->editContactElement($editContact);
 
@@ -155,6 +160,9 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
 
     // Check if static title is displayed.
     $this->assertSession()->pageTextContains('Primary Contact');
+    $this->assertSession()->pageTextContains('Description of the static contact element');
+    //Make sure email field is not loaded.
+    $this->assertFalse($this->getSession()->getDriver()->isVisible($this->cssSelectToXpath('.form-type-email')));
 
     // Check if "None Found" text is present in the static element.
     $this->assertSession()->elementTextContains('css', '[id="edit-civicrm-2-contact-1-fieldset-fieldset"]', '- None Found -');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -318,9 +318,16 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if ($openWidget) {
       $this->assertSession()->waitForElementVisible('css', '[data-drupal-selector="edit-form"]');
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-form"]')->click();
+      $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-field-handling"]')->click();
     }
     if (!empty($params['title'])) {
       $this->getSession()->getPage()->fillField('title', $params['title']);
+    }
+    if (!empty($params['description'])) {
+      $this->fillCKEditor('properties[description][value]', $params['description']);
+    }
+    if (!empty($params['hide_fields'])) {
+      $this->getSession()->getPage()->selectFieldOption('properties[hide_fields][]', $params['hide_fields']);
     }
 
     $this->assertSession()->waitForElementVisible('xpath', '//select[@name="properties[widget]"]');
@@ -384,6 +391,24 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
     $page->find('xpath', '//li[contains(@class, "token-input-dropdown")][1]')->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
+   * Fill CKEditor field.
+   *
+   * @param string $locator
+   * @param string $value
+   */
+  public function fillCKEditor($locator, $value) {
+    $el = $this->getSession()->getPage()->findField($locator);
+    if (empty($el)) {
+      throw new ExpectationException('Could not find WYSIWYG with locator: ' . $locator, $this->getSession());
+    }
+    $fieldId = $el->getAttribute('id');
+    if (empty($fieldId)) {
+      throw new Exception('Could not find an id for field with locator: ' . $locator);
+    }
+    $this->getSession()->executeScript("CKEDITOR.instances[\"$fieldId\"].setData(\"$value\");");
   }
 
   /**

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -394,24 +394,6 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
-   * Fill CKEditor field.
-   *
-   * @param string $locator
-   * @param string $value
-   */
-  public function fillCKEditor($locator, $value) {
-    $el = $this->getSession()->getPage()->findField($locator);
-    if (empty($el)) {
-      throw new ExpectationException('Could not find WYSIWYG with locator: ' . $locator, $this->getSession());
-    }
-    $fieldId = $el->getAttribute('id');
-    if (empty($fieldId)) {
-      throw new Exception('Could not find an id for field with locator: ' . $locator);
-    }
-    $this->getSession()->executeScript("CKEDITOR.instances[\"$fieldId\"].setData(\"$value\");");
-  }
-
-  /**
    * Asserts that a select option in the current page is checked.
    *
    * @param string $id

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -11,6 +11,7 @@ use Drupal\webform\Entity\Webform;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\node\Entity\Node;
+use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
 
 /**
@@ -564,6 +565,30 @@ function _webform_civicrm_status() {
   }
 
   return $status;
+}
+
+/**
+ * Implements hook_preprocess_webform_civicrm_contact().
+ *
+ * @param array $variables
+ */
+function webform_civicrm_preprocess_webform_civicrm_contact(&$variables) {
+  $element = &$variables['element'] ?? NULL;
+
+  if (!empty($element['#description'])) {
+    $variables['description']['content'] = $element['#description'];
+    $variables['description_display'] = $element['#description_display'];
+
+    if (empty($variables['description']['attributes'])) {
+      $variables['description']['attributes'] = new Attribute();
+    }
+    $variables['description']['attributes']->addClass('description');
+  }
+
+  if (!empty($element['#_title_display']) && $element['#_title_display'] == 'inline') {
+    $variables['title_attributes'] = new Attribute();
+    $variables['title_attributes']->addClass('webform-element--title-inline');
+  }
 }
 
 /**


### PR DESCRIPTION
Overview
----------------------------------------
Fix issues with contact element.

Before
----------------------------------------

Test webform to replicate all the below cases - https://gist.githubusercontent.com/jitendrapurohit/46a271b38baf1f9b73954e1935c0b734/raw/506088c072c35df154211e45c1392f03fd12a74d/contact_element

1. Description of static contact element not displayed (Element 1 in the attached webform).
2. Search and None prompt not displayed as per values set on the form (Element 2).

![image](https://user-images.githubusercontent.com/5929648/126033534-f8721e34-a99a-4049-a119-0e993f96c745.png)

3. Locked fields are displayed for static contact elements. Replicate it by passing cid3=xx for 3rd contact element. Email is locked (hidden) for the contact but it is still displayed by default.

![image](https://user-images.githubusercontent.com/5929648/126033550-cf586fca-12dd-4963-b5d2-0d36c3b4c2a2.png)

After
----------------------------------------
Fixed.


