### PR TITLE
D8/9 - Fix fatal error when no option is selected for radio

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2673,7 +2673,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $data = $webform_submission->getData();
 
     if (!isset($data[$fid])) {
-      return NULL;
+      return [NULL];
     }
 
     // Expects an array.

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -66,6 +66,56 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $result['is_error']);
     $this->assertEquals(1, $result['count']);
 
+    // Add Radio options for empty submission.
+    $result = civicrm_api3('OptionGroup', 'create', [
+      'name' => "test_radio_2",
+      'title' => "Test Radio 2",
+      'data_type' => "String",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "test_radio_2",
+      'name' => "radiooptionone",
+      'label' => "Radio Option One",
+      'value' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "test_radio_2",
+      'name' => "radiooptiontwo",
+      'label' => "Radio Option Two",
+      'value' => 2,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('OptionValue', 'create', [
+      'option_group_id' => "test_radio_2",
+      'name' => "radiooptionthree",
+      'label' => "Radio Option Three",
+      'value' => 3,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $result = civicrm_api3('CustomField', 'create', [
+      'custom_group_id' => "Custom",
+      'label' => "Custom Radio Field test for empty submission",
+      'name' => 'test_radio_2',
+      'html_type' => "Radio",
+      'data_type' => "String",
+      'option_group_id' => "test_radio_2",
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+    $this->_customFields['test_radio_2'] = $result['id'];
+
     $result = civicrm_api3('OptionGroup', 'create', [
       'name' => "checkboxes_1",
       'title' => "Checkboxes",


### PR DESCRIPTION
Overview
----------------------------------------
Fix https://www.drupal.org/project/webform_civicrm/issues/3221922

Before
----------------------------------------
Fatal Error when webform is submitted with no option selected for custom radio field. To replicate -

- Create a new custom field for radio with 3 options.
- Add this field on the webform.
- Submit the webform without selecting any option for this field.
- Fatal Error.

After
----------------------------------------
Submission is done without any issues.

Comments
----------------------------------------
@KarinG 