### PR TITLE
Webform use release instead of dev

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,8 @@ jobs:
       - name: Ensure Webform ^6.0
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev'
+	  COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.1'
+          #COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev'
       - name: Install webform_civicrm
         run: |
           cd ~/drupal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Ensure Webform ^6.0
         run: |
           cd ~/drupal
-	  COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.1'
+          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.1'
           #COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev'
       - name: Install webform_civicrm
         run: |


### PR DESCRIPTION
Overview
----------------------------------------
We started noticing test failures a few days ago. The test that failed consistently across all Drupal and CiviCRM versions is one of our integration tests -> `testTokensInEmail`

Taking a screenshot during the test (Github actions) -> shows CKEditor does not appear to be loading properly:

![image](https://user-images.githubusercontent.com/5340555/145723518-72619751-5a94-4031-9c67-a401a4a595a2.png)

Closer inspection -> we were testing against webform-dev (entire matrix). So I did:

Before
----------------------------------------
The build includes composer require 'drupal/webform:6.x-dev@dev' -> were ❌

After
----------------------------------------
The build now includes composer require 'drupal/webform:^6.1' ✅

Comments
----------------------------------------
There were just a handful of commits in the webform repo the past couple of days. Will open an issue on drupal.org to alert Jake.
