### PR TITLE
Change package to "CiviCRM"

### DIFF
--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -2,7 +2,7 @@ name: 'Webform CiviCRM'
 type: module
 description: 'Webform CiviCRM Integration'
 core_version_requirement: ^8.8 || ^9
-package: 'Custom'
+package: 'CiviCRM'
 dependencies:
   - drupal:webform
   - civicrm


### PR DESCRIPTION
Changes the package so the module is grouped with other CiviCRM modules.

Historically, this module has been in the "CiviCRM" package: https://github.com/colemanw/webform_civicrm/blob/7.x-5.x/webform_civicrm.info#L4

I think this might have been an oversight during the porting process, as "Custom" is probably boilerplate code.