### PR TITLE
D8/9 - Include webform receipt values in contribution emails

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,7 @@ jobs:
       # - CiviCRM requires `compile-mode: all`
       - name: Setup sendmail
         run: |
-        sudo apt-get install sendmail
+          sudo apt-get install sendmail
       - name: Setup Drupal
         run: |
           COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
       # Notes
       # - Must enable patching for civicrm/civicrm-core
       # - CiviCRM requires `compile-mode: all`
+      - name: Setup sendmail
+        run: |
+        sudo apt-get install sendmail
       - name: Setup Drupal
         run: |
           COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:${{ matrix.drupal }} ~/drupal --no-interaction

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -976,4 +976,27 @@ class Utils implements UtilsInterface {
     }
   }
 
+  /**
+   * Build params for contribution receipt.
+   *
+   * @return array
+   */
+  public function getReceiptParams($data, $contributionID) {
+    $contributionData = wf_crm_aval($data, 'contribution:1:contribution:1');
+    $params = ['id' => $contributionID];
+    $params['payment_processor_id'] = $contributionData['payment_processor_id'];
+    unset($params['payment_processor']);
+
+    $params['financial_type_id'] = $contributionData['financial_type_id'];
+    $params['currency'] = wf_crm_aval($data, "contribution:1:currency");
+
+    //Assign receipt values set on the webform config page.
+    $receipt = wf_crm_aval($data, "receipt", []);
+    $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'pay_later_receipt', 'receipt_from_name', 'receipt_from_email'];
+    foreach ($receiptValues as $val) {
+      $params[$val] = $receipt["number_number_of_receipt_{$val}"] ?? '';
+    }
+    return $params;
+  }
+
 }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -352,30 +352,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $template = \CRM_Core_Smarty::singleton();
       $template->assign('is_pay_later', 1);
     }
-    $this->utils->wf_civicrm_api('contribution', 'sendconfirmation', $this->getReceiptParams());
-  }
-
-  /**
-   * Build params for contribution receipt.
-   *
-   * @return array
-   */
-  private function getReceiptParams() {
-    $contributionData = wf_crm_aval($this->data, 'contribution:1:contribution:1');
-    $params = ['id' => $this->ent['contribution'][1]['id']];
-    $params['payment_processor_id'] = $contributionData['payment_processor_id'];
-    unset($params['payment_processor']);
-
-    $params['financial_type_id'] = $contributionData['financial_type_id'];
-    $params['currency'] = wf_crm_aval($this->data, "contribution:1:currency");
-
-    //Assign receipt values set on the webform config page.
-    $receipt = wf_crm_aval($this->data, "receipt", []);
-    $receiptValues = ['cc_receipt', 'bcc_receipt', 'receipt_text', 'pay_later_receipt', 'receipt_from_name', 'receipt_from_email'];
-    foreach ($receiptValues as $val) {
-      $params[$val] = $receipt["number_number_of_receipt_{$val}"] ?? '';
-    }
-    return $params;
+    $this->utils->wf_civicrm_api('contribution', 'sendconfirmation', $this->utils->getReceiptParams($this->data, $this->ent['contribution'][1]['id']));
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -23,7 +23,10 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     ]));
     $this->enableCivicrmOnWebform();
 
-    $this->configureContributionTab(FALSE, $payment_processor['id']);
+    $params = [
+      'pp' => $payment_processor['id'],
+    ];
+    $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField("Contribution Amount");
     $this->assertSession()->checkboxChecked("Contribution Amount");
 
@@ -90,7 +93,10 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->clickLink('2. Contact 2');
     $this->getSession()->getPage()->checkField("civicrm_2_contact_1_contact_existing");
 
-    $this->configureContributionTab(FALSE, $payment_processor['id']);
+    $params = [
+      'pp' => $payment_processor['id'],
+    ];
+    $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField("Contribution Amount");
     $this->assertSession()->checkboxChecked("Contribution Amount");
     $el = $this->getSession()->getPage()->findField('Payment Processor');
@@ -253,7 +259,10 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertSession()->waitForField('nid');
     $this->getSession()->getPage()->checkField('nid');
 
-    $this->configureContributionTab(FALSE, $payment_processor['id']);
+    $params = [
+      'pp' => $payment_processor['id'],
+    ];
+    $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField('Contribution Amount');
     $el = $this->getSession()->getPage()->findField('Payment Processor');
     $opts = $el->findAll('css', 'option');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -261,7 +261,11 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
 
     // Configure Contribution tab.
-    $this->configureContributionTab(FALSE, $payment_processor['id'], '2');
+    $params = [
+      'pp' => $payment_processor['id'],
+      'financial_type_id' => 2,
+    ];
+    $this->configureContributionTab($params);
 
     // Configure Membership tab.
     $this->getSession()->getPage()->clickLink('Memberships');

--- a/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MultiCustomFieldsSubmissionTest.php
@@ -109,7 +109,7 @@ final class MultiCustomFieldsSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     //Configure Contribution tab.
-    $this->configureContributionTab(TRUE);
+    $this->configureContributionTab();
     $this->getSession()->getPage()->checkField('Contribution Amount');
     $this->assertSession()->checkboxChecked('Contribution Amount');
 

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -44,6 +44,44 @@ function webform_civicrm_library_info_alter(array &$libraries, $extension) {
 }
 
 /**
+ * Add webform receipt params to contribution emails.
+ *
+ * @param array $params
+ * @param string $context
+ */
+function webform_civicrm_civicrm_alterMailParams(&$params, $context) {
+  if (!empty($params['valueName'])) {
+    if (in_array($params['valueName'], ['contribution_online_receipt', 'membership_online_receipt']) && !empty($params['tplParams']['contributionID'])) {
+      $query = \Drupal::database()
+        ->select('webform_civicrm_submissions', 'wcs')
+        ->condition('civicrm_data', "%{$params['tplParams']['contributionID']}%", 'LIKE')
+        ->condition('contact_id', "%-{$params['contactId']}-%", 'LIKE')
+        ->fields('wcs', ['sid', 'civicrm_data']);
+      $query->leftJoin('webform_submission', 'ws', 'ws.sid = wcs.sid');
+      $query->isNotNull('ws.sid');
+      $results = $query->execute();
+
+      while ($content = $results->fetchAssoc()) {
+        $civicrm_data = unserialize($content['civicrm_data']);
+        if (!empty($content['sid']) && !empty($civicrm_data['contribution'][1]['id']) && $civicrm_data['contribution'][1]['id'] == $params['tplParams']['contributionID']) {
+          $submission = WebformSubmission::load($content['sid']);
+          $webform = $submission->getWebform();
+          $handler = $webform->getHandlers('webform_civicrm');
+          $config = $handler->getConfiguration();
+          if (empty($config['webform_civicrm'])) {
+            continue;
+          }
+          $settings = &$config['webform_civicrm']['settings'];
+          $utils = \Drupal::service('webform_civicrm.utils');
+          $receiptParams = $utils->getReceiptParams($settings['data'], $params['tplParams']['contributionID']);
+          $params['tplParams']= array_merge($params['tplParams'], $receiptParams);
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_element_info_alter().
  */
 function webform_civicrm_element_info_alter(array &$types) {


### PR DESCRIPTION
Overview
----------------------------------------
Webform Receipt params missing from contribution emails.

Before
----------------------------------------
Receipt params are now configured in webform settings => Contribtuion tab

![image](https://user-images.githubusercontent.com/5929648/146774839-9902a738-3a12-43e7-9eb0-c4acbeecaaa0.png)

These params are missing from contribution receipts if payment is completed from IPN, etc. To replicate.

- Create a webform with receipt fields enabled. Enter text for pay later text and receipt text.
- Create a pay later payment
- Complete the payment using API explorer 
 
```
civicrm_api3('Contribution', 'completetransaction', [
  'id' => $contribution['id'],
  'is_email_receipt' => 1,
]);
```
- Email received with the above does not have the receipt params set in the webform.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
uses `webform_civicrm_civicrm_alterMailParams()` hook and insert the webform receipt field values in the emails.

