### PR TITLE
D8/9 - Add option to enable public groups on the webform

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1508,6 +1508,9 @@ class AdminForm implements AdminFormInterface {
       if ($field['type'] != 'hidden') {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
+      if ($name == 'group') {
+        $options += ['public_groups' => t('- Public Groups -')];
+      }
       $options += $utils->wf_crm_field_options($field, 'config_form', $this->data);
       $item += [
         '#type' => 'select',
@@ -1878,7 +1881,9 @@ class AdminForm implements AdminFormInterface {
         $field = $utils->wf_crm_get_field($key);
         if (!isset($enabled[$key])) {
           $val = (array) $val;
-          if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
+          if (in_array('create_civicrm_webform_element', $val, TRUE)
+          || (!empty($val[0]) && $field['type'] == 'hidden')
+          || (preg_match('/_group$/', $key) && in_array('public_groups', $val, TRUE))) {
             // Restore disabled component
             if (isset($disabled[$key])) {
               webform_component_update($disabled[$key]);
@@ -2146,7 +2151,7 @@ class AdminForm implements AdminFormInterface {
     // Find fields to delete
     foreach ($fields as $key => $val) {
       $val = (array) wf_crm_aval($this->settings, $key);
-      if (((in_array('create_civicrm_webform_element', $val, TRUE)) && $this->settings['nid'])
+      if (((in_array('create_civicrm_webform_element', $val, TRUE) || in_array('public_groups', $val, TRUE)) && $this->settings['nid'])
         || strpos($key, 'fieldset') !== FALSE) {
         unset($fields[$key]);
       }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -64,7 +64,12 @@ class FieldOptions implements FieldOptionsInterface {
         $ret = $utils->wf_crm_get_tags($ent, wf_crm_aval($split, 1));
       }
       elseif (isset($field['table']) && $field['table'] === 'group') {
-        $ret = $utils->wf_crm_apivalues('group', 'get', ['is_hidden' => 0], 'title');
+        $params = ['is_hidden' => 0];
+        $options = wf_crm_aval($data, "contact:$c:other:1:group");
+        if (!empty($options) && !empty($options['public_groups'])) {
+          $params['visibility'] = "Public Pages";
+        }
+        $ret = $utils->wf_crm_apivalues('group', 'get',  $params, 'title');
       }
       elseif ($name === 'survey_id') {
         $ret = $utils->wf_crm_get_surveys(wf_crm_aval($data, "activity:$c:activity:1", []));

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2440,6 +2440,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           }
           if (substr($name, 0, 6) === 'custom' || ($table == 'other' && in_array($name, ['group', 'tag']))) {
             $val = array_filter($val);
+            if ($name == 'group') {
+              unset($val['public_groups']);
+            }
           }
 
           // We need to handle items being de-selected too and provide an array to pass to Entity.create API


### PR DESCRIPTION
Overview
----------------------------------------
Add option to enable public groups on the webform

Before
----------------------------------------
https://chat.civicrm.org/civicrm/pl/u9pouzzjcidmbmf3dnmmcuwfsw

>iirc for Webform - currently we have the Groups field we can set to 'user select' but that then puts all groups on show, and one has to manually untick all non-public ones if the goal is to have this field function as a newsletter sign up group - correct? if so, do others see the benefit in having an option in the setting dropdown for eg
user selects (all groups)
user selects (public groups only)
and then hopefully that list would change on the form dynamically as Public Groups were added/removed. thoughts?
(edited)


After
----------------------------------------
Group field has a new option -

![image](https://user-images.githubusercontent.com/5929648/140496764-17a237d2-abed-46bf-86fd-58f691d99597.png)

If chosen - only public groups are loaded on the webform.

