### PR TITLE
Highlight token input field in case of an error

### DIFF
--- a/css/token-input.css
+++ b/css/token-input.css
@@ -125,3 +125,7 @@ form.contact-loading,
 form.contact-loading * {
     cursor: progress !important;
 }
+
+form div.form-item.has-error ul.token-input-list {
+  border-color: #d72222;
+}

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -35,6 +35,11 @@
             field.data('form-defaults'),
           );
         });
+
+        //In case of error, highlight the token-input field.
+        if (field.hasClass('error')) {
+          field.parent('div.form-item').addClass('has-error');
+        }
       });
 
 


### PR DESCRIPTION
Overview
----------------------------------------
Highlight token input field in case of an error

Before
----------------------------------------
Token input field is not focussed when an existing contact field has an error on submit. To replicate 

- Create a contact with existing contact field. 
- Disable client side validation on the form (Settings -> Form -> Disable client-side validation)
- Set it to autocomplete widget and disable and default load on it. Make it a required field.
- Submit the webform without entering any value on it.
- The label is red, but the field is displayed as it is -

- Some themes (eg bartik) does not display the label as red, in this case, there is no way to identify the exact error.

![image](https://user-images.githubusercontent.com/5929648/147400367-300ea159-56b4-4172-87c1-6a8396551fb6.png)


After
----------------------------------------
Fixed.

![image](https://user-images.githubusercontent.com/5929648/147400292-d58930a8-3943-4d94-be1a-7b3368632a40.png)

With client-side validation enabled, it still is not able to focus on the element, since we keep the default text field hidden by default. With this PR, it only works with the client-side validation disabled.

Comments
----------------------------------------
Also replicates on d7 so seems to be an issue from a long time.