### PR TITLE
Add AJAX contribution.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,10 @@ jobs:
           - drupal: '9.2.*'
             civicrm: '5.39.*'
           - drupal: '9.2.*'
-            civicrm: '5.43.x-dev'
+            civicrm: '5.45.x-dev'
           - drupal: '9.2.*'
-            civicrm: 'dev-master'
+	    civicrm: '5.44.*'
+            #civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - drupal: '9.2.*'
             civicrm: '5.45.x-dev'
           - drupal: '9.2.*'
-	    civicrm: '5.44.*'
+            civicrm: '5.44.*'
             #civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -144,4 +144,4 @@
     }
   }
 
-})(jQuery, Drupal, drupalSettings);
+})(cj, Drupal, drupalSettings);

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -212,6 +212,7 @@ final class StripeTest extends WebformCivicrmTestBase {
 
     $this->assertCount(3, $this->getOptions('Payment Processor'));
     $this->getSession()->getPage()->selectFieldOption('Payment Processor', $this->paymentProcessorID);
+    $this->enableBillingSection();
 
     $this->getSession()->getPage()->selectFieldOption('lineitem_1_number_of_lineitem', 2);
     $this->assertSession()->assertWaitOnAjaxRequest();

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -152,7 +152,10 @@ final class StripeTest extends WebformCivicrmTestBase {
    */
   private function verifyPaymentResult() {
     $utils = \Drupal::service('webform_civicrm.utils');
-    $api_result = $this->utils->wf_civicrm_api('contribution', 'get', []);
+    $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
+      'contribution_status_id' => 'Completed',
+      'sequential' => 1,
+    ]);
     $this->assertEquals(1, $api_result['count']);
     $contribution = reset($api_result['values']);
     $this->assertNotEmpty($contribution['trxn_id']);


### PR DESCRIPTION
Overview
----------------------------------------
When AJAX is enabled for a webform and contribution is enabled, the contribution doesn't work. The line items are not being updated and the billing block is not loaded.

The AJAX contribution is found under Settings > General > AJAX settings. This has been only manually tested though.

I don't seem to find this on the d.o issue queue.

Before
----------------------------------------

Contribution not working when AJAX is enabled.

After
----------------------------------------

Contribution is working when AJAX is enabled.

Technical Details
----------------------------------------

The relevant JS in webform_civicrm_payment.js responsible for updating the line item total and loading billing block is wrapped inside Drupal.behaviors similar to webform_civicrm_forms.js.

`cj` is also replaced by just `jQuery` which seemed to work fine when I tested.