### PR TITLE
D8/9 - Fix error on selecting country with numeric state abbreviation

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -121,16 +121,7 @@ class Utils implements UtilsInterface {
   function wf_crm_state_abbr($input, $ret = 'abbreviation', $country_id = NULL) {
     $params = ['sequential' => 1];
     if ($ret == 'id') {
-      if (is_numeric($input)) {
-        $state = $this->wf_civicrm_api('state_province', 'getsingle', [
-          'return' => 'abbreviation',
-          'id' => $input,
-        ]);
-        $params['abbreviation'] = $state['abbreviation'] ?? $input;
-      }
-      else {
-        $params['abbreviation'] = $input;
-      }
+      $params['abbreviation'] = $input;
       if (!$country_id || $country_id === 'default') {
         $country_id = (int) $this->wf_crm_get_civi_setting('defaultContactCountry', 1228);
       }

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -46,6 +46,8 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->assertPageNoErrorMessages();
 
+    $this->country = 'United Kingdom';
+    $this->state = 'Newport';
     // Change widget of Amount element to checkbox.
     $this->changeTypeOfAmountElement('checkboxes');
     $this->submitWebform('checkboxes');
@@ -56,6 +58,8 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->submitWebform('radios');
     $this->verifyResult();
 
+    $this->country = 'Malaysia';
+    $this->state = 'Selangor';
     // Change widget of Amount element to radio + other.
     $this->changeTypeOfAmountElement('webform_radios_other');
     $this->submitWebform('webform_radios_other');
@@ -73,9 +77,9 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-    $this->getSession()->getPage()->selectFieldOption("Country", 'United Kingdom');
+    $this->getSession()->getPage()->selectFieldOption("Country", $this->country);
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption('State/Province', 'Newport');
+    $this->getSession()->getPage()->selectFieldOption('State/Province', $this->state);
 
     $this->getSession()->getPage()->pressButton('Next >');
     $this->assertSession()->waitForField('civicrm_1_contribution_1_contribution_total_amount');
@@ -172,10 +176,10 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
       'sequential' => 1,
     ])['values'][0];
     $country = $this->utils->wf_civicrm_api('Country', 'get', [
-      'name' => "United Kingdom",
+      'name' => $this->country,
     ]);
     $state = $this->utils->wf_civicrm_api('StateProvince', 'get', [
-      'name' => "Newport",
+      'name' => $this->state,
     ]);
     $this->assertEquals($country['id'], $address['country_id']);
     $this->assertEquals($state['id'], $address['state_province_id']);


### PR DESCRIPTION
Overview
----------------------------------------
Fix error on selecting country with numeric state abbreviation

Before
----------------------------------------
Selecting country with numeric abbreviation, throws a fatal error on webform submission. Eg Selangor state has numeric abbreviation in civicrm_state_province table.

To replicate select Malaysia in the country dropdown with any state and submit the webform.

After
----------------------------------------
Fixed. I've also extended the test to confirm this usecase.



Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3232579