### PR TITLE
Multiple Case role selection on case configuration

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -507,6 +507,9 @@ class Fields implements FieldsInterface {
                     'data_type' => 'ContactReference',
                     'set' => 'caseRoles',
                     'empty_option' => t('None'),
+                    'extra' => [
+                      'multiple' => 1,
+                    ],
                   ];
                 }
                 $fields['case_role_' . $rel_type['id']]['case_types'][] = $case_type['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Multi select case roles in webform

Before
----------------------------------------
On d7 - we were able to select multiple contacts for case roles -

![image](https://user-images.githubusercontent.com/5929648/138695302-a275e879-38d8-48fb-a384-5543399c31ca.png)

On d9 - we can't.

After
----------------------------------------
Fixed -

![image](https://user-images.githubusercontent.com/5929648/138700040-c1cc933d-ce91-4f3c-8312-1cea379c2555.png)


