### PR TITLE
D8/9 - Fix contribution amount to be used as hidden field

### DIFF
--- a/src/Plugin/WebformElement/CivicrmNumber.php
+++ b/src/Plugin/WebformElement/CivicrmNumber.php
@@ -30,7 +30,7 @@ class CivicrmNumber extends Number {
     $types = parent::getRelatedTypes($element);
     // Allow number field to be retyped into options widgets.
     $elements = $this->elementManager->getInstances();
-    $supportedTypes = ['civicrm_options'];
+    $supportedTypes = ['civicrm_options', 'hidden'];
     foreach ($elements as $element_name => $element_instance) {
       if (in_array($element_name, $supportedTypes)) {
         $types[$element_name] = $element_instance->getPluginLabel();

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -593,7 +593,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       $field = $elements[$this->enabled[$fid]];
       if ($field['#type'] === 'hidden') {
         $this->line_items[] = [
-          'line_total' => $field['value'],
+          'line_total' => $field['#default_value'],
           'qty' => 1,
           'element' => 'civicrm_1_contribution_1',
           'label' => !empty($field['name']) ? $field['name'] : t('Contribution Amount'),

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -78,7 +78,45 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertStringContainsString('Thank you for your contribution', $sent_email);
   }
 
+  /**
+   * Test webform submission with hidden contribution amount.
+   */
+  public function testHiddenAmount() {
+    $this->setupWebform();
+
+    // Change widget of Amount element to radios.
+    $this->changeTypeOfAmountElement('hidden');
+    $this->submitWebform('hidden');
+    $this->verifyResult();
+  }
+
+  /**
+   * Test webform submission with checkbox, radio amount.
+   */
   public function testSubmitContribution() {
+    $this->setupWebform();
+    // Change widget of Amount element to checkbox.
+    $this->changeTypeOfAmountElement('checkboxes', TRUE);
+    $this->submitWebform('checkboxes');
+    $this->verifyResult();
+
+    // Change widget of Amount element to radios.
+    $this->changeTypeOfAmountElement('radios');
+    $this->submitWebform('radios');
+    $this->verifyResult();
+
+    $this->country = 'Malaysia';
+    $this->state = 'Selangor';
+    // Change widget of Amount element to radio + other.
+    $this->changeTypeOfAmountElement('webform-radios-other');
+    $this->submitWebform('webform_radios_other');
+    $this->verifyResult();
+  }
+
+  /**
+   * Setup webform with contribution.
+   */
+  public function setUpWebform() {
     $this->createFinancialCustomGroup();
     $this->createFinancialCustomGroup('Donation');
     $this->createFinancialCustomGroup('Member Dues');
@@ -117,22 +155,6 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
     $this->country = 'United Kingdom';
     $this->state = 'Newport';
-    // Change widget of Amount element to checkbox.
-    $this->changeTypeOfAmountElement('checkboxes', TRUE);
-    $this->submitWebform('checkboxes');
-    $this->verifyResult();
-
-    // Change widget of Amount element to radios.
-    $this->changeTypeOfAmountElement('radios');
-    $this->submitWebform('radios');
-    $this->verifyResult();
-
-    $this->country = 'Malaysia';
-    $this->state = 'Selangor';
-    // Change widget of Amount element to radio + other.
-    $this->changeTypeOfAmountElement('webform-radios-other');
-    $this->submitWebform('webform_radios_other');
-    $this->verifyResult();
   }
 
   /**
@@ -162,7 +184,7 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
       $this->assertSession()->waitForField('civicrm_1_contribution_1_contribution_total_amount[other]');
       $this->getSession()->getPage()->fillField('civicrm_1_contribution_1_contribution_total_amount[other]', '30');
     }
-    else {
+    elseif ($amountType != 'hidden') {
       $this->getSession()->getPage()->checkField('10');
       $this->getSession()->getPage()->checkField('20');
     }
@@ -257,14 +279,19 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
   /**
    * Change contribution amount widget
-   * to radio or checkbox.
+   * to radio, checkbox or hidden field.
+   *
+   * @param string $type
+   * @param boolean $changeTypeToOption
+   *  TRUE, if element type should be changed back to CiviCRM Options widget.
    */
   private function changeTypeOfAmountElement($type, $changeTypeToOption = FALSE) {
     $this->drupalGet($this->webform->toUrl('edit-form'));
     $this->assertPageNoErrorMessages();
 
-    if ($type == 'webform-radios-other' && !$changeTypeToOption) {
-      $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contribution-1-contribution-total-amount-operations', FALSE, FALSE, NULL, $type);
+    if (in_array($type, ['hidden', 'webform-radios-other']) && !$changeTypeToOption) {
+      $default = ($type == 'hidden') ? 30 : NULL;
+      $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contribution-1-contribution-total-amount-operations', FALSE, FALSE, $default, $type);
       return;
     }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -328,7 +328,12 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]', 3000);
     }
     if ($default) {
-      $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);
+      if ($type == 'hidden') {
+        $this->getSession()->getPage()->fillField("properties[default_value]", $default);
+      }
+      else {
+        $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);
+      }
     }
     if (!$type || $type == 'civicrm-options') {
       $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');


### PR DESCRIPTION
Overview
----------------------------------------
Allow contribution amount to be typed as a hidden field.

Before
----------------------------------------
In d7, the contribution amount field could be converted to a hidden field with a default value.

D9 - there is no way via UI, we need to modify the source and set it to `type: hidden`. But we still get a notice error on display.

![image](https://user-images.githubusercontent.com/5929648/147403057-bcc544ae-024c-4da2-b1f8-46bbccd354d9.png)


After
----------------------------------------
Fixed. CiviCRM Number field can be changed to Hidden field via build form.

![image](https://user-images.githubusercontent.com/5929648/147403041-e84ff689-2754-4668-9503-7c47cb1e4916.png)


