### PR TITLE
D8/9 - Remove contact paging if it is disabled from additional options

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1996,7 +1996,7 @@ class AdminForm implements AdminFormInterface {
     $handler->setConfiguration($handler_configuration);
 
     $this->addEnabledElements($enabled);
-    $this->sortPaging();
+    $this->setPaging();
     // Update existing contact fields
     foreach ($existing as $fid => $id) {
       if (substr($fid, -8) === 'existing') {
@@ -2045,27 +2045,41 @@ class AdminForm implements AdminFormInterface {
   /**
    * Fix paging on the webform.
    */
-  protected function sortPaging() {
-    $elements = $this->webform->getElementsInitialized();
+  protected function setPaging() {
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $elements = $this->webform->getElementsDecoded();
     if (!isset($elements['contact_pagebreak'])) {
       return;
     }
 
-    //Move contact page to top.
-    if (key($elements) != 'contact_pagebreak') {
-      $elements = array_merge([
-        'contact_pagebreak' => $elements['contact_pagebreak']
-      ], $elements);
-    }
-    foreach ($elements as $key => &$element) {
-      if (strpos($key, 'civicrm') !== 0
-        || isset($element['#parent']) || !empty($element['#webform_parent_key'])
-        || empty($element['#type']) || $element['#type'] == 'webform_wizard_page') {
-        continue;
+    if (!empty($this->settings['disable_contact_paging'])) {
+      $children = $this->webform->getElement('contact_pagebreak')['#webform_children'] ?? [];
+      foreach ($children as $child) {
+        if (is_string($child) && isset($elements['contact_pagebreak'][$child])) {
+          $elements = array_merge([
+            $child => $elements['contact_pagebreak'][$child]
+          ], $elements);
+        }
       }
-      $page = (strpos($key, '_contribution_') !== FALSE) ? 'contribution_pagebreak' : 'contact_pagebreak';
-      $elements[$page][$key] = $element;
-      unset($elements[$key]);
+      $utils->remove_element($elements, 'contact_pagebreak');
+    }
+    else {
+      // Move contact page to top.
+      if (key($elements) != 'contact_pagebreak') {
+        $elements = array_merge([
+          'contact_pagebreak' => $elements['contact_pagebreak']
+        ], $elements);
+      }
+      foreach ($elements as $key => &$element) {
+        if (strpos($key, 'civicrm') !== 0
+          || isset($element['#parent']) || !empty($element['#webform_parent_key'])
+          || empty($element['#type']) || $element['#type'] == 'webform_wizard_page') {
+          continue;
+        }
+        $page = (strpos($key, '_contribution_') !== FALSE) ? 'contribution_pagebreak' : 'contact_pagebreak';
+        $elements[$page][$key] = $element;
+        unset($elements[$key]);
+      }
     }
     $this->webform->setElements($elements);
     $this->webform->save();

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -962,4 +962,23 @@ class Utils implements UtilsInterface {
     return $result;
   }
 
+  /**
+   * Searches for all occurrence of form key in the array and
+   * unsets it from the webform element.
+   *
+   * @param array $elements
+   * @param string $form_key
+   */
+  function remove_element(&$elements, $form_key) {
+    unset($elements[$form_key]);
+    foreach ($elements as $k => &$value) {
+      if (is_array($value)) {
+        $this->remove_element($value, $form_key);
+      }
+      elseif ($value === $form_key) {
+        unset($elements[$k]);
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Remove contact paging if disabled from additional options

Before
----------------------------------------
- Disable Contact Paging was only implemented to skip adding contact page break on the webform. 
- contact_pagebreak is present in the `#parent` key even if the paging is disabled.

After
----------------------------------------
- Extended the fix so when Disable Contact Paging? is turned on - It removes the contact paging from the webform.
- Removes all traces of `contact_pagebreak` fielset on the webform.


Comments
----------------------------------------
@KarinG @MegaphoneJon Can you pls confirm if it works for you?

https://www.drupal.org/project/webform_civicrm/issues/3230899