### PR TITLE
[Test only] - Unit tests - Fix matrix versions and deal with scssphp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,14 +12,12 @@ jobs:
       matrix:
         include:
           - drupal: '^8.9'
-            civicrm: '~5.33'
+            civicrm: '~5.35.0'
           - drupal: '^8.9'
-            civicrm: '~5.35'
-          - drupal: '^8.9'
-            civicrm: '~5.39'
-          - drupal: '^9.2'
+            civicrm: '~5.39.0'
+          - drupal: '~9.2.0'
             civicrm: '5.42.x-dev'
-          - drupal: '^9.2'
+          - drupal: '~9.2.0'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
@@ -64,6 +62,11 @@ jobs:
           composer config repositories.0 path $GITHUB_WORKSPACE
           composer config repositories.1 composer https://packages.drupal.org/8
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }}
+      - name: Deal with https://lab.civicrm.org/dev/drupal/-/issues/164
+        # This is temporary until no longer testing anything less than 5.41. A more sophisticated way would be to make this conditional on civi version so that for 5.41+ it doesn't do this, giving a closer approximation to real installs for 5.41+, but as far as I know this is only used by compile-lib to make some bootstrap css files.
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require scssphp/scssphp:1.6.0
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal


### PR DESCRIPTION
Overview
----------------------------------------
`~5.N` will install the latest 5.x, even beyond "N", so `~5.39` actually installs 5.41 as of right now.

But then when installing 5.39 for real need to deal with scssphp problem in https://lab.civicrm.org/dev/drupal/-/issues/164

Before
----------------------------------------
Testing 5.41 three times.

After
----------------------------------------
Testing all different versions.

Technical Details
----------------------------------------
Composer

Comments
----------------------------------------
Composer
