### PR TITLE
Incorrect event count leads to broken line items

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -503,16 +503,15 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         'is_test' => 0,
       ]);
       foreach ($existing as $participant) {
-        if (isset($this->events[$participant['event_id']])) {
-          if (!(--$this->events[$participant['event_id']]['count'])) {
-            unset($this->events[$participant['event_id']]);
-          }
-        }
         foreach ($this->line_items as $k => &$item) {
           if ($participant['event_id'] == $item['event_id'] && in_array($participant['contact_id'], $item['contact_ids'])) {
             unset($this->line_items[$k]['contact_ids'][array_search($participant['contact_id'], $item['contact_ids'])]);
             if (!(--$item['qty'])) {
               unset($this->line_items[$k]);
+            }
+            // Update the count in $this->events elements.
+            if (!(--$this->events[$participant['event_id']]['count'])) {
+              unset($this->events[$participant['event_id']]);
             }
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
When submitting an event registration for an existing contact, WFC checks to see if the contact is already registered, and if so, removes the registration/line item from the payment page.  However, this code can lead to incorrect line items for unrelated contacts.

### Steps to replicate
* Create a webform with two contacts, event reg enabled, with reg method of "Register each contact separately".
* Register contact 1 for Event A (through form or backend, doesn't matter).
* Start the form over.  Register contact 1 for Event B and contact 2 for Event A.
* When you reach the registration page, the line item for contact 2 won't have the event name.

Before
----------------------------------------
Contacts who register for an event a different contact has registered for won't display the event name in the line item.

After
----------------------------------------
Line items display correctly.

Technical Details
----------------------------------------
Starting with the comment `// Subtract events already registered for - this only works with known contacts`, the following happens:
* Gather a list of existing contact IDs and event IDs in the current submission
* Use `Participant.get` to get the existing records which contain both the contact and event IDs.
Notably, it is *not* getting records where the contact and event ID for a single registration match.  E.g. in the example above, the second submission will return contact 1's registration for event A, even though contact 1 isn't registering for event A.
* We then decrement the count of registrations for found registration in `$this->events` - even if the registration doesn't match on both contact and event.
* Then we do the same for `$this->line_items` - but this time we *do* check that it matches on both.

If the count of registrations reaches 0, the event is removed from `$this->events`, so a few lines down, when creating a line item description, the event name is inaccessible.

Comments
----------------------------------------
I solved this by moving the "decrement, and unset if we reach 0" code into the `$this->line_items` loop, since it correctly checks that both contact and event IDs match.
