### PR TITLE
Update Github Testing Matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         include:
           - drupal: '^8.9'
             civicrm: '~5.33'
-          - drupal: '~9.1.1'
+          - drupal: '~9.2.1'
             civicrm: '~5.40'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '~9.2.1'
-            civicrm: '~5.40'
+            civicrm: '~5.42-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '~9.2.1'
-            civicrm: '5.39.x-dev'
+            civicrm: '5.41.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '~9.2.1'
-            civicrm: '~5.42.x-dev'
+            civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '~9.2.1'
-            civicrm: '~5.42-dev'
+            civicrm: '~5.42.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,12 @@ jobs:
       matrix:
         include:
           - drupal: '^8.9'
-            civicrm: '~5.33'
-          - drupal: '~9.2.1'
+            civicrm: '~5.35'
+	  - drupal: '^9.2'
+            civicrm: '~5.39'
+          - drupal: '^9.2'
+            civicrm: '5.42.x-dev'
+          - drupal: '^9.2'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
           - drupal: '^8.9'
             civicrm: '~5.33'
           - drupal: '~9.2.1'
-            civicrm: 'dev-master'
+            civicrm: '5.39.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
             civicrm: '~5.33'
           - drupal: '~9.1.1'
             civicrm: '~5.40'
-          - drupal: '~9.2.1'
-            civicrm: '5.41.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,10 @@ jobs:
         include:
           - drupal: '^8.9'
             civicrm: '~5.33'
-          - drupal: '^8.9'
-            civicrm: '~5.35'
-          - drupal: '^9.1'
-            civicrm: '~5.36'
-          - drupal: '^9.1'
-            civicrm: '5.39.x-dev'
+          - drupal: '~9.1.1'
+            civicrm: '~5.40'
+          - drupal: '~9.2.1'
+            civicrm: '5.41.x-dev'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:


### PR DESCRIPTION
Overview
----------------------------------------
Use 9.1 with latest numbered release and 9.2 with latest release-candidate.

For clarity since composer's method of specifying version is difficult:

`~9.1.1` means the latest 9.1 - the last digit will auto-adjust to whatever the latest is. Before when it said `^9.1`, it will install 9.2.x.