### PR TITLE
D8/9 - Fix the submission of a locked field when it has a default value

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2606,12 +2606,18 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         if (in_array($type, $component['#hide_fields'])) {
           $value = wf_crm_aval($this->loadContact($c), "$table:$n:$name");
           // Check to see if configured to Submit disabled field value(s)
-          if ($checkSubmitDisabledSetting && !empty($component['#submit_disabled']) && !empty($value)) {
-            $fieldKey = implode('_', ['civicrm', $c, $ent, $n, $table, $name]);
-            $data = $this->submission->getData();
-            if (isset($data[$fieldKey])) {
-              $data[$fieldKey] = $value;
-              $this->submission->setData($data);
+          if ($checkSubmitDisabledSetting && !empty($component['#submit_disabled'])) {
+            // If field is disabled on the webform, do not overwrite existing values on the contact.
+            if (!empty($value) && !empty($this->submission)) {
+              $fieldKey = implode('_', ['civicrm', $c, $ent, $n, $table, $name]);
+              $data = $this->submission->getData();
+              if (isset($data[$fieldKey])) {
+                $data[$fieldKey] = $value;
+                $this->submission->setData($data);
+              }
+            }
+            else {
+              return FALSE;
             }
           }
           // With the no_hide_blank setting we must load the contact to determine if the field was hidden

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -357,6 +357,21 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   }
 
   /**
+   * Set default value on webform element.
+   */
+  protected function setDefaultValue($selector, $value) {
+    $this->assertSession()->elementExists('css', "[data-drupal-selector='{$selector}'] a.webform-ajax-link")->click();
+    $this->htmlOutput();
+    $this->assertSession()->waitForElementVisible('xpath', '//a[contains(@id, "--advanced")]');
+    $this->assertSession()->elementExists('xpath', '//a[contains(@id, "--advanced")]')->click();
+    $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-default"]')->click();
+    $this->getSession()->getPage()->fillField('properties[default_value]', $value);
+    $this->getSession()->getPage()->pressButton('Save');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertSession()->pageTextContains(' has been updated');
+  }
+
+  /**
    * Edit contact element on the build form.
    *
    * @param array $params
@@ -393,6 +408,12 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     }
     if (!empty($params['hide_fields'])) {
       $this->getSession()->getPage()->selectFieldOption('properties[hide_fields][]', $params['hide_fields']);
+    }
+    if (!empty($params['submit_disabled'])) {
+      $this->getSession()->getPage()->checkField("properties[submit_disabled]");
+    }
+    if (!empty($params['no_hide_blank'])) {
+      $this->getSession()->getPage()->checkField("properties[no_hide_blank]");
     }
 
     $this->assertSession()->waitForElementVisible('xpath', '//select[@name="properties[widget]"]');


### PR DESCRIPTION
Overview
----------------------------------------
Fix the submission of a locked field when it has a default value set on it.

Before
----------------------------------------
Locked field + submit disabled field setting does not submit a value to civi. To replicate -

- Enable a contact with `Relationship Description` field on a webform.
- Edit the existing contact element and lock the Relationship field set from `Fields to Lock` setting.
- Enable `Submit disabled field value` setting.
- Edit the `Relationship Description` field element and set a default value on it.
- Load the form. The element is hidden.
- Submit the form.
 
After
----------------------------------------
The value is saved.


