### PR TITLE
Fix inconsistencies with date fields

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -151,16 +151,19 @@ var wfCivi = (function ($, D, drupalSettings) {
       var n = name.split('-');
       if (n[0] === 'civicrm' && parseInt(n[1]) == num && n[2] === 'contact' && n[5] !== 'existing') {
         if (clear) {
+          var $wrapper = $(formClass +' div.form-item[class*="-'+(name.replace(/_/g, '-'))+'"]');
           // Reset country to default
           if (n[5] === 'country') {
             $('select.civicrm-processed', this).val(setting.defaultCountry).trigger('change', 'webform_civicrm:reset');
           }
           //Set default value if it is specified in component settings.
-          else if ($el.hasClass('form-date') && typeof defaults != "undefined" && defaults.hasOwnProperty(name)) {
-            var date = defaults[name].split('-');
-            $el.find('select.year, input.year').val(+date[0]);
-            $el.find('select.month').val(+date[1]);
-            $el.find('select.day').val(+date[2]);
+          else if ($wrapper.length && $wrapper.is('[class*="form-type-date"]')) {
+            if (typeof defaults != "undefined" && defaults.hasOwnProperty(name)) {
+              var date = defaults[name].split('-');
+              $(':input[id$="year"]', $wrapper).val(date[0]).trigger('change', 'webform_civicrm:autofill');
+              $(':input[id$="month"]', $wrapper).val(parseInt(date[1], 10)).trigger('change', 'webform_civicrm:autofill');
+              $(':input[id$="day"]', $wrapper).val(parseInt(date[2], 10)).trigger('change', 'webform_civicrm:autofill');
+            }
           }
           else {
             $(':input', this).not(':radio, :checkbox, :button, :submit, :file, .form-file').each(function() {
@@ -211,7 +214,12 @@ var wfCivi = (function ($, D, drupalSettings) {
       if (val.indexOf('-civicrm') > 0) {
         val = val.substring(val.lastIndexOf('-civicrm') + 1);
         if (val.indexOf('fieldset') < 0) {
-          name = val;
+          if (val.indexOf('custom-') != -1 && val.lastIndexOf('-year') != -5) {
+            name = val.replace('-year', '');
+          }
+          else {
+            name = val;
+          }
         }
       }
     });

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -871,19 +871,24 @@ abstract class WebformCivicrmBase {
   }
 
   /**
-   * Returns a default value for a component.
-   *
-   * @param object $node
+   * Returns default values for elements
+   * set on the webform.
    *
    * @return array
    */
-  function getDefaults() {
+  function getWebformDefaults() {
+    $utils = \Drupal::service('webform_civicrm.utils');
     $defaults = [];
     $elements = $this->node->getElementsDecodedAndFlattened();
     foreach ($elements as $comp) {
-      if (!empty($comp['#default_value'])) {
+      if (!empty($comp['#default_value']) && isset($comp['#form_key'])) {
         $key = str_replace('_', '-', $comp['#form_key']);
-        $defaults[$key] = $comp['#type'] == 'date' ? date('Y-m-d', strtotime($comp['#default_value'])) : $comp['#default_value'];
+        if ($comp['#type'] == 'date' || $comp['#type'] == 'datelist') {
+          $defaults[$key] = date('Y-m-d', strtotime($comp['#default_value']));
+        }
+        else {
+          $defaults[$key] = $comp['#default_value'];
+        }
       }
     }
     return $defaults;

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -86,7 +86,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $this->form['#attributes']['data-civicrm-ids'] = Json::encode($cid_data);
       }
     }
-    $this->form['#attributes']['data-form-defaults'] = Json::encode($this->getDefaults());
+    $this->form['#attributes']['data-form-defaults'] = Json::encode($this->getWebformDefaults());
     // Early return if the form (or page) was already submitted
     $triggering_element = $this->form_state->getTriggeringElement();
     if ($triggering_element && $triggering_element['#id'] == 'edit-wizard-prev'
@@ -553,7 +553,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             elseif ($element['#type'] == 'value') {
               $element['#value'] = $val;
             }
-            elseif ($element['#type'] == 'datetime') {
+            elseif ($element['#type'] == 'datetime' || $element['#type'] == 'datelist') {
               if (!empty($val)) {
                 $element['#default_value'] = DrupalDateTime::createFromTimestamp(strtotime($val));
               }


### PR DESCRIPTION
Overview
----------------------------------------
Fix issues with date fields.

Before
----------------------------------------
Issue 1: Custom date field is not loaded as default when the format is year only. To replicate

- Create a custom date field with format = yearonly
- Enable this on the webform.
- Since this is a yearonly field, change the type of this element from the build page. 

Type: Date list

![image](https://user-images.githubusercontent.com/5929648/139416454-89652590-2860-4d03-b1ef-8497434b6831.png)


- Make sure a contact A in civi is holding a value for this field.
- Load the webform with c1 = A loaded by default. i.e cid1=xx in the url.
- The year only date field is not loaded with the existing value from CiviCRM.

Issue 2: Same webform:

- Remove the default setting from existing contact element and change the widget to Autocomplete.
- Load the webform and select a contact from autocomplete contact field.
- The year value is not retrieved.

Issue 3: Same webform.

- Enter a default value of the year only date field to `today`.

![image](https://user-images.githubusercontent.com/5929648/139416787-25f9e5cb-b59d-4ffc-a0a0-2fb5b9a961ea.png)

- Edit Existing contact element: make sure the custom field is select to no autofill.

![image](https://user-images.githubusercontent.com/5929648/139416880-c89a2e36-1654-47fa-9290-ebef068e4154.png)

- Load the webform and ensure the date field value is set correctly before and after selecting a contact. i.e, it should stay as today's year.

After
----------------------------------------
Fixed. All 3 cases work as expected.


