### PR TITLE
Fix updating records when editing a submission

### DIFF
--- a/src/Plugin/WebformHandler/CivicrmWebformHandler.php
+++ b/src/Plugin/WebformHandler/CivicrmWebformHandler.php
@@ -126,7 +126,7 @@ class CivicrmWebformHandler extends WebformHandlerBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
     $this->civicrm->initialize();
-    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission->getWebform());
+    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission);
     $processor->validate($form, $form_state, $webform_submission);
   }
 
@@ -135,7 +135,7 @@ class CivicrmWebformHandler extends WebformHandlerBase {
    */
   public function preSave(WebformSubmissionInterface $webform_submission) {
     $this->civicrm->initialize();
-    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission->getWebform());
+    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission);
     $processor->preSave($webform_submission);
   }
 
@@ -144,7 +144,7 @@ class CivicrmWebformHandler extends WebformHandlerBase {
    */
   public function postSave(WebformSubmissionInterface $webform_submission, $update = TRUE) {
     $this->civicrm->initialize();
-    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission->getWebform());
+    $processor = \Drupal::service('webform_civicrm.postprocess')->initialize($webform_submission);
     $processor->postSave($webform_submission);
   }
 

--- a/src/Plugin/WebformHandler/CivicrmWebformHandler.php
+++ b/src/Plugin/WebformHandler/CivicrmWebformHandler.php
@@ -108,9 +108,7 @@ class CivicrmWebformHandler extends WebformHandlerBase {
 
   public function alterForm(array &$form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission) {
     $this->civicrm->initialize();
-    $settings = $this->configuration;
-    $data = $settings['data'];
-    $processor = \Drupal::service('webform_civicrm.preprocess')->initialize($form, $form_state, $this);
+    $processor = \Drupal::service('webform_civicrm.preprocess')->initialize($form, $form_state, $this, $webform_submission);
     $processor->alterForm();
   }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -132,10 +132,13 @@ abstract class WebformCivicrmBase {
     $contact = $this->data['contact'][$c];
     $prefix = 'civicrm_' . $c . '_contact_1_';
     $existing_contact_field = $this->node->getElement($prefix . 'contact_existing');
-    $element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
-    $existing_component_plugin = $element_manager->getElementInstance($existing_contact_field);
-    $element_exclude = $existing_component_plugin->getElementProperty($existing_contact_field, 'no_autofill');
-    $exclude = array_merge($exclude, $element_exclude);
+    // If editing a webform submission, contact id might be present without being supplied by an existing_contact field
+    if ($existing_contact_field) {
+      $element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
+      $existing_component_plugin = $element_manager->getElementInstance($existing_contact_field);
+      $element_exclude = $existing_component_plugin->getElementProperty($existing_contact_field, 'no_autofill');
+      $exclude = array_merge($exclude, $element_exclude);
+    }
     foreach (array_merge(['contact'], $this->utils->wf_crm_location_fields()) as $ent) {
       if ((!empty($contact['number_of_' . $ent]) && !in_array($ent, $exclude)) || $ent == 'contact') {
         $params = ['contact_id' => $cid];

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2779,7 +2779,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $saveParams = ['id' => $cid];
     foreach ($contact as $table => $items) {
       if (is_array($items) && $items && $this->isMultiRecordCustomSet($table)) {
-        $existingCustomData = $existingCustomData ?? $this->getCustomData($cid, 'contact', FALSE);
+        $existingCustomData = $existingCustomData ?? $this->getCustomData($cid, 'contact', FALSE, $index);
         $existing = $existingCustomData[$table] ?? [];
         // Index existing ids beginning with 1
         $existingIds = array_slice(array_merge([NULL], array_keys($existing)), 1, NULL, TRUE);

--- a/src/WebformCivicrmPostProcessInterface.php
+++ b/src/WebformCivicrmPostProcessInterface.php
@@ -15,30 +15,27 @@ use Drupal\webform\WebformSubmissionInterface;
 interface WebformCivicrmPostProcessInterface {
 
 
-  function initialize(WebformInterface $webform);
+  function initialize(WebformSubmissionInterface $webform_submission);
 
   /**
    * Called after a webform is submitted
    * Or, for a multipage form, called after each page
    * @param array $form
-   * @param array $form_state (reference)
+   * @param FormStateInterface $form_state
    */
-  public function validate($form, FormStateInterface $form_state, WebformSubmissionInterface $webform_submission);
+  public function validate($form, FormStateInterface $form_state);
 
   /**
-   * Process webform submission when it is about to be saved. Called by the following hook:
-   *
-   * @see webform_civicrm_webform_submission_presave
+   * Process webform submission when it is about to be saved.
    *
    * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
    */
   public function preSave(WebformSubmissionInterface $webform_submission);
 
   /**
-   * Process webform submission after it is has been saved. Called by the following hooks:
-   * @see webform_civicrm_webform_submission_insert
-   * @see webform_civicrm_webform_submission_update
-   * @param stdClass $submission
+   * Process webform submission after it is has been saved.
+   *
+   * @param \Drupal\webform\WebformSubmissionInterface $webform_submission
    */
   public function postSave(WebformSubmissionInterface $webform_submission);
 

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -54,6 +54,17 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     $this->all_sets = $this->utils->wf_crm_get_fields('sets');
     $this->enabled = $this->utils->wf_crm_enabled_fields($handler->getWebform());
     $this->line_items = $form_state->get(['civicrm', 'line_items']) ?: [];
+    $this->editingSubmission = $webform_submission->id();
+    // If editing an existing submission, load entity data
+    if ($this->editingSubmission) {
+      $query = \Drupal::database()->select('webform_civicrm_submissions', 'wcs')
+        ->fields('wcs', ['civicrm_data'])
+        ->condition('sid', $this->editingSubmission, '=');
+      $content = $query->execute()->fetchAssoc();
+      if (!empty($content['civicrm_data'])) {
+        $this->ent = unserialize($content['civicrm_data']);
+      }
+    }
     return $this;
   }
 

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -15,6 +15,7 @@ use Drupal\Core\Link;
 use Drupal\Core\Render\Markup;
 use Drupal\Core\Url;
 use Drupal\webform\Plugin\WebformHandlerInterface;
+use Drupal\webform\WebformSubmissionInterface;
 use Drupal\webform_civicrm\Plugin\WebformElement\CivicrmContact;
 use Drupal\webform_civicrm\WebformCivicrmBase;
 use Drupal\Core\Datetime\DrupalDateTime;
@@ -29,7 +30,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
   private $info = [];
   private $all_fields;
   private $all_sets;
-  private $handler;
 
   public function __construct(UtilsInterface $utils) {
     $this->utils = $utils;
@@ -38,12 +38,12 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
   /**
    * Initialize form variables.
    *
-   * @param $form
-   * @param $form_state
-   * @param $handler
+   * @param array $form
+   * @param FormStateInterface $form_state
+   * @param WebformHandlerInterface $handler
+   * @param WebformSubmissionInterface $webform_submission
    */
-  function initialize(&$form, FormStateInterface $form_state, WebformHandlerInterface $handler) {
-    $this->handler = $handler;
+  function initialize(array &$form, FormStateInterface $form_state, WebformHandlerInterface $handler, WebformSubmissionInterface $webform_submission) {
     $this->form = &$form;
     $this->form_state = $form_state;
     $this->node = $handler->getWebform();
@@ -518,15 +518,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           if (isset($this->info[$ent][$c][$table][$n][$name])
             && !(isset($element['#form_key']) && isset($submitted[$element['#form_key']]))) {
             $val = $this->info[$ent][$c][$table][$n][$name];
-            if ($ent === 'contact') {
-              $createModeKey = 'civicrm_' . $c . '_contact_' . $n . '_' . $table . '_createmode';
-              $multivaluesCreateMode = isset($this->data['config']['create_mode'][$createModeKey]) ? (int) $this->data['config']['create_mode'][$createModeKey] : NULL;
-
-              // Set empty value for field with 'Create only' mode.
-              if ($multivaluesCreateMode === self::MULTIVALUE_FIELDSET_MODE_CREATE_ONLY) {
-                $val = wf_crm_aval($element, '#default_value', '');
-              }
-            }
             if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
               $val = $this->utils->wf_crm_explode_multivalue_str($val);
             }

--- a/src/WebformCivicrmPreProcessInterface.php
+++ b/src/WebformCivicrmPreProcessInterface.php
@@ -4,17 +4,19 @@ namespace Drupal\webform_civicrm;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\webform\Plugin\WebformHandlerInterface;
+use Drupal\webform\WebformSubmissionInterface;
 
 interface WebformCivicrmPreProcessInterface {
 
   /**
    * Initialize form variables.
    *
-   * @param $form
-   * @param $form_state
-   * @param $handler
+   * @param array $form
+   * @param FormStateInterface $form_state
+   * @param WebformHandlerInterface $handler
+   * @param WebformSubmissionInterface $webform_submission
    */
-  function initialize(&$form, FormStateInterface $form_state, WebformHandlerInterface $handler);
+  function initialize(array &$form, FormStateInterface $form_state, WebformHandlerInterface $handler, WebformSubmissionInterface $webform_submission);
 
   /**
    * Alter front-end of webforms: Called by hook_form_alter() when rendering a civicrm-enabled webform

--- a/tests/src/FunctionalJavascript/SubmissionEditTest.php
+++ b/tests/src/FunctionalJavascript/SubmissionEditTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
+
+use Drupal\Core\Url;
+use Drupal\webform\Entity\WebformSubmission;
+
+/**
+ * Tests editing webform submissions.
+ *
+ * @group webform_civicrm
+ */
+final class SubmissionEditTest extends WebformCivicrmTestBase {
+
+  public function testEditSubmission() {
+    // Set up webform-civicrm with one contact, create-only
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->uncheckField("civicrm_1_contact_1_contact_existing");
+    $this->saveCiviCRMSettings();
+
+    $oldMax = $this->getMaxId();
+
+    // Submit form to create a contact
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->getSession()->getPage()->fillField('First Name', 'Dummy');
+    $this->getSession()->getPage()->fillField('Last Name', 'Tester');
+    $this->getSession()->getPage()->pressButton('Submit');
+
+    // Should have created one contact
+    $newMax = $this->getMaxId();
+    $this->assertEquals($oldMax + 1, $newMax);
+
+    $this->assertEquals('Dummy', civicrm_api3('Contact', 'get', ['id' => $newMax])['values'][$newMax]['first_name']);
+
+    // Get submission id
+    $database = \Drupal::database();
+    $query = $database->query("SELECT MAX(sid) AS maxsid FROM {webform_submission} WHERE webform_id = :wfid", [
+      ':wfid' => $this->webform->id(),
+    ]);
+    $sid = $query->fetchAll()[0]->maxsid;
+    $submission = WebformSubmission::load($sid);
+
+    // Edit submission and save
+    $this->drupalGet($submission->toUrl('edit-form'));
+    $this->getSession()->getPage()->fillField('First Name', 'Smarty');
+    $this->getSession()->getPage()->fillField('Last Name', 'Tester');
+    $this->getSession()->getPage()->pressButton('Save');
+
+    // Should have updated not created a new contact
+    $this->assertEquals($newMax, $this->getMaxId());
+
+    $this->assertEquals('Smarty', civicrm_api3('Contact', 'get', ['id' => $newMax])['values'][$newMax]['first_name']);
+
+  }
+
+  protected function getMaxId($entity = 'Contact') {
+    return civicrm_api3($entity, 'get', [
+      'options' => ['sort' => "id DESC", 'limit' => 1]
+    ])['id'];
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Ensures that when editing an existing submission, the previously submitted contacts, etc will be updated.

Before
----------------------------------------

**Problem 1**
1. Make a "create new contact" style webform (without existing contact matching)
2. Submit the form. A new contact will be created.
3. Go back and edit the submission, then submit again.
4. Instead of updating the contact previously created, it creates a 2nd contact.

**Problem 2**
1. Add a multi-record custom group which contains a text field and a contact ref field
2. Expose both to a "create new contact" style webform, adding a 2nd contact to the form as the value of the contact reference field.
3. When saving the form, 2 records will be inserted, one for each field. Should have been a single record with both values.

**Problem 3**
1. Add a multi-record custom group with some fields
2. Make an "update current user" style webform (existing contact match to user)
3. Add one set of the multi-value fields, selecting "Create Only" for the create mode.
4. Submit the form. Note one custom record has been inserted.
5. Edit the form submission and save. Note a second record has been inserted instead of updating the previously created one.

After
----------------------------------------
All the above work as expected now.