### PR TITLE
[Test only] - Ad-hoc PR for PR620.

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -63,6 +63,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
   }
 
   public function testSubmitContribution() {
+    $utils = \Drupal::service('webform_civicrm.utils');
     $payment_processor = $this->createPaymentProcessor();
     $this->createMembershipType(100, FALSE, 'Basic');
     $this->createMembershipType(200, FALSE, 'Advanced');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -235,6 +235,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
    * (5% and 13% Sales Tax - based on province)
    */
   public function testMembershipVaryingSalesTax() {
+    $utils = \Drupal::service('webform_civicrm.utils');
     // Add Canada
     \Civi::settings()->set('countryLimit', [1228, 1039]);
     // Make it the default country

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -235,7 +235,6 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
    * (5% and 13% Sales Tax - based on province)
    */
   public function testMembershipVaryingSalesTax() {
-    $utils = \Drupal::service('webform_civicrm.utils');
     // Add Canada
     \Civi::settings()->set('countryLimit', [1228, 1039]);
     // Make it the default country
@@ -283,7 +282,8 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->purchaseMembershipProvince('Ontario');
   }
 
-  public function purchaseMembershipProvince($province){
+  public function purchaseMembershipProvince($province) {
+    $utils = \Drupal::service('webform_civicrm.utils');
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
 

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -42,6 +42,7 @@ final class StripeTest extends WebformCivicrmTestBase {
    * Verifies the payment with 1 contribution and 2 line item amounts.
    */
   public function testSubmitContribution() {
+    $utils = \Drupal::service('webform_civicrm.utils');
     $this->drupalLogin($this->adminUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -42,7 +42,6 @@ final class StripeTest extends WebformCivicrmTestBase {
    * Verifies the payment with 1 contribution and 2 line item amounts.
    */
   public function testSubmitContribution() {
-    $utils = \Drupal::service('webform_civicrm.utils');
     $this->drupalLogin($this->adminUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
@@ -132,6 +131,7 @@ final class StripeTest extends WebformCivicrmTestBase {
    * Verify Payment values.
    */
   private function verifyPaymentResult() {
+    $utils = \Drupal::service('webform_civicrm.utils');
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', []);
     $this->assertEquals(1, $api_result['count']);
     $contribution = reset($api_result['values']);


### PR DESCRIPTION
Overview
----------------------------------------
#620 predated the composer v2 vs v1 edits so it had previously been testing against beta8 - This ad-hoc PR ensures `$utils` is defined

Before
----------------------------------------
```
1) Drupal\Tests\webform_civicrm\FunctionalJavascript\ContributionDummyTest::testSubmitContribution
Undefined variable: utils

/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/ContributionDummyTest.php:198

2) Drupal\Tests\webform_civicrm\FunctionalJavascript\MembershipSubmissionTest::testMembershipVaryingSalesTax
Undefined variable: utils

/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/MembershipSubmissionTest.php:375
/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/MembershipSubmissionTest.php:281

3) Drupal\Tests\webform_civicrm\FunctionalJavascript\StripeTest::testSubmitContribution
Undefined variable: utils

/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/StripeTest.php:163
/home/runner/work/webform_civicrm/webform_civicrm/tests/src/FunctionalJavascript/StripeTest.php:103
```

After
----------------------------------------
✅

