### PR TITLE
Annotate Contribution + Line Item + Memberships Test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,3 +103,4 @@ jobs:
           name: phpunit_browser_output
           # For some reason Drupal prints here and not our specified BROWSERTEST_OUTPUT_DIRECTORY.
           path: '/home/runner/drupal/web/sites/simpletest/browser_output'
+	        retention-days: 7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,4 +103,4 @@ jobs:
           name: phpunit_browser_output
           # For some reason Drupal prints here and not our specified BROWSERTEST_OUTPUT_DIRECTORY.
           path: '/home/runner/drupal/web/sites/simpletest/browser_output'
-	        retention-days: 7
+          retention-days: 7

--- a/tests/src/FunctionalJavascript/ContactRelationshipTest.php
+++ b/tests/src/FunctionalJavascript/ContactRelationshipTest.php
@@ -121,7 +121,7 @@ final class ContactRelationshipTest extends WebformCivicrmTestBase {
     // Visit the webform with cid2 id in the url.
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contact1['id'], 'cid2' => $contact2['id']]]));
     $this->assertSession()->waitForField('First Name');
-    $this->createScreenshot($this->htmlOutputDirectory . '/relationship_selection.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/relationship_selection.png');
 
     //Make sure the checkbox are enabled by default.
     $this->assertSession()->checkboxChecked("Child of");

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -178,8 +178,9 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Amounts = 10 + 20.00 + 29.50 + 100.00 + 200.00 = 359.5
     // Taxes = 1.48 + 5 + 10 = 16.48
     // Total = 359.5 + 16.48 = 375.98
+
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '375.98');
-    $this->createScreenshot($this->htmlOutputDirectory . '/line_items.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/lineitems.png');
 
     $this->fillCardAndSubmit();
 

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -179,6 +179,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Taxes = 1.48 + 5 + 10 = 16.48
     // Total = 359.5 + 16.48 = 375.98
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '375.98');
+    $this->createScreenshot($this->htmlOutputDirectory . '/line_items.png');
 
     $this->fillCardAndSubmit();
 

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -179,7 +179,8 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Total = 359.5 + 16.48 = 375.98
 
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '375.98');
-    $this->createScreenshot($this->htmlOutputDirectory . '/lineitems12345.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/lineitem_tally.png');
+
     $this->htmlOutput();
 
     $this->fillCardAndSubmit();

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -172,7 +172,6 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
-    $this->htmlOutput();
 
     // Contribution Amount + Line1 + Line2 + Mem1 + Mem2
     // Amounts = 10 + 20.00 + 29.50 + 100.00 + 200.00 = 359.5
@@ -180,7 +179,8 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Total = 359.5 + 16.48 = 375.98
 
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '375.98');
-    $this->createScreenshot($this->htmlOutputDirectory . '/lineitems.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/lineitems12345.png');
+    $this->htmlOutput();
 
     $this->fillCardAndSubmit();
 

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -155,7 +155,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->assertPageNoErrorMessages();
-    $this->createScreenshot($this->htmlOutputDirectory . 'faps169.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . 'faps169.png');
     $this->htmlOutput();
 
     $this->assertSession()->waitForElementVisible('css', '.webform-confirmation');

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -329,7 +329,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     ])->toString();
     $this->drupalGet($fieldURL);
     $this->getSession()->getPage()->uncheckField('Active?');
-    $this->createScreenshot($this->htmlOutputDirectory . '/custom_field.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/custom_field.png');
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
@@ -392,7 +392,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][label]');
     $this->getSession()->getPage()->fillField('properties[options][options][civicrm_option_1][label]', 'Red - Recommended');
     $this->htmlOutput();
-    $this->createScreenshot($this->htmlOutputDirectory . '/afterlabelchange.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/afterlabelchange.png');
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -106,6 +106,19 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
+   * Create Financial Type
+   */
+  protected function createFinancialType($name) {
+    $result = civicrm_api3('FinancialType', 'create', [
+      'name' => $name,
+      'is_active' => 1,
+    ]);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+    return array_pop($result['values']);
+  }
+
+  /**
    * Create custom group.
    */
   protected function createCustomGroup($params = []) {


### PR DESCRIPTION
Overview
----------------------------------------
Annotate + adding a new Financial Type function that we can use for testing a Product Purchase (line item with Sales Tax - but not Member Dues or Event Fee (as we would expect Membership and Participation records as well when using those). 

I noted that the js that pulls together the line items [your screenshot on PR 608] does -not- reflect the filled out first name and last name fields? 

-> see screenshot below

We would be expecting:
Basic: Frederick Pabst
Advanced: MarkUpdated CooperUpdated

<img width="879" alt="image" src="https://user-images.githubusercontent.com/5340555/132149160-fcb0bbc3-bf84-4647-bcdf-cbae1e5f5342.png">

