### PR TITLE
D8/9 - Fix display of contribution custom fields as per financial type selected

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1074,20 +1074,37 @@ class AdminForm implements AdminFormInterface {
     }
     // Make sure webform is set-up to prevent credit card abuse.
     $this->checkSubmissionLimit();
+    $financialType = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
     // Add contribution fields
     foreach ($this->sets as $sid => $set) {
-      if ($set['entity_type'] == 'contribution' && (empty($set['sub_types']))) {
-        $this->form['contribution']['sets'][$sid] = [
-          '#type' => 'fieldset',
-          '#title' => $set['label'],
-          '#attributes' => ['id' => $sid, 'class' => ['web-civi-checkbox-set']],
-          'js_select' => $this->addToggle($sid),
-        ];
-        $this->addDynamicCustomSetting($this->form['contribution']['sets'][$sid], $sid, 'contribution', 1);
+      if ($set['entity_type'] == 'contribution' && (empty($set['sub_types']) || in_array($financialType, $set['sub_types']) )) {
+        //Build custom fields as per financial type selected.
+        if (strpos($sid, 'cg') === 0) {
+          $this->form['contribution']['sets']['custom'][$sid] = [
+            '#type' => 'fieldset',
+            '#title' => $set['label'],
+            '#attributes' => ['id' => $sid, 'class' => ['web-civi-checkbox-set']],
+            'js_select' => $this->addToggle($sid),
+          ];
+          $this->addDynamicCustomSetting($this->form['contribution']['sets']['custom'][$sid], $sid, 'contribution', 1);
+        }
+        else {
+          $this->form['contribution']['sets'][$sid] = [
+            '#type' => 'fieldset',
+            '#title' => $set['label'],
+            '#attributes' => ['id' => $sid, 'class' => ['web-civi-checkbox-set']],
+            'js_select' => $this->addToggle($sid),
+          ];
+        }
         if (isset($set['fields'])) {
           foreach ($set['fields'] as $fid => $field) {
             $fid = "civicrm_1_contribution_1_$fid";
-            $this->form['contribution']['sets'][$sid][$fid] = $this->addItem($fid, $field);
+            if (strpos($sid, 'cg') === 0) {
+              $this->form['contribution']['sets']['custom'][$sid][$fid] = $this->addItem($fid, $field);
+            }
+            else {
+              $this->form['contribution']['sets'][$sid][$fid] = $this->addItem($fid, $field);
+            }
           }
         }
       }
@@ -1099,10 +1116,11 @@ class AdminForm implements AdminFormInterface {
     $this->form['contribution']['sets']['contribution']['civicrm_1_contribution_1_contribution_financial_type_id'] = [
       '#type' => 'select',
       '#title' => t('Financial Type'),
-      '#default_value' => wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id'),
+      '#default_value' => $financialType,
       '#options' => $ft_options,
       '#required' => TRUE,
     ];
+    $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_financial_type_id", "..:custom");
 
     //Add Currency.
     $this->form['contribution']['sets']['contribution']['contribution_1_settings_currency'] = [
@@ -1126,6 +1144,10 @@ class AdminForm implements AdminFormInterface {
     ];
     $this->addAjaxItem("contribution:sets", "billing_1_number_of_billing", "billing");
 
+    //Move custom key after billing section.
+    $customFields = $this->form['contribution']['sets']['custom'];
+    unset($this->form['contribution']['sets']['custom']);
+    $this->form['contribution']['sets']['custom'] = $customFields;
     if ($n) {
       // Add contribution fields
       foreach ($this->sets as $sid => $set) {

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -12,8 +12,11 @@ use Drupal\webform\Entity\Webform;
  */
 final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
-
   public function testSubmitContribution() {
+    $this->createFinancialCustomGroup();
+    $this->createFinancialCustomGroup('Donation');
+    $this->createFinancialCustomGroup('Member Dues');
+
     $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
@@ -28,6 +31,16 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
     $this->configureContributionTab(TRUE, 'Pay Later');
     $this->getSession()->getPage()->checkField('Contribution Amount');
+
+    // Change financial type to Member Dues and confirm if its custom field is loaded.
+    $this->getSession()->getPage()->selectFieldOption('Financial Type', 'Member Dues');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->verifyFTCustomSet('Member Dues');
+
+    $this->getSession()->getPage()->selectFieldOption('Financial Type', 'Donation');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->verifyFTCustomSet('Donation');
+    $this->getSession()->getPage()->checkField($this->_customFields['Donation']['label']);
 
     $this->saveCiviCRMSettings();
     $this->drupalGet($this->webform->toUrl('edit-form'));
@@ -84,14 +97,63 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
     $this->htmlOutput();
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '30.00');
-    $this->getSession()->getPage()->pressButton('Submit');
+    $this->getSession()->getPage()->fillField('Donation Custom Field', 'Donation for xyz');
 
+    $this->getSession()->getPage()->pressButton('Submit');
     $this->assertPageNoErrorMessages();
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
   }
 
+  /**
+   * Create custom sets for financial type.
+   *
+   * @param string $ftName
+   */
+  public function createFinancialCustomGroup($ftName = NULL) {
+    $params = [
+      'title' => "{$ftName} Custom Group",
+      'extends' => "Contribution",
+    ];
+    if ($ftName) {
+      $ftId = civicrm_api3('FinancialType', 'get', [
+        'return' => ["id"],
+        'name' => $ftName,
+      ])['id'];
+      $params['extends_entity_column_value'] = $ftId;
+    }
+    $key = $ftName ?? 'all';
+    $this->_customGroup[$key] = reset($this->createCustomGroup($params)['values']);
+
+    // Add custom field.
+    $params = [
+      'custom_group_id' => $this->_customGroup[$key]['id'],
+      'label' => "{$ftName} Custom Field",
+      'data_type' => 'String',
+      'html_type' => 'Text',
+    ];
+    $cf = $this->utils->wf_civicrm_api('CustomField', 'create', $params);
+    $this->assertEquals(0, $cf['is_error']);
+    $this->assertEquals(1, $cf['count']);
+    $this->_customFields[$key] = reset($cf['values']);
+  }
+
+  /**
+   * Confirm custom sets are loaded as per financial type.
+   *
+   * @param string $ftName
+   */
+  public function verifyFTCustomSet($ftName) {
+    $this->assertSession()->elementTextContains('css', '[id="civicrm-ajax-contribution-sets-custom"]', $this->_customGroup[$ftName]['title']);
+    $this->assertSession()->elementTextContains('css', '[id="civicrm-ajax-contribution-sets-custom"]', $this->_customGroup['all']['title']);
+  }
+
+  /**
+   * Check submission results.
+   */
   private function verifyResult() {
+    $cfName = "custom_{$this->_customFields['Donation']['id']}";
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
+      'return' => ["contribution_source", $cfName, "total_amount", "contribution_status_id", "currency", "id"],
       'sequential' => 1,
     ]);
 
@@ -101,6 +163,8 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertEquals('30.00', $contribution['total_amount']);
     $this->assertEquals('Pending', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
+    // Check if financial custom field value is pushed to civi.
+    $this->assertEquals('Donation for xyz', $contribution[$cfName]);
     $this->utils->wf_civicrm_api('contribution', 'delete', [
       'id' => $contribution['id'],
     ]);

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -98,6 +98,7 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '30.00');
     $this->getSession()->getPage()->fillField('Donation Custom Field', 'Donation for xyz');
+    $this->createScreenshot($this->htmlOutputDirectory . '/donation.png');
 
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -116,6 +116,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
     $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
 
     if ($pp) {
       $this->getSession()->getPage()->selectFieldOption('Payment Processor', $pp);


### PR DESCRIPTION
Overview
----------------------------------------
Fix display of contribution custom fields as per financial type selected

Before
----------------------------------------
Contribution custom fields are not available on contribution tab.

After
----------------------------------------
Displayed as per financial type selected.

Comments
----------------------------------------
@KarinG 