### PR TITLE
Evaluate checksum on webform submit

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2299,6 +2299,7 @@ class AdminForm implements AdminFormInterface {
     if (isset($field['value_callback'])) {
       $method = 'get_default_' . $table . '_' . $name;
       $field['value'] = self::$method($field['form_key'], $options);
+      unset($field['value_callback']);
     }
     // For hidden+select fields such as contribution_page
     if ($field['type'] == 'hidden' && !empty($field['expose_list']) && !empty($settings[$field['form_key']])) {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2701,7 +2701,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $field = (array) $data[$fid];
     // During submission preprocessing this is used to alter the submission
     if ($value !== NULL) {
-      $field = (array) $value;
+      $data[$fid] = $value;
+      $webform_submission->setData($data);
+      return $value;
     }
     return $field;
   }


### PR DESCRIPTION
Overview
----------------------------------------
Evaluate checksum on submitting the webform.

Before
----------------------------------------

If a checksum element is present on the webform, it does not evaluate the cs value for the contact on submission. Tokens, etc are not rendered correctly. To replicate

- Create a contact with Fname, Lname and Checksum field
- Submit the webform.
- Result page displays 7 (cs limit) in the checksum column.

![image](https://user-images.githubusercontent.com/5929648/138689106-5d7fb02d-fa21-48e0-beff-2abfb5189e7d.png)


After
----------------------------------------

Fixed.

![image](https://user-images.githubusercontent.com/5929648/138689137-5642ede4-9092-4b92-9f03-be03f958d574.png)


