### PR TITLE
fix instance of format_plural

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -532,10 +532,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             $this->form_state->setErrorByName($eid, t('%event : @text', ['%event' => $event['title'], '@text' => $event['event_full_text']]));
           }
           else {
-            $this->form_state->setErrorByName($eid, format_plural($event['available_places'],
-              'Sorry, you tried to register !count people for %event but there is only 1 space remaining.',
-              'Sorry, you tried to register !count people for %event but there are only @count spaces remaining.',
-              ['%event' => $event['title'], '@count' => $event['count']]));
+            $registrations = \Drupal::translation()->formatPlural($event['count'], '1 person', '@count people');
+            $this->form_state->setErrorByName($eid, \Drupal::translation()->formatPlural($event['available_places'],
+              'Sorry, you tried to register @registrations for %event but there is only 1 space remaining.',
+              'Sorry, you tried to register @registrations for %event but there are only @count spaces remaining.',
+              ['%event' => $event['title'], '@registrations' => $registrations]));
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
I found this WSOD bug while testing #647.

### Steps to Replicate
* Create a form with 3 contacts, enable events, all contacts register for same event, event is "User Select".  The event has max participants of 1.
* Attempt to register 2 or more contacts for the event.

Before
----------------------------------------
`Error: Call to undefined function Drupal\webform_civicrm\format_plural() in Drupal\webform_civicrm\WebformCivicrmPostProcess->validateParticipants() (line 535 of <mysite>/web/modules/contrib/webform_civicrm/src/WebformCivicrmPostProcess.php) `

After
----------------------------------------
Correctly formatted error message.

Technical Details
----------------------------------------
`format_plural` only existed in D7 and earlier.  This is the only remaining instance of it in the module.

Comments
----------------------------------------
I don't think this message ever worked properly, even in D7, because it tried to us `!count` to reference number of registrations, but didn't define it.
