### PR TITLE
Need to map is_recur for payment processors not using propertyBag.

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -727,6 +727,10 @@ class Utils implements UtilsInterface {
       // propertyBag has 'currency', iATS uses `currencyID` until https://github.com/iATSPayments/com.iatspayments.civicrm/pull/350 is merged
       $payParams['currencyID'] = $propertyBag->getCurrency();
       $payParams['amount'] = $params['total_amount'];
+      // For legacy purposes (if payment processor does not use propertyBag)
+      if (isset($payParams['isRecur'])) {
+        $payParams['is_recur'] = $payParams['isRecur'];
+      }
       $payResult = reset(civicrm_api3('PaymentProcessor', 'pay', $payParams)['values']);
 
       // webform_civicrm sends out receipts using Contribution.send_confirmation API if the contribution page is has is_email_receipt = TRUE.


### PR DESCRIPTION
Overview
----------------------------------------
And using old/existing params in if statements (e.g. is_recur via online Contribution Pages, isRecur via Order API/propertyBag).

Before
----------------------------------------
Recurring Contributions w/ iATS not generating/storing payment_tokens - essentially breaking recurring payments with D8/D9 Webform CiviCRM module. No issue in D7 (it's using our version of Transact API).

After
----------------------------------------
Working - as far as I can tell at this point. 

Technical Details
----------------------------------------
propertyBag has it's own nomenclature (amount vs total_amount, isRecur vs is_recur). I was debating reverting to Transact API but for now it looks like this simple mapping works. 

Needs a test.

