### PR TITLE
D8/9 - Ensure price field is always set for line items

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2315,8 +2315,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       if (empty($item['contribution_id'])) {
         $item['contribution_id'] = $id;
       }
+      $priceSetId = 'default_contribution_amount';
       // Membership
       if (!empty($item['membership_id'])) {
+        $priceSetId = 'default_membership_type_amount';
         $item['entity_id'] = $item['membership_id'];
         $lineItemArray = $utils->wf_civicrm_api('LineItem', 'get', [
           'entity_table' => "civicrm_membership",
@@ -2334,6 +2336,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           }
         }
       }
+      $item['price_field_id'] = $utils->wf_civicrm_api('PriceField', 'get', [
+        'sequential' => 1,
+        'price_set_id' => $priceSetId,
+        'options' => ['limit' => 1],
+      ])['id'] ?? NULL;
 
       // Save the line_item
       $line_result = $utils->wf_civicrm_api('line_item', 'create', $item);

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -190,6 +190,17 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertEquals('16.48', $contribution['tax_amount']);
     $tax_total_amount = $contribution['tax_amount'];
 
+    $contriPriceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => 'default_contribution_amount',
+      'options' => ['limit' => 1],
+    ])['id'] ?? NULL;
+    $membershipPriceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => 'default_membership_type_amount',
+      'options' => ['limit' => 1],
+    ])['id'] ?? NULL;
+
     $api_result = $this->utils->wf_civicrm_api('line_item', 'get', [
       'sequential' => 1,
     ]);
@@ -198,20 +209,25 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertEquals('100.00', $api_result['values'][0]['line_total']);
     $this->assertEquals('2', $api_result['values'][0]['financial_type_id']);
     $this->assertEquals('5.00', $api_result['values'][0]['tax_amount']);
+    $this->assertEquals($membershipPriceFieldID, $api_result['values'][0]['price_field_id']);
 
     $this->assertEquals('200.00', $api_result['values'][1]['line_total']);
     $this->assertEquals('2', $api_result['values'][1]['financial_type_id']);
     $this->assertEquals('10.00', $api_result['values'][1]['tax_amount']);
+    $this->assertEquals($membershipPriceFieldID, $api_result['values'][1]['price_field_id']);
 
     $this->assertEquals('10.00', $api_result['values'][2]['line_total']);
     $this->assertEquals('1', $api_result['values'][2]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][2]['price_field_id']);
 
     $this->assertEquals('20.00', $api_result['values'][3]['line_total']);
     $this->assertEquals('1', $api_result['values'][3]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][3]['price_field_id']);
 
     $this->assertEquals('29.50', $api_result['values'][4]['line_total']);
     $this->assertEquals('1.48', $api_result['values'][4]['tax_amount']);
     $this->assertEquals('5', $api_result['values'][4]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][4]['price_field_id']);
 
     $sum_line_total = array_sum(array_column($api_result['values'], 'line_total'));
     $sum_tax_amount = array_sum(array_column($api_result['values'], 'tax_amount'));

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -289,19 +289,28 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertEquals($creditCardID, $contribution['payment_instrument_id']);
     $tax_total_amount = $contribution['tax_amount'];
 
+    $contriPriceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => 'default_contribution_amount',
+      'options' => ['limit' => 1],
+    ])['id'] ?? NULL;
+
     $api_result = $utils->wf_civicrm_api('line_item', 'get', [
       'sequential' => 1,
     ]);
 
-    // throw new \Exception(var_export($api_result, TRUE));
-
     $this->assertEquals('3.00', $api_result['values'][0]['line_total']);
     $this->assertEquals('1', $api_result['values'][0]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][0]['price_field_id']);
+
     $this->assertEquals('1.75', $api_result['values'][1]['line_total']);
     $this->assertEquals('1', $api_result['values'][1]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][1]['price_field_id']);
+
     $this->assertEquals('5.00', $api_result['values'][2]['line_total']);
     $this->assertEquals('0.25', $api_result['values'][2]['tax_amount']);
     $this->assertEquals('2', $api_result['values'][2]['financial_type_id']);
+    $this->assertEquals($contriPriceFieldID, $api_result['values'][2]['price_field_id']);
 
     $sum_line_total = $api_result['values'][0]['line_total'] + $api_result['values'][1]['line_total'] + $api_result['values'][2]['line_total'];
     $sum_tax_amount = $api_result['values'][2]['tax_amount'];

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -372,10 +372,16 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
       $this->assertEquals(2, $api_result['count']);
       $line_items = next($api_result['values']);
     }
+    $priceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => 'default_membership_type_amount',
+      'options' => ['limit' => 1],
+    ])['id'] ?? NULL;
 
     $this->assertEquals('1.00', $line_items['qty']);
     $this->assertEquals('100.00', $line_items['unit_price']);
     $this->assertEquals('100.00', $line_items['line_total']);
+    $this->assertEquals($priceFieldID, $line_items['price_field_id']);
     $this->assertEquals($expected_tax_amount, $line_items['tax_amount']);
     $this->assertEquals($financial_type_id, $line_items['financial_type_id']);
 

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -159,6 +159,15 @@ final class StripeTest extends WebformCivicrmTestBase {
     $expectedFTIds = ['1', '1', '2'];
     $this->assertEquals($expectedFTIds, $financialTypeIds);
     $this->assertEquals($contribution['total_amount'], array_sum($lineTotals));
+
+    $priceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+      'sequential' => 1,
+      'price_set_id' => 'default_contribution_amount',
+      'options' => ['limit' => 1],
+    ])['id'] ?? NULL;
+    foreach ($lineItems as $item) {
+      $this->assertEquals($priceFieldID, $item['price_field_id']);
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Ensure price field is always set for line items

Before
----------------------------------------
Price field id is kept empty by webform CiviCRM since there is no price field attached to the payment done. Civi seems to trigger an error and requires it to be set for every line item.

After
----------------------------------------
Set price field on the line item to default quick config price field value.

