### PR TITLE
Port #420 - Remove doTransferCheckout

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1983,41 +1983,33 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
     $params['webform_redirect_cancel'] = $this->getIpnRedirectUrl('cancel');
     $params['webform_redirect_success'] = $this->getIpnRedirectUrl('success');
 
-    if (method_exists($paymentProcessor, 'doTransferCheckout')) {
-      //Paypal Express checkout
-      if(wf_crm_aval($_POST, 'credit_card_number') == 'express'){
-        try {
-          $params['button'] = 'express';
-          $params['component'] = 'contribute';
-          $result = $paymentProcessor->doPreApproval($params);
-            if (empty($result)) {
-            // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
-            return;
-          }
-        }
-        catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-          drupal_set_message(ts('Payment approval failed with message :') . $e->getMessage(),'error');
-          CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
-        }
-        $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
-        $params = array_merge($params, $preApprovalParams);
-        if (!empty($result['redirect_url'])) {
-          CRM_Utils_System::redirect($result['redirect_url']);
-        }
-      }
-      // doTransferCheckout is deprecated but some processors might still implement it.
-      // Somewhere around 4.6 it was replaced by doPayment as the method of choice,
-      // but to be safe still call it if it exists for now.
-      $paymentProcessor->doTransferCheckout($params, 'contribute');
-    }
-    else {
+    //Paypal Express checkout
+    if (wf_crm_aval($_POST, 'credit_card_number') == 'express') {
       try {
-        $paymentProcessor->doPayment($params);
+        $params['button'] = 'express';
+        $params['component'] = 'contribute';
+        $result = $paymentProcessor->doPreApproval($params);
+          if (empty($result)) {
+          // This could happen, for example, when paypal looks at the button value & decides it is not paypal express.
+          return;
+        }
       }
       catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
         drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
         CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
       }
+      $preApprovalParams = $paymentProcessor->getPreApprovalDetails($result['pre_approval_parameters']);
+      $params = array_merge($params, $preApprovalParams);
+      if (!empty($result['redirect_url'])) {
+        CRM_Utils_System::redirect($result['redirect_url']);
+      }
+    }
+    try {
+      $paymentProcessor->doPayment($params);
+    }
+    catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
+      drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
+      CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
     }
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
Port of #420.

Before
----------------------------------------


>Error: Call to protected method CRM_Core_Payment::doTransferCheckout() from context 'wf_crm_webform_postprocess' in wf_crm_webform_postprocess->submitIPNPayment() (line 1941 of .../sites/all/modules/webform_civicrm/includes/wf_crm_webform_postprocess.inc).


After
----------------------------------------
Fixed.

Comments
----------------------------------------
The title of https://github.com/colemanw/webform_civicrm/pull/423 says it was the port of #420, but it wasn't the actual port and didn't removed doTransferCheckout() call from the file? The function is still present on 7.x version and resulting in a fatal error for payments. 