### PR TITLE
Don't create a blank billing address or email

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1918,8 +1918,13 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
     if ($cid) {
       $address['contact_id'] = $email['contact_id'] = $this->ent['contact'][1]['id'] = $cid;
-      $utils->wf_civicrm_api('address', 'create', $address);
-      $utils->wf_civicrm_api('email', 'create', $email);
+      // Don't create a blank billing address.
+      if ($address['street_address'] || $address['city'] || $address['country_id'] || $address['state_province_id'] || $address['postal_code']) {
+        $utils->wf_civicrm_api('address', 'create', $address);
+      }
+      if ($email['email'] ?? FALSE) {
+        $utils->wf_civicrm_api('email', 'create', $email);
+      }
     }
     return $cid;
   }


### PR DESCRIPTION
Overview
----------------------------------------
When a billing address isn't required, Webform-CiviCRM will still create a blank billing address record.

Before
----------------------------------------
![Selection_1211](https://user-images.githubusercontent.com/1796012/131729414-9942155d-83eb-47e1-8c48-ac9cec208232.png)


After
----------------------------------------
![Selection_1212](https://user-images.githubusercontent.com/1796012/131729485-30914f23-fc26-4eb2-905c-63637916e00e.png)


Comments
----------------------------------------
In the olden days, billing address was required, which is, I assume how this happened.

Note the open D7 version of this PR here: https://github.com/colemanw/webform_civicrm/pull/317.  Note also that there's a logic error in that PR that needs fixing before it's merged.