### PR TITLE
D8/9 - extend membership count to 10

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1021,7 +1021,7 @@ class AdminForm implements AdminFormInterface {
         '#type' => 'select',
         '#title' => t('Number of Memberships for @contact', ['@contact' => $utils->wf_crm_contact_label($c, $this->data, 'wrap')]),
         '#default_value' => $num,
-        '#options' => range(0, 9),
+        '#options' => range(0, 10),
         '#prefix' => '<div class="number-of">',
         '#suffix' => '</div>',
       ];


### PR DESCRIPTION
Overview
----------------------------------------
Extend the range of membership to 10.

Before
----------------------------------------
Only 9 memberships can be created on a contact.

After
----------------------------------------
Extended to 10.

Comments
----------------------------------------
We use this on live from few weeks. ok to have this in core @KarinG?

 I'll add a test soon.