### PR TITLE
D8/9 - Allow number field to be retyped into options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Installation & Getting Started
 - Create a new webform (or go to edit an existing one).
 - Click on the Settings -> CiviCRM tab.
 - Enable the fields you like, and optionally choose introduction text and other settings.
-- Customize the webform settings for your new fields however you wish!
+- Customize the webform settings for your new fields however you wish.
 
 Documentation
 -------------

--- a/src/Element/CivicrmNumber.php
+++ b/src/Element/CivicrmNumber.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\webform_civicrm\Element;
+
+use Drupal\Core\Render\Element\Number;
+
+/**
+ * @FormElement("civicrm_number")
+ */
+class CivicrmNumber extends Number {
+
+}

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -29,6 +29,9 @@ class FieldOptions implements FieldOptionsInterface {
         list($contact_types, $sub_types) = $utils->wf_crm_get_contact_types();
         $ret = wf_crm_aval($sub_types, $data['contact'][$c]['contact'][1]['contact_type'], []);
       }
+      elseif (isset($field['type']) && $field['type'] === 'civicrm_number') {
+        return [];
+      }
       elseif ($name === 'relationship_type_id') {
         $ret = $utils->wf_crm_get_contact_relationship_types($data['contact'][$c]['contact'][1]['contact_type'], $data['contact'][$n]['contact'][1]['contact_type'], $data['contact'][$c]['contact'][1]['contact_sub_type'], $data['contact'][$n]['contact'][1]['contact_sub_type']);
       }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -87,7 +87,7 @@ class Fields implements FieldsInterface {
   protected function getMoneyDefaults(): array {
     $utils = \Drupal::service('webform_civicrm.utils');
     return [
-      'type' => 'number',
+      'type' => 'civicrm_number',
       'data_type' => 'Money',
       'extra' => [
         'field_prefix' => $utils->wf_crm_get_civi_setting('defaultCurrencySymbol', '$'),
@@ -432,7 +432,7 @@ class Fields implements FieldsInterface {
       ];
       $fields['activity_duration'] = [
         'name' => t('Activity # Duration'),
-        'type' => 'number',
+        'type' => 'civicrm_number',
         'field_suffix' =>  t('min.'),
         /*ToDo Figure out why setting min does not work!*/
         'min' => 0,
@@ -677,7 +677,7 @@ class Fields implements FieldsInterface {
         ];
         $fields['contribution_installments'] = [
           'name' => t('Number of Installments'),
-          'type' => 'number',
+          'type' => 'civicrm_number',
           'default_value' => '1',
           'min' => '0',
           'step' => '1',
@@ -685,7 +685,7 @@ class Fields implements FieldsInterface {
         ];
         $fields['contribution_frequency_interval'] = [
           'name' => t('Interval of Installments'),
-          'type' => 'number',
+          'type' => 'civicrm_number',
           'default_value' => '1',
           'min' => '0',
           'step' => '1',

--- a/src/Plugin/WebformElement/CivicrmNumber.php
+++ b/src/Plugin/WebformElement/CivicrmNumber.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\webform_civicrm\Plugin\WebformElement;
+
+use Drupal\webform\Plugin\WebformElement\Number;
+use Drupal\webform\Utility\WebformReflectionHelper;
+
+/**
+ * Provides a 'civicrm_number' element.
+ *
+ * @WebformElement(
+ *   id = "civicrm_number",
+ *   label = @Translation("CiviCRM Number"),
+ *   description = @Translation("Provides a CiviCRM powered numeric field."),
+ *   category = @Translation("CiviCRM"),
+ * )
+ *
+ * @see \Drupal\webform_example_element\Element\WebformExampleElement
+ * @see \Drupal\webform\Plugin\WebformElementBase
+ * @see \Drupal\webform\Plugin\WebformElementInterface
+ * @see \Drupal\webform\Annotation\WebformElement
+ */
+class CivicrmNumber extends Number {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRelatedTypes(array $element) {
+    $types = parent::getRelatedTypes($element);
+    // Allow number field to be retyped into options widgets.
+    $elements = $this->elementManager->getInstances();
+    $supportedTypes = ['civicrm_options'];
+    foreach ($elements as $element_name => $element_instance) {
+      if (in_array($element_name, $supportedTypes)) {
+        $types[$element_name] = $element_instance->getPluginLabel();
+      }
+    }
+    asort($types);
+    return $types;
+  }
+
+}

--- a/src/Plugin/WebformElement/CivicrmNumber.php
+++ b/src/Plugin/WebformElement/CivicrmNumber.php
@@ -4,6 +4,7 @@ namespace Drupal\webform_civicrm\Plugin\WebformElement;
 
 use Drupal\webform\Plugin\WebformElement\Number;
 use Drupal\webform\Utility\WebformReflectionHelper;
+use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Provides a 'civicrm_number' element.
@@ -22,7 +23,6 @@ use Drupal\webform\Utility\WebformReflectionHelper;
  */
 class CivicrmNumber extends Number {
 
-
   /**
    * {@inheritdoc}
    */
@@ -38,6 +38,14 @@ class CivicrmNumber extends Number {
     }
     asort($types);
     return $types;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    unset($element['#options'], $element['#data_type']);
+    parent::prepare($element, $webform_submission);
   }
 
 }

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -83,7 +83,7 @@ class CivicrmOptions extends OptionsBase {
     ];
 
     // Do not load option values if this is a numeric field.
-    if ($this->isNumberField($element_properties)) {
+    if ($this->isNumberField($form_state->get('element_properties'))) {
       return $form;
     }
 

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -70,7 +70,7 @@ class CivicrmOptions extends OptionsBase {
       '#title' => $this->t('Listbox'),
       '#description' => $this->t('Check this option if you want the select component to be displayed as a select list box instead of radio buttons or checkboxes.'),
       '#access' => TRUE,
-      '#default_value' => $element_properties['extra']['aslist'],
+      '#default_value' => $element_properties['extra']['aslist'] ?? FALSE,
       '#parents' => ['properties', 'extra', 'aslist'],
     ];
     $form['extra']['multiple'] = [
@@ -78,9 +78,14 @@ class CivicrmOptions extends OptionsBase {
       '#title' => $this->t('Multiple'),
       '#description' => $this->t('Check this option if multiple options can be selected for the input field.'),
       '#access' => TRUE,
-      '#default_value' => $element_properties['extra']['multiple'],
+      '#default_value' => $element_properties['extra']['multiple'] ?? FALSE,
       '#parents' => ['properties', 'extra', 'multiple'],
     ];
+
+    // Do not load option values if this is a numeric field.
+    if ($this->isNumberField($element_properties)) {
+      return $form;
+    }
 
     // Options.
     $form['options'] = [
@@ -135,6 +140,9 @@ class CivicrmOptions extends OptionsBase {
    */
   public function getConfigurationFormProperties(array &$form, FormStateInterface $form_state) {
     $properties = parent::getConfigurationFormProperties($form, $form_state);
+    if ($this->isNumberField($properties)) {
+      return $properties;
+    }
     if (!empty($form['properties'])) {
       // Get additional properties off of the options element.
       $select_options = $form['properties']['options']['options'];
@@ -212,6 +220,24 @@ class CivicrmOptions extends OptionsBase {
   }
 
   /**
+   * If this is a CiviCRM Number element.
+   *
+   * @param array $element
+   *
+   * @return bool
+   */
+  protected function isNumberField($element) {
+    $form_key = $element['form_key'] ?? $element['#form_key'] ?? NULL;
+    if (!empty($form_key)) {
+      $field = \Drupal::service('webform_civicrm.utils')->wf_crm_get_field($form_key);
+      if (isset($field['type']) && $field['type'] == 'civicrm_number') {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Ajax callback.
    *
    * @param array $form
@@ -253,20 +279,38 @@ class CivicrmOptions extends OptionsBase {
     $types = [];
     $has_multiple_values = $this->hasMultipleValues($element);
 
-    $supportedTypes = ['checkboxes', 'radios', 'select'];
+    $supportedTypes = [
+      'checkboxes',
+      'radios',
+      'webform_radios_other',
+      'select',
+      'webform_select_other',
+      'civicrm_number'
+    ];
     $elements = $this->elementManager->getInstances();
     foreach ($elements as $element_name => $element_instance) {
-      if (!in_array($element_name, $supportedTypes)) {
-        continue;
+      if (in_array($element_name, $supportedTypes)) {
+        $types[$element_name] = $element_instance->getPluginLabel();
       }
-      if ($has_multiple_values !== $element_instance->hasMultipleValues($element)) {
-        continue;
-      }
-      $types[$element_name] = $element_instance->getPluginLabel();
     }
 
     asort($types);
     return $types;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $properties = $this->getConfigurationFormProperties($form, $form_state);
+    if ($this->isNumberField($properties)) {
+      foreach ($properties['#options'] as $key => $option) {
+        if (!is_numeric($key)) {
+          $form_state->setErrorByName('options', $this->t('This is a CiviCRM number field. @field keys must be numeric.', ['@field' => $properties['#title']]));
+          break;
+        }
+      }
+    }
   }
 
 }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2534,7 +2534,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $val .= $time;
         }
         // The admin can change a number field to use checkbox/radio/select/grid widget and we'll sum the result
-        elseif ($field['type'] === 'number') {
+        elseif ($field['type'] === 'number' || $field['type'] === 'civicrm_number') {
           $sum = 0;
           foreach ((array) $val as $k => $v) {
             // Perform multiplication across grid elements


### PR DESCRIPTION
Overview
----------------------------------------
Allow number fields to be retyped into options element.

Before
----------------------------------------
Number fields (eg Contribution Amount, etc) cannot be changed to select, radio, checkboxes, etc.

After
----------------------------------------
Can be retyped into different widgets.

![image](https://user-images.githubusercontent.com/5929648/138544189-75a00e87-f3ef-4dea-9a52-028833296778.png)

Select `CiviCRM Options` from the list of related types.

![image](https://user-images.githubusercontent.com/5929648/138544199-7fd13b9e-72a1-40ae-937a-e6f88f5bc6bb.png)

If you still wanna change the type to native select, radio, radio_other, select_other, change the type from CiviCRM Options => these types.

![image](https://user-images.githubusercontent.com/5929648/138544225-e65f7c19-2b08-40f6-ad4f-c94851ccf8b0.png)
 

Technical Details
----------------------------------------
This PR adds a new plugin for numeric elements. (Civicrm Number). This can be retyped into our custom plugin Civicrm Options which is already able to render as select, radio, etc based on configurable settings for Listbox, Multiple checkboxes.

Comments
----------------------------------------
@KarinG 