### PR TITLE
D8/9 - Enable waitlist registration via webforms

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -897,7 +897,7 @@ class AdminForm implements AdminFormInterface {
     $this->form['participant']['reg_options']['show_remaining'] = $field;
     $this->form['participant']['reg_options']['validate'] = [
       '#type' => 'checkbox',
-      '#title' => t('Prevent Registration for Past/Full Events'),
+      '#title' => t('Prevent Registration (enable waitlist) for Past/Full Events'),
       '#default_value' => (bool) wf_crm_aval($this->data, 'reg_options:validate'),
     ];
     $this->help($this->form['participant']['reg_options']['validate'], 'reg_options_validate');

--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -227,7 +227,10 @@ class AdminHelp implements AdminHelpInterface {
 
   protected function reg_options_validate() {
     return '<p>' .
-      t('Will not allow the form to be submitted if user registers for an event that is ended or full.') .
+      t('Will not allow the form to be submitted if user registers for an event that is ended or full.').
+      '</p>'.
+     '<p>' .
+      t('If an event offers a waitlist, the form will be submitted and the participant will be added to a waiting list.').
       '</p>';
   }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -29,6 +29,7 @@ abstract class WebformCivicrmBase {
   protected $data = [];
   protected $ent = [];
   protected $events = [];
+  protected $waitlist_events = [];
   protected $line_items = [];
   protected $membership_types = [];
   protected $loadedContacts = [];
@@ -625,7 +626,7 @@ abstract class WebformCivicrmBase {
     if (!empty($this->events)) {
       $now = time();
       $events = $this->utils->wf_crm_apivalues('Event', 'get', [
-        'return' => ['title', 'start_date', 'end_date', 'event_type_id', 'max_participants', 'financial_type_id', 'event_full_text', 'is_full'],
+        'return' => ['title', 'start_date', 'end_date', 'event_type_id', 'max_participants', 'financial_type_id', 'event_full_text', 'is_full', 'has_waitlist', 'waitlist_text'],
         'id' => ['IN' => array_keys($this->events)],
       ]);
       foreach ($events as $id => $event) {

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -305,7 +305,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         }
       }
     }
-    if ($this->events && (!empty($reg['show_remaining']) || !empty($reg['block_form']))) {
+    if ($this->events) {
       $this->loadEvents();
       foreach ($this->events as $eid => $event) {
         if ($event['ended']) {
@@ -313,9 +313,12 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             $this->setMessage(t('Sorry, %event has ended.', ['%event' => $event['title']]), 'warning');
           }
         }
+        elseif (!empty($event['is_full']) && !empty($event['has_waitlist']) && !empty($event['waitlist_text'])) {
+          $this->setMessage(Markup::create('<em>' . Html::escape($event['title']) . '</em>: ' . Html::escape($event['waitlist_text'])), 'warning');
+        }
         elseif (!empty($event['is_full'])) {
           if (!empty($reg['show_remaining'])) {
-            $this->setMessage('<em>' . Html::escape($event['title']) . '</em>: ' . Html::escape($event['event_full_text']), 'warning');
+            $this->setMessage(Markup::create('<em>' . Html::escape($event['title']) . '</em>: ' . Html::escape($event['event_full_text'])), 'warning');
           }
         }
         else {


### PR DESCRIPTION
Overview
----------------------------------------
Enable waitlist registration via webforms

Before
----------------------------------------
Can't submit a waitlist registration

After
----------------------------------------
Participants can be submitted with status = `On Waitlist` via webforms.

1. Extended this setting to support waitlist registrations -

![image](https://user-images.githubusercontent.com/5929648/143732967-d53c3b0d-2865-49d4-86eb-088511ee50e4.png)
 
2. So if an event has space available = 2 and webform is registering 3 participants to an event, the first 2 are registered and the 3rd one is added to the waitlist (Test added to assert this behaviour).
3. Waitlist text from CiviCRM is displayed on the webform if event is full.

![image](https://user-images.githubusercontent.com/5929648/143733047-7c7a0422-71a8-4d35-9c2b-522ebf7b16f5.png)

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3248788