### PR TITLE
D8/9 - Fix fatal error on gender field

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -159,7 +159,7 @@ class CivicrmSelectOptions extends FormElement {
         '#type' => 'radio',
         '#title' => t('Mark @item as the default value', ['@item' => $option]),
         '#title_display' => 'invisible',
-        '#default_value' => $element['#default_option'] == $key ? $key : 0,
+        '#default_value' => $element['#default_option'] == $key ? $key : '',
         '#parents' => array_merge($element['#parents'], ['default']),
         '#return_value' => $key,
       ];


### PR DESCRIPTION
Overview
----------------------------------------
Gender field returns an error when edited.

Before
----------------------------------------
Can be replicated by -

- Add a contact + gender field on the webform.
- Edit and save the gender field from the build form.
- Add Gender to Fields to lock setting on the existing contact
- Submit the webform.
- Error.


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
When the gender field is edited and saved, WC incorrect sets the #default_option + #default_value = 0 on the yaml config.

```yml
'#default_option': 0
'#default_value': 0
```

0 isn't a valid value for gender and results into an error. Fix here sets it to an empty string instead.

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3230564
