### PR TITLE
D8/9 - Fix case update when client != c1

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1358,8 +1358,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
         //Check if webform is set to update the existing case on contact.
-        if (!empty($this->data['case'][$n]['existing_case_status']) && empty($this->ent['case'][$n]['id']) && !empty($this->ent['contact'][$n]['id'])) {
-          $existingCase = $this->findCaseForContact($this->ent['contact'][$n]['id'], [
+        if (!empty($this->data['case'][$n]['existing_case_status']) && empty($this->ent['case'][$n]['id'])) {
+          $existingCase = $this->findCaseForContact($data['case'][1]['client_id'], [
             'case_type_id' => wf_crm_aval($this->data['case'][$n], 'case:1:case_type_id'),
             'status_id' => $this->data['case'][$n]['existing_case_status']
           ]);


### PR DESCRIPTION
Overview
----------------------------------------
Fix case update when client != c1.

Before
----------------------------------------
Case updated on c1 when client is set to c2. To replicate -

- Create a webform with 2 contacts.
- Case tab - Select 1 in the Number of case with Case client = Contact 2.
-  Ensure `Update Existing Case` is set to Ongoing.
- Set the widget of Contact 2 to autocomplete.
- Load the webform and submit. Confirm a case is created on contact 2.
- Load the webform again and submit with same set of contacts.

Expected Result: Case on contact 2 should be updated.

Actual Result: New Case is created on contact 2. 

After
----------------------------------------
Fixed. Existing case on the contact is updated.

Technical Details
----------------------------------------
The previous variable - `$this->ent['contact'][$n]['id']` has $n iterating as 1, 2, 3... which considers c1, c2 to check for existing case. This should instead be checking for client id set on the webform setting which correctly arrives on `$data['case'][1]['client_id']`.

