### PR TITLE
D8/9 - Fix usage of webform_civicrm tokens in emails.

### DIFF
--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -116,6 +116,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     // Ensure option labels are present on result page.
     $this->drupalGet($this->webform->toUrl('results-submissions'));
     $this->htmlOutput();
+    $this->assertSession()->pageTextContains('Frederick Pabst');
     $this->assertSession()->pageTextContains('Major Donor');
     $this->assertSession()->pageTextContains('Volunteer');
     $this->assertSession()->pageTextContains('GroupB');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -478,4 +478,40 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->getSession()->getPage()->fillField('Postal Code', $params['postal_code']);
   }
 
+  /**
+   * Fill CKEditor field.
+   *
+   * @param string $locator
+   * @param string $value
+   */
+  public function fillCKEditor($locator, $value) {
+    $el = $this->getSession()->getPage()->findField($locator);
+    if (empty($el)) {
+      throw new ExpectationException('Could not find WYSIWYG with locator: ' . $locator, $this->getSession());
+    }
+    $fieldId = $el->getAttribute('id');
+    if (empty($fieldId)) {
+      throw new Exception('Could not find an id for field with locator: ' . $locator);
+    }
+    $this->getSession()->executeScript("CKEDITOR.instances[\"$fieldId\"].setData(\"$value\");");
+  }
+
+  /**
+   * Add email handler
+   *
+   * @param array $params
+   */
+  protected function addEmailHandler($params) {
+    $this->drupalGet("admin/structure/webform/manage/civicrm_webform_test/handlers/add/email");
+    if (!empty($params['to_mail'])) {
+      $this->getSession()->getPage()->selectFieldOption('settings[to_mail][select]', $params['to_mail']);
+    }
+
+    $this->getSession()->getPage()->selectFieldOption('edit-settings-body', '_other_');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->fillCKEditor('settings[body_custom_html][value]', $params['body']);
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -11,6 +11,7 @@ use Drupal\webform\Entity\Webform;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Entity\WebformSubmission;
 use Drupal\node\Entity\Node;
+use Drupal\Core\Url;
 
 /**
  * The versions of CiviCRM and WebForm. Min is >=.  Max is <. FALSE = no MAX
@@ -151,27 +152,67 @@ function webform_civicrm_theme() {
  * Display labels for civicrm option element.
  */
 function webform_civicrm_webform_submission_load($entities) {
-  $utils = \Drupal::service('webform_civicrm.utils');
   foreach ($entities as $entity) {
-    $data = $entity->getData();
-    $webform = $entity->getWebform();
-    foreach ($data as $key => $val) {
-      $element = $webform->getElement($key);
-      if ($element['#type'] == 'civicrm_options' && !empty($val)) {
-        if (!empty($element['#webform_multiple'])) {
-          foreach ($val as $k => $v) {
-            if (isset($element['#options'][$v])) {
-              $data[$key][$k] = $element['#options'][$v];
-            }
+    $data = _fillCiviCRMData($entity->getData(), $entity);
+    $entity->setData($data);
+  }
+}
+
+/**
+ * Fill civicrm data to the submission object.
+ *
+ * @param array $data
+ * @param object $webformSubmission
+ */
+function _fillCiviCRMData($data, $webformSubmission) {
+  if (!empty($data['civicrm'])) {
+    return $data;
+  }
+
+  $utils = \Drupal::service('webform_civicrm.utils');
+  $webform = $webformSubmission->getWebform();
+  foreach ($data as $key => $val) {
+    $element = $webform->getElement($key);
+    if (!empty($val) && $element['#type'] == 'civicrm_options') {
+      if (!empty($element['#webform_multiple'])) {
+        foreach ($val as $k => $v) {
+          if (isset($element['#options'][$v])) {
+            $data[$key][$k] = $element['#options'][$v];
           }
         }
-        elseif (isset($element['#options'][$val])) {
-          $data[$key] = $element['#options'][$val];
+      }
+      elseif (isset($element['#options'][$val])) {
+        $data[$key] = $element['#options'][$val];
+      }
+    }
+  }
+
+  $contacts = [];
+  $query = \Drupal::database()->select('webform_civicrm_submissions', 'wcs')
+    ->fields('wcs', ['contact_id', 'civicrm_data'])
+    ->condition('sid', $webformSubmission->id(), '=');
+  $results = $query->execute();
+  while ($content = $results->fetchAssoc()) {
+    $civicrm_data = unserialize($content['civicrm_data']) + ['contact' => []];
+    if ($content['contact_id']) {
+      foreach (explode('-', trim($content['contact_id'], '-')) as $c => $cid) {
+        $civicrm_data['contact'][$c + 1]['id'] = $cid;
+        $civicrm_data['contact'][$c + 1]['display_name'] = '';
+        if ($c == 0 && $cid) {
+          $contacts[$cid] = '';
         }
       }
     }
-    $entity->setData($data);
+    $data['civicrm'] = $civicrm_data;
   }
+  if ($contacts) {
+    // Retrieve contact names and add to submission objects
+    $contacts = $utils->wf_crm_apivalues('contact', 'get', ['id' => ['IN' => array_keys($contacts)]], 'display_name') + $contacts;
+    if (!empty($data['civicrm']['contact'][1]['id'])) {
+      $data['civicrm']['contact'][1]['display_name'] = $contacts[$data['civicrm']['contact'][1]['id']];
+    }
+  }
+  return $data;
 }
 
 /**
@@ -530,43 +571,43 @@ function _webform_civicrm_status() {
  */
 function webform_civicrm_token_info() {
   $info = [];
-  $info['tokens']['submission']['contact-id'] = [
+  $info['contact-id'] = [
     'name' => t('Webform CiviCRM Contacts IDs'),
     'description' => t('The IDs of Contacts that got created after submitting the webform. Replace the "?" with the contact number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  $info['tokens']['submission']['contact-link'] = [
+  $info['contact-link'] = [
     'name' => t('Webform CiviCRM Contacts Links'),
     'description' => t('The links to Contacts that got created after submitting the webform. Replace the "?" with the contact number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  $info['tokens']['submission']['activity-id'] = [
+  $info['activity-id'] = [
     'name' => t('Webform CiviCRM Activity IDs'),
     'description' => t('The IDs of activities that got created after submitting the webform. Replace the "?" with the activity number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  $info['tokens']['submission']['activity-link'] = [
+  $info['activity-link'] = [
     'name' => t('Webform CiviCRM Activity Links'),
     'description' => t('The links to activities that got created after submitting the webform. Replace the "?" with the activity number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  $info['tokens']['submission']['case-id'] = [
+  $info['case-id'] = [
     'name' => t('Webform CiviCRM Case IDs'),
     'description' => t('The IDs of cases that got created after submitting the webform. Replace the "?" with the case number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  $info['tokens']['submission']['case-link'] = [
+  $info['case-link'] = [
     'name' => t('Webform CiviCRM Case Links'),
     'description' => t('The links to cases that got created after submitting the webform. Replace the "?" with the case number starting from 1'),
     'dynamic' => TRUE,
   ];
 
-  return $info;
+  return ['tokens' => ['webform_submission' => $info]];
 }
 
 /**
@@ -579,7 +620,8 @@ function webform_civicrm_tokens($type, $tokens = '', array $data = [], array $op
   }
 
   $replacedTokens = [];
-  $webformSubmissionData = $data['webform-submission'];
+  $webformSubmissionData = $data['webform_submission']->getData();
+  $webformSubmissionData = _fillCiviCRMData($webformSubmissionData, $data['webform_submission']);
 
   $contactIdsReplacedTokens = _webform_civicrm_replaceContactIdTokens($tokens, $webformSubmissionData);
   $replacedTokens = array_merge($replacedTokens, $contactIdsReplacedTokens);
@@ -613,9 +655,8 @@ function webform_civicrm_tokens($type, $tokens = '', array $data = [], array $op
  */
 function _webform_civicrm_isWebformSubmission($tokenType, $webformData) {
   return (
-    $tokenType === 'submission' &&
-    !empty($webformData['webform-submission']) &&
-    \Drupal::state()->get('webform_token_access')
+    $tokenType === 'webform_submission' &&
+    !empty($webformData['webform_submission'])
   );
 }
 
@@ -633,15 +674,15 @@ function _webform_civicrm_isWebformSubmission($tokenType, $webformData) {
 function _webform_civicrm_replaceContactIdTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'contact-id');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'contact-id');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['contact'][$entityID]['id'])) {
-      $contactID = $webformSubmissionData->civicrm['contact'][$entityID]['id'];
+    if (!empty($webformSubmissionData['civicrm']['contact'][$entityID]['id'])) {
+      $contactID = $webformSubmissionData['civicrm']['contact'][$entityID]['id'];
       $tokenNewValue = $contactID;
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
@@ -664,16 +705,19 @@ function _webform_civicrm_replaceContactIdTokens($tokens, $webformSubmissionData
 function _webform_civicrm_replaceContactLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'contact-link');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'contact-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['contact'][$entityID]['id'])) {
-      $contactID = $webformSubmissionData->civicrm['contact'][$entityID]['id'];
-      $tokenNewValue = url("/civicrm/contact/view?reset=1&cid={$contactID}", ['absolute' => TRUE]);
+    if (!empty($webformSubmissionData['civicrm']['contact'][$entityID]['id'])) {
+      $contactID = $webformSubmissionData['civicrm']['contact'][$entityID]['id'];
+      $tokenNewValue = Url::fromUri('internal:/civicrm/contact/view', [
+        'absolute' => TRUE,
+        'query' => ['reset' => 1, 'cid' => $contactID]
+      ])->toString();
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
   }
@@ -695,15 +739,15 @@ function _webform_civicrm_replaceContactLinkTokens($tokens, $webformSubmissionDa
 function _webform_civicrm_replaceActivityIdTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'activity-id');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'activity-id');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['activity'][$entityID]['id'])) {
-      $activityId = $webformSubmissionData->civicrm['activity'][$entityID]['id'];
+    if (!empty($webformSubmissionData['civicrm']['activity'][$entityID]['id'])) {
+      $activityId = $webformSubmissionData['civicrm']['activity'][$entityID]['id'];
       $tokenNewValue = $activityId;
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
@@ -726,16 +770,19 @@ function _webform_civicrm_replaceActivityIdTokens($tokens, $webformSubmissionDat
 function _webform_civicrm_replaceActivityLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'activity-link');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'activity-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['activity'][$entityID]['id'])) {
-      $activityId = $webformSubmissionData->civicrm['activity'][$entityID]['id'];
-      $tokenNewValue = url("/civicrm/activity?action=view&reset=1&id={$activityId}", ['absolute' => TRUE]);
+    if (!empty($webformSubmissionData['civicrm']['activity'][$entityID]['id'])) {
+      $activityId = $webformSubmissionData['civicrm']['activity'][$entityID]['id'];
+      $tokenNewValue = Url::fromUri('internal:/civicrm/activity', [
+        'absolute' => TRUE,
+        'query' => ['action' => 'view', 'reset' => 1, 'id' => $activityId]
+      ])->toString();
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
   }
@@ -757,15 +804,15 @@ function _webform_civicrm_replaceActivityLinkTokens($tokens, $webformSubmissionD
 function _webform_civicrm_replaceCaseIdTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'case-id');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'case-id');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['case'][$entityID]['id'])) {
-      $tokenNewValue = $webformSubmissionData->civicrm['case'][$entityID]['id'];
+    if (!empty($webformSubmissionData['civicrm']['case'][$entityID]['id'])) {
+      $tokenNewValue = $webformSubmissionData['civicrm']['case'][$entityID]['id'];
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
   }
@@ -787,17 +834,25 @@ function _webform_civicrm_replaceCaseIdTokens($tokens, $webformSubmissionData) {
 function _webform_civicrm_replaceCaseLinkTokens($tokens, $webformSubmissionData) {
   $replacedTokens = [];
 
-  $tokenValues = token_find_with_prefix($tokens, 'case-link');
+  $tokenValues = \Drupal::token()->findWithPrefix($tokens, 'case-link');
   if (!$tokenValues) {
     return $replacedTokens;
   }
 
   foreach ($tokenValues as $entityID => $tokenName) {
     $tokenNewValue = '';
-    if (!empty($webformSubmissionData->civicrm['case'][$entityID]['id'])) {
-      $caseID = $webformSubmissionData->civicrm['case'][$entityID]['id'];
+    if (!empty($webformSubmissionData['civicrm']['case'][$entityID]['id'])) {
+      $caseID = $webformSubmissionData['civicrm']['case'][$entityID]['id'];
       $caseContactID = _webform_civicrm_getCaseContactID($caseID);
-      $tokenNewValue = url("/civicrm/contact/view/case?reset=1&id={$caseID}&cid={$caseContactID}&action=view", ['absolute' => TRUE]);
+      $tokenNewValue = Url::fromUri('internal:/civicrm/contact/view/case', [
+        'absolute' => TRUE,
+        'query' => [
+          'reset' => 1,
+          'id' => $caseID,
+          'cid' => $caseContactID,
+          'action' => 'view',
+        ]
+      ])->toString();
     }
     $replacedTokens[$tokenName] = $tokenNewValue;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Fix usage of webform civicrm tokens in emails.

Before
----------------------------------------
WC has the following tokens in d7. None of them works in d8. To replicate - click on `Browse available token`

![image](https://user-images.githubusercontent.com/5929648/127739368-6f834578-7f52-427f-938b-9ba32ec0f785.png)

Lists the following tokens in d7 -

![image](https://user-images.githubusercontent.com/5929648/127739340-346e096f-3adb-470f-a6e5-6862cfd9494f.png)

To replicate in drupal 8 - 

Add an email handler and try to use these tokens -

```
Existing Contact - [webform_submission:values:civicrm_1_contact_1_contact_existing] 
Activity 1 ID - [webform_submission:activity-id:1] 
Activity 2 ID - [webform_submission:activity-id:2] 
Webform CiviCRM Contacts IDs - [webform_submission:contact-id:1] 
Webform CiviCRM Contacts Links - [webform_submission:contact-link:1]
```

Another related bug -

Existing Contact field displays an ID in the results page -

![image](https://user-images.githubusercontent.com/5929648/127739504-924856df-2595-4860-9b7a-b25145cebe04.png)


After
----------------------------------------
The tokens are rendered correctly.

Existing contact displays a link to the civic contact.

![image](https://user-images.githubusercontent.com/5929648/127739529-4e3cb788-bedb-46f1-9b45-f0a506c9440b.png)



Comments
----------------------------------------
@KarinG 