### PR TITLE
D8/9 - Fix default load of multiple custom group file fields

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -541,7 +541,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             if ($dt == 'File') {
               $fileInfo = $this->getFileInfo($name, $val, $ent, $n);
               if ($fileInfo && in_array($element['#type'], ['file', 'managed_file'])) {
-                $elements['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
+                $this->form['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
                   'eid' => $eid,
                   'fileInfo' => $fileInfo
                 ];


### PR DESCRIPTION
Overview
----------------------------------------
File previews not working when two custom groups with file fields are enabled

Before
----------------------------------------
File previews not working when two custom groups with file fields are enabled

![image](https://user-images.githubusercontent.com/5929648/143671413-479e07fb-a0d5-4dd6-bb64-da49749469fe.png)

After
----------------------------------------
Works fine.

Comments
----------------------------------------
Drupal Issue - https://www.drupal.org/project/webform_civicrm/issues/3249620