### PR TITLE
Cleanup old hooks

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -377,17 +377,10 @@ function webform_civicrm_civicrm_merge($type, $data, $new_id = NULL, $old_id = N
 }
 
 /**
- * Implements hook_admin_paths().
- */
-function webform_civicrm_admin_paths() {
-  return ['node/*/civicrm' => TRUE];
-}
-
-/**
  * Implements hook_help().
  */
 function webform_civicrm_help($section) {
-  if ($section == 'admin/help#webform_civicrm') {
+  if ($section == 'help.page.webform_civicrm') {
     // Return a line-break version of the module README.md
     return nl2br(file_get_contents(drupal_get_path('module', 'webform_civicrm') . '/README.md'));
   }


### PR DESCRIPTION
Overview
----------------------------------------
Deletes one unused hook that no longer exists in D9, and fixes the path for `hook_help()` (the output is pretty lame, but at least it works now).