### PR TITLE
Added SelectAll SelectNone feature in CiviCRM static options element

### DIFF
--- a/css/webform_civicrm_options.css
+++ b/css/webform_civicrm_options.css
@@ -1,0 +1,4 @@
+/* Edit CiviCRM Options Element */
+#webform-civicrm-options-wrapper .table-select .form-item {
+  display:none;
+}

--- a/js/webform_civicrm_options.js
+++ b/js/webform_civicrm_options.js
@@ -56,9 +56,8 @@ if (typeof jQuery.fn.prop !== 'function') {
         }
       }).change();
 
-     //Currently we are looking at using #tableSelect thus, we are commenting out 'select-all-civi-options' code for now
-     //until we are certain that we can remove it.
-      
+      // Currently we are looking at using #tableSelect thus, we are commenting out 'select-all-civi-options' code for now
+      // until we are certain that we can remove it.
       /**
       $('input.select-all-civi-options').once('wf-civi').change(function() {
         if ($(this).is(':checked') ) {
@@ -68,7 +67,7 @@ if (typeof jQuery.fn.prop !== 'function') {
           $('input.civicrm-enabled, input.select-all-civi-options, input.select-all-civi-defaults').prop('checked', false);
         }
         $('input.civicrm-enabled').change();
-      }); 
+      });
       */
 
       var defaultName = 'civicrm_options_fieldset[civicrm_defaults]';

--- a/js/webform_civicrm_options.js
+++ b/js/webform_civicrm_options.js
@@ -56,6 +56,10 @@ if (typeof jQuery.fn.prop !== 'function') {
         }
       }).change();
 
+     //Currently we are looking at using #tableSelect thus, we are commenting out 'select-all-civi-options' code for now
+     //until we are certain that we can remove it.
+      
+      /**
       $('input.select-all-civi-options').once('wf-civi').change(function() {
         if ($(this).is(':checked') ) {
           $('input.civicrm-enabled, input.select-all-civi-options').prop('checked', true);
@@ -64,7 +68,8 @@ if (typeof jQuery.fn.prop !== 'function') {
           $('input.civicrm-enabled, input.select-all-civi-options, input.select-all-civi-defaults').prop('checked', false);
         }
         $('input.civicrm-enabled').change();
-      });
+      }); 
+      */
 
       var defaultName = 'civicrm_options_fieldset[civicrm_defaults]';
 

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -97,6 +97,7 @@ class CivicrmSelectOptions extends FormElement {
           'group' => 'weight',
         ],
       ],
+      '#value_callback' => [get_called_class(), 'valueCallback'],
     ];
 
     if ($element['#civicrm_live_options']) {

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -101,6 +101,7 @@ class CivicrmSelectOptions extends FormElement {
 
     if ($element['#civicrm_live_options']) {
       $element['options']['#tabledrag'] = [];
+      $element['options']['#tableselect'] = FALSE;
     }
 
     $current_options = $element['#default_value'];

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -39,7 +39,7 @@ class CivicrmSelectOptions extends FormElement {
       // return static::convertOptionsToValues($options, $element['#options_description']);
     }
     elseif (is_array($input) && isset($input['options'])) {
-       return $input['options'];
+      return $input['options'];
     }
     else {
       return $element['#default_value'];
@@ -60,16 +60,14 @@ class CivicrmSelectOptions extends FormElement {
 
     $element['options'] = [
       '#type' => 'table',
-      '#tableselect' => FALSE,
+      '#tableselect' => TRUE,
       '#header' => [
         'item' => [
           'data' => ['#markup' => 'Item',]
         ],
         'enabled' => [
           'data' => [
-              '#type' => 'checkbox',
-              '#checked' => 'checked',
-            '#title' => "<b> ENABLED </b>",
+            '#markup' => 'Enabled',
             '#access' => !$element['#civicrm_live_options'],
           ]
         ],

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -67,7 +67,9 @@ class CivicrmSelectOptions extends FormElement {
         ],
         'enabled' => [
           'data' => [
-            '#markup' => 'Enabled',
+              '#type' => 'checkbox',
+              '#checked' => 'checked',
+            '#title' => "<b> ENABLED </b>",
             '#access' => !$element['#civicrm_live_options'],
           ]
         ],

--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -174,7 +174,7 @@ class CivicrmSelectOptions extends FormElement {
       ];
       $weight++;
     }
-
+    $element['#attached']['library'][] = 'webform_civicrm/civicrmoptions';
     return $element;
   }
 

--- a/webform_civicrm.libraries.yml
+++ b/webform_civicrm.libraries.yml
@@ -32,3 +32,8 @@ civicrm_contact:
     js/webform_civicrm_contact.js: {}
   dependencies:
     - webform_civicrm/forms
+
+civicrmoptions:
+  css:
+    component:
+      css/webform_civicrm_options.css: {}


### PR DESCRIPTION
Drupal Issue URL: https://www.drupal.org/project/webform_civicrm/issues/3224544

Work in progress: Checking off this checkbox will not enable all countries(check off checkboxes below it) like it is supposed to yet.

Overview
----------------------------------------
Added a checkbox beside "ENABLED"  in the static options for the country field. However, the checkbox is not responsive, i.e: clicking it will check itself but it doesn't do anything to the checkboxes below it. 
Expected: Checking off the checkbox should enable all countries (i.e: checkoff all checkboxes associated with countries)
