### PR TITLE
D8/9 - Add test for membership + contribution + line item with taxes

### DIFF
--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -12,21 +12,6 @@ use Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver;
  */
 final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
-  private function createMembershipType($amount = 0, $autoRenew = FALSE, $name = 'Basic') {
-    $result = civicrm_api3('MembershipType', 'create', [
-      'member_of_contact_id' => 1,
-      'financial_type_id' => "Member Dues",
-      'duration_unit' => "year",
-      'duration_interval' => 1,
-      'period_type' => "rolling",
-      'minimum_fee' => $amount,
-      'name' => $name,
-      'auto_renew' => $autoRenew,
-    ]);
-    $this->assertEquals(0, $result['is_error']);
-    $this->assertEquals(1, $result['count']);
-  }
-
   function testSubmitMembershipAutoRenew() {
     $this->createMembershipType(1, TRUE);
     $payment_processor = $this->createPaymentProcessor();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -87,6 +87,25 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
+   * Create Membership Type
+   */
+  protected function createMembershipType($amount = 0, $autoRenew = FALSE, $name = 'Basic') {
+    $result = civicrm_api3('MembershipType', 'create', [
+      'member_of_contact_id' => 1,
+      'financial_type_id' => "Member Dues",
+      'duration_unit' => "year",
+      'duration_interval' => 1,
+      'period_type' => "rolling",
+      'minimum_fee' => $amount,
+      'name' => $name,
+      'auto_renew' => $autoRenew,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+    return array_pop($result['values']);
+  }
+
+  /**
    * Create custom group.
    */
   protected function createCustomGroup($params = []) {


### PR DESCRIPTION
Overview
----------------------------------------
Test for membership + contribution + line item with taxes

Before
----------------------------------------
No test 

After
----------------------------------------
Test Added.

Technical Details
----------------------------------------

The test will fail with the current civi version (probably older as well). It submits the following line items 

![Pasted Graphic 1](https://user-images.githubusercontent.com/5929648/132129493-61c34b14-423b-4eac-8889-7e75fa263797.jpg)

Amount breakage - 

```
Total Amount = 10 + 20.00 + 29.50 + 100.00 + 200.00 = 359.5
Taxes = 1.48 + 5 + 10 = 16.48
Total = 359.5 + 16.48 = 375.98
```

With the current civi code, the amount stored in civicrm_contribution => total_amount is Tax exclusive = 359.5.

The test expects the value that was paid by the user, i.e, 375.98

