### PR TITLE
Add support for contact image.

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -104,7 +104,8 @@ var wfCivi = (function ($, D, drupalSettings) {
 
   pub.initFileField = function(field, info) {
     info = info || {};
-    var container = $('div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled');
+    var element = 'div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled';
+    var container = $(element.toLowerCase());
     if (container.length > 0) {
       if ($('.file', container).length > 0) {
         if ($('.file', container).is(':visible')) {
@@ -123,7 +124,8 @@ var wfCivi = (function ($, D, drupalSettings) {
   };
 
   pub.clearFileField = function(field) {
-    var container = $('div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled');
+    var element = 'div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled';
+    var container = $(element.toLowerCase());
     $('.civicrm-remove-file, .civicrm-file-icon', container).remove();
     $('input[type=file], input[type=submit]', container).show();
   };

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -103,6 +103,7 @@ class Fields implements FieldsInterface {
     $components = $this->getComponents();
     $sets = $this->getSets($components);
     $utils = \Drupal::service('webform_civicrm.utils');
+    $elements = \Drupal::service('plugin.manager.webform.element')->getInstances();
 
     static $fields = [];
 
@@ -192,17 +193,14 @@ class Fields implements FieldsInterface {
         'type' => 'select',
         'value' => $utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
       ];
-      /*
-       * @todo is this fine w/ the core file element?
-      if (array_key_exists('file', webform_components())) {
-        $fields['contact_image_URL'] = array(
+      if (!$elements['managed_file']->isDisabled() && !$elements['managed_file']->isHidden()) {
+        $fields['contact_image_URL'] = [
           'name' => t('Upload Image'),
-          'type' => 'file',
+          'type' => 'managed_file',
           'extra' => array('width' => 40),
           'data_type' => 'File',
-        );
+        ];
       }
-      */
       $fields['contact_contact_id'] = [
         'name' => t('Contact ID'),
         'type' => 'hidden',

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -8,6 +8,7 @@ namespace Drupal\webform_civicrm;
  */
 
 use Drupal\Component\Utility\UrlHelper;
+use Drupal\Core\Url;
 use Drupal\File\Entity\File;
 
 /**
@@ -834,10 +835,11 @@ abstract class WebformCivicrmBase {
       $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'getsingle', ['id' => $id]);
 
       if ($result) {
-        return [
-          'name' => $config->customFileUploadDir . wf_crm_aval($result, 'uri'),
-          'type' => wf_crm_aval($result, 'mime_type'),
-        ];
+        $photo = basename($config->customFileUploadDir . wf_crm_aval($result, 'uri'));
+        return Url::fromRoute('civicrm.civicrm_contact_imagefile', [], [
+          'query' => ['photo' => $photo],
+          'absolute' => TRUE,
+        ])->toString();
       }
     }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -7,6 +7,7 @@ namespace Drupal\webform_civicrm;
  * Front-end form handler base class.
  */
 
+use Drupal\Component\Utility\UrlHelper;
 use Drupal\File\Entity\File;
 
 /**
@@ -798,10 +799,11 @@ abstract class WebformCivicrmBase {
       return NULL;
     }
     if ($fieldName === 'image_URL') {
+      $parsed = UrlHelper::parse($val);
+
       return [
         'data_type' => 'File',
-        // Hardcode the name for now since the value is the file URL.
-        'name' => 'photo.jpg',
+        'name' => $parsed['query']['photo'],
         'icon' => 'image',
         'file_url' => $val,
       ];

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -798,11 +798,13 @@ abstract class WebformCivicrmBase {
       return NULL;
     }
     if ($fieldName === 'image_URL') {
-      return [
-        'data_type' => 'File',
-        'name' => NULL,
-        'icon' => $val,
-      ];
+      // @todo Figure out why, the image isn't returned correctly.
+      return NULL;
+      // return [
+      //   'data_type' => 'File',
+      //   'name' => NULL,
+      //   'icon' => $val,
+      // ];
     }
     $file = \Drupal::service('webform_civicrm.utils')->wf_crm_apivalues('Attachment', 'get', $val);
     if (!empty($file[$val])) {
@@ -821,12 +823,23 @@ abstract class WebformCivicrmBase {
    *
    * @param int $id Drupal file id
    *
-   * @return string|bool: url of file if found
+   * @return mixed
+   *   An array of the file entity or empty string.
    */
   function getDrupalFileUrl($id) {
-    $file = File::load($id);
+    if ($id = $this->saveDrupalFileToCivi($id)) {
+      $config = \CRM_Core_Config::singleton();
+      $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'getsingle', ['id' => $id]);
 
-    return $file ? file_create_url($file->uri) : FALSE;
+      if ($result) {
+        return [
+          'name' => $config->customFileUploadDir . wf_crm_aval($result, 'uri'),
+          'type' => wf_crm_aval($result, 'mime_type'),
+        ];
+      }
+    }
+
+    return '';
   }
 
   /**

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -798,13 +798,13 @@ abstract class WebformCivicrmBase {
       return NULL;
     }
     if ($fieldName === 'image_URL') {
-      // @todo Figure out why, the image isn't returned correctly.
-      return NULL;
-      // return [
-      //   'data_type' => 'File',
-      //   'name' => NULL,
-      //   'icon' => $val,
-      // ];
+      return [
+        'data_type' => 'File',
+        // Hardcode the name for now since the value is the file URL.
+        'name' => 'photo.jpg',
+        'icon' => 'image',
+        'file_url' => $val,
+      ];
     }
     $file = \Drupal::service('webform_civicrm.utils')->wf_crm_apivalues('Attachment', 'get', $val);
     if (!empty($file[$val])) {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -718,6 +718,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if ($params['contact_type'] == 'Individual' && empty($params['first_name']) && empty($params['last_name'])) {
       $params['display_name'] = $params['sort_name'] = empty($params['nick_name']) ? $contact['email'][1]['email'] : $params['nick_name'];
     }
+    if (isset($params['image_URL'])) {
+      \CRM_Contact_BAO_Contact::processImageParams($params);
+    }
     $result = $utils->wf_civicrm_api('contact', 'create', $params);
     return wf_crm_aval($result, 'id', 0);
   }
@@ -759,6 +762,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       }
     }
     $params['id'] = $this->ent['contact'][$c]['id'];
+    if (isset($params['image_URL'])) {
+      \CRM_Contact_BAO_Contact::processImageParams($params);
+    }
     $utils->wf_civicrm_api('contact', 'create', $params);
   }
 

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -718,9 +718,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if ($params['contact_type'] == 'Individual' && empty($params['first_name']) && empty($params['last_name'])) {
       $params['display_name'] = $params['sort_name'] = empty($params['nick_name']) ? $contact['email'][1]['email'] : $params['nick_name'];
     }
-    if (isset($params['image_URL'])) {
-      \CRM_Contact_BAO_Contact::processImageParams($params);
-    }
     $result = $utils->wf_civicrm_api('contact', 'create', $params);
     return wf_crm_aval($result, 'id', 0);
   }
@@ -762,9 +759,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       }
     }
     $params['id'] = $this->ent['contact'][$c]['id'];
-    if (isset($params['image_URL'])) {
-      \CRM_Contact_BAO_Contact::processImageParams($params);
-    }
     $utils->wf_civicrm_api('contact', 'create', $params);
   }
 

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -505,7 +505,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           if (isset($this->info[$ent][$c][$table][$n][$name])
             && !(isset($element['#form_key']) && isset($submitted[$element['#form_key']]))) {
             $val = $this->info[$ent][$c][$table][$n][$name];
-
             if ($ent === 'contact') {
               $createModeKey = 'civicrm_' . $c . '_contact_' . $n . '_' . $table . '_createmode';
               $multivaluesCreateMode = isset($this->data['config']['create_mode'][$createModeKey]) ? (int) $this->data['config']['create_mode'][$createModeKey] : NULL;
@@ -540,6 +539,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             // Contact image & custom file fields
             if ($dt == 'File') {
               $fileInfo = $this->getFileInfo($name, $val, $ent, $n);
+
               if ($fileInfo && in_array($element['#type'], ['file', 'managed_file'])) {
                 $elements['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
                   'eid' => $eid,


### PR DESCRIPTION
Overview
----------------------------------------
This is a fix for this issue - https://www.drupal.org/project/webform_civicrm/issues/3248702.

Before
----------------------------------------
Contact Image disabled.

After
----------------------------------------
Make contact image work.

Comments
----------------------------------------
Implementation is a bit different as compared to the old one as it seems that public allowed is default in the Drupal 7 version. The Drupal 7 implementation loads the contact image from the **Drupal file system** while this one loads it from the **CiviCRM file system** since private is the default storage for images and CiviCRM isn't able to access it.

~Currently, loading of the image upon webform submission doesn't work though i.e. when you create a new submission and the form contains file elements, custom file elements are loading the default image correctly although the contact image isn't loading the correct one - https://take.ms/KZb27.~

~I've added a `@todo` temporarily here - https://github.com/colemanw/webform_civicrm/pull/644/files#diff-c92b516a71a531e151759b309eb473bf58592139e399edb412d9be9217960d0aR801.~
