### PR TITLE
Fix undefined variable from PR621

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -2195,7 +2195,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
           }
         }
       }
-      $item['price_field_id'] = $utils->wf_civicrm_api('PriceField', 'get', [
+      $item['price_field_id'] = wf_civicrm_api('PriceField', 'get', [
         'sequential' => 1,
         'price_set_id' => $priceSetId,
         'options' => ['limit' => 1],


### PR DESCRIPTION
Overview
----------------------------------------
Fix undefined variable from https://github.com/colemanw/webform_civicrm/pull/621. I think this was a miss in porting the PR from d8. `$utils` isn't available in d7 code so shouldn't be present. @KarinG Can you pls merge?