### PR TITLE
D8/9 - Fix ajax load of radio, checkbox and date fields

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -228,13 +228,14 @@ var wfCivi = (function ($, D, drupalSettings) {
         pub.initFileField(fid, this);
         return;
       }
-      var $wrapper = $(formClass +' div.form-item[class*="--'+(fid.replace(/_/g, '-'))+'"]');
+      var $wrapper = $(formClass +' div.form-item[class*="-'+(fid.replace(/_/g, '-'))+'"]');
       if (this.data_type === 'Date') {
         var vals = val.split(' ');
-        var $el = $('input[type="date"]', $wrapper);
-        if ($el.length) {
-          $('input[type="date"]', $wrapper).val(vals[0]).trigger('change', 'webform_civicrm:autofill');
-          $('input[type="time"]', $wrapper).val(vals[1]).trigger('change', 'webform_civicrm:autofill');
+        var $date_el = $('input[name="' + fid + '[date]"]', $wrapper);
+        var $time_el = $('input[name="' + fid + '[time]"]', $wrapper);
+        if ($date_el.length) {
+          $date_el.val(vals[0]).trigger('change', 'webform_civicrm:autofill');
+          $time_el.val(vals[1]).trigger('change', 'webform_civicrm:autofill');
         }
         else {
           var date = val.split('-');

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -228,6 +228,24 @@ var wfCivi = (function ($, D, drupalSettings) {
         pub.initFileField(fid, this);
         return;
       }
+      var $wrapper = $(formClass +' div.form-item[class*="--'+(fid.replace(/_/g, '-'))+'"]');
+      if (this.data_type === 'Date') {
+        var vals = val.split(' ');
+        var $el = $('input[type="date"]', $wrapper);
+        if ($el.length) {
+          $('input[type="date"]', $wrapper).val(vals[0]).trigger('change', 'webform_civicrm:autofill');
+          $('input[type="time"]', $wrapper).val(vals[1]).trigger('change', 'webform_civicrm:autofill');
+        }
+        else {
+          var date = val.split('-');
+          if (date.length === 3) {
+            $(':input[id$="year"]', $wrapper).val(date[0]).trigger('change', 'webform_civicrm:autofill');
+            $(':input[id$="month"]', $wrapper).val(parseInt(date[1], 10)).trigger('change', 'webform_civicrm:autofill');
+            $(':input[id$="day"]', $wrapper).val(parseInt(date[2], 10)).trigger('change', 'webform_civicrm:autofill');
+          }
+        }
+        return;
+      }
       // First try to find a single element - works for textfields and selects
       var $el = $(formClass +' :input.civicrm-enabled[name$="'+fid+'"]').not(':checkbox, :radio');
       if ($el.length) {
@@ -245,26 +263,11 @@ var wfCivi = (function ($, D, drupalSettings) {
           $el.val(val).trigger('change', 'webform_civicrm:autofill');
         }
       }
-      // Next go after the wrapper - for radios, dates & checkboxes
+      // Next go after the wrapper - for radios & checkboxes
       else {
-        var $wrapper = $(formClass +' div.form-item.webform-component[class*="--'+(fid.replace(/_/g, '-'))+'"]');
-        if ($wrapper.length) {
-          // Date fields
-          if ($wrapper.hasClass('webform-component-date')) {
-            var vals = val.split('-');
-            if (vals.length === 3) {
-              $(':input[id$="year"]', $wrapper).val(vals[0]).trigger('change', 'webform_civicrm:autofill');
-              $(':input[id$="month"]', $wrapper).val(parseInt(vals[1], 10)).trigger('change', 'webform_civicrm:autofill');
-              $(':input[id$="day"]', $wrapper).val(parseInt(vals[2], 10)).trigger('change', 'webform_civicrm:autofill');
-            }
-          }
-          // Checkboxes & radios
-          else {
-            $.each($.makeArray(val), function(k, v) {
-              $(':input[value="'+v+'"]', $wrapper).prop('checked', true).trigger('change', 'webform_civicrm:autofill');
-            });
-          }
-        }
+        $.each($.makeArray(val), function(k, v) {
+          $('input[value="'+v+'"]', $wrapper).prop('checked', true).trigger('change', 'webform_civicrm:autofill');
+        });
       }
     });
   }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -239,12 +239,18 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    * Assert populated values on the field.
    * fieldValueEquals() fails for populated values on chromedriver > 91
    *
-   * @param $id
+   * @param $selector
    * @param $value
+   * @param $isRadio
    */
-  public function assertFieldValue($id, $value) {
+  public function assertFieldValue($selector, $value, $isRadio = FALSE) {
     $driver = $this->getSession()->getDriver();
-    $fieldVal = $driver->evaluateScript("document.getElementById('{$id}').value;");
+    if ($isRadio) {
+      $fieldVal = $driver->evaluateScript("document.querySelector(\"input[type=radio][name='{$selector}']:checked\").value;");
+    }
+    else {
+      $fieldVal = $driver->evaluateScript("document.getElementById('{$selector}').value;");
+    }
     $this->assertEquals($fieldVal, $value);
   }
 
@@ -492,7 +498,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    */
   protected function assertOptionSelected($id, $option, $message = NULL) {
     $option_field = $this->assertSession()->optionExists($id, $option);
-    $message = $message ?: "Option $option for field $id is selected.";
+    $message = $message ?: "Option $option for field $id is not selected.";
     $this->assertTrue($option_field->hasAttribute('selected'), $message);
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fix ajax load of contact values on radio, checkbox and date fields

Before
----------------------------------------
Existing Contact does not populate webform for radio and multiple select. 

Details in https://www.drupal.org/project/webform_civicrm/issues/3252095

After
----------------------------------------
Fixed.


