### PR TITLE
D8/9 - Fix case start date error

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -481,12 +481,12 @@ class Fields implements FieldsInterface {
         $fields['case_start_date'] = [
           'name' => t('Case # Start Date'),
           'type' => 'date',
-          'value' => 'now',
+          'default_value' => 'now',
         ];
         $fields['case_end_date'] = [
           'name' => t('Case # End Date'),
           'type' => 'date',
-          'value' => 'now',
+          'default_value' => 'now',
         ];
         $fields['case_details'] = [
           'name' => t('Case # Details'),

--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -31,6 +31,7 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Update Existing Case', 'Ongoing');
     $this->getSession()->getPage()->selectFieldOption('Case Type', 'Housing Support');
     $this->getSession()->getPage()->checkField('Case Subject');
+    $this->getSession()->getPage()->checkField('Case Start Date');
 
     $this->saveCiviCRMSettings();
 
@@ -73,6 +74,7 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
     ]);
     $this->assertEquals(1, $case_result['count']);
     $this->assertEquals($caseSubject, $case_result['values'][0]['subject']);
+    $this->assertEquals(date('Y-m-d'), $case_result['values'][0]['start_date']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix case start date 

Before
----------------------------------------
Case start date field returns a validation error on webform submission.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Reported at https://www.drupal.org/project/webform_civicrm/issues/3229614
