### PR TITLE
D8/9 - Incorrect labels on line item table when displayed on single page

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -75,6 +75,7 @@
       }
       $('td+td', $lineItem).html(CRM.formatMoney(amount * taxPara));
       $lineItem.data('amount', amount * taxPara);
+      $lineItem.attr('data-amount', amount * taxPara);
     }
     tally();
   }
@@ -97,7 +98,7 @@
   function calculateLineItemAmount() {
     var fieldKey = $(this).data('civicrmFieldKey'),
       amount = getFieldAmount(fieldKey),
-      label = $(this).closest('div.webform-component').find('label').text() || Drupal.t('Contribution'),
+      label = $(this).closest('div.form-item').find('label').text() || Drupal.t('Contribution'),
       lineKey = fieldKey.split('_').slice(0, 4).join('_');
     updateLineItem(lineKey, amount, label);
   }

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -49,6 +49,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
     $this->htmlOutput();
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '10.00');
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-items .civicrm_1_contribution_1', 'Contribution Amount');
 
     $this->fillCardAndSubmit();
 


### PR DESCRIPTION
Overview
----------------------------------------
Incorrect labels on line item table when displayed on single page

Before
----------------------------------------
Labels on line item table are wrong when payment section is displayed on the first page. To replicate -

- Create a webform with contribution + 2 line items.
- Disable Contact Paging from the additional tab.
- Load the webform and notice the labels are default to `Contribution` for all the rows.

![image](https://user-images.githubusercontent.com/5929648/147399203-ea491348-3574-4ec6-bc5a-923a5e1d50cc.png)

After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/147399206-718ef258-eca1-442a-a482-ee7b7b746d15.png)


