### PR TITLE
Remove old jQuery shim leftover from Drupal7 module

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -1,8 +1,3 @@
-// Shim for old versions of jQuery
-if (typeof jQuery.fn.prop !== 'function') {
-  jQuery.fn.prop = jQuery.fn.attr;
-}
-
 /**
  * Javascript Module for managing the webform_civicrm admin form.
  */

--- a/js/webform_civicrm_options.js
+++ b/js/webform_civicrm_options.js
@@ -1,8 +1,3 @@
-// Shim for old versions of jQuery
-if (typeof jQuery.fn.prop !== 'function') {
-  jQuery.fn.prop = jQuery.fn.attr;
-}
-
 /**
  * Javascript Module for managing webform_civicrm options for select elements.
  */


### PR DESCRIPTION
Overview
----------------------------------------
Removes code leftover from Drupal7's ancient version of jQuery

Before
----------------------------------------
Shim for Drupal7 exists

After
----------------------------------------
Gone