### PR TITLE
Check for empty fields.

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1034,7 +1034,7 @@ class AdminForm implements AdminFormInterface {
           'js_select' => $this->addToggle($fs),
         ];
         foreach ($this->sets as $sid => $set) {
-          if ($set['entity_type'] == 'membership') {
+          if ($set['entity_type'] == 'membership' && !empty($set['fields'])) {
             foreach ($set['fields'] as $fid => $field) {
               $fid = "civicrm_{$c}_membership_{$n}_$fid";
               $this->form['membership'][$c]['membership'][$fs][$fid] = $this->addItem($fid, $field);


### PR DESCRIPTION
Overview
----------------------------------------

When you have a custom group for "Membership" and no enabled fields, there is a warning when you enable "Membership" in the "CiviCRM" settings page:

> Notice: Undefined index: fields in Drupal\webform_civicrm\AdminForm->buildMembershipTab() (line 1038 of modules/contrib/webform_civicrm/src/AdminForm.php).

Before
----------------------------------------

Has error.

After
----------------------------------------

Checks if there are enabled fields.