### PR TITLE
D8/9 render tags/symbols in status message

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -18,6 +18,8 @@ use Drupal\webform\Plugin\WebformHandlerInterface;
 use Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact;
 use Drupal\webform_civicrm\WebformCivicrmBase;
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\webform\Utility\WebformHtmlHelper;
+use Drupal\webform\Utility\WebformXss;
 
 
 class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivicrmPreProcessInterface {
@@ -832,7 +834,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
    */
   function setMessage($message, $type='status') {
     if (empty($_POST)) {
-      \Drupal::messenger()->addStatus($message);
+      \Drupal::messenger()->addStatus(WebformHtmlHelper::toHtmlMarkup($message, WebformXss::getHtmlTagList()));
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
HTML tags/symbols are not rendered in status message.

Before
----------------------------------------
HTML tags/symbols are not rendered in status message. To replicate

- Create a membership type with label "A & B".
- Add a membership for the contact.
- Create a webform and enable Membership type with user select option.
- Load the webform, the status message displayed above render as `A &amp; B`, something like -

![Screenshot 2021-11-02 at 6 18 59 PM](https://user-images.githubusercontent.com/5929648/139849734-f756f9fd-2797-4546-933b-0140aa9ed74d.jpg)


After
----------------------------------------
Fixed.

