### PR TITLE
Remove fixed value that makes relationship always active.

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -553,7 +553,6 @@ class Fields implements FieldsInterface {
         'name' => t('Is Active'),
         'type' => 'select',
         'expose_list' => TRUE,
-        'value' => '1',
       ];
       $fields['relationship_relationship_permission'] = [
         'name' => t('Permissions'),


### PR DESCRIPTION
Overview
----------------------------------------
When adding a Relationship -> the in_active field had a "value" = 1 (always) so you could never make a relationship inactive.

Removing the 1 from the Build tab -> Element config works. The is_active element can now be toggled to ON or OFF without it defaulting to 1 (ON) all the time.
