### PR TITLE
fix formatting on 'no results' result for existing contact widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Webform CiviCRM is a powerful, flexible, user-friendly form builder for CiviCRM!
 Installation & Getting Started
 ------------------------------
 
-- Download and enable this module, plus CiviCRM, Webform.
+- Download and enable this module, plus CiviCRM, Webform!
 - Create a new webform (or go to edit an existing one).
 - Click on the Settings -> CiviCRM tab.
 - Enable the fields you like, and optionally choose introduction text and other settings.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation
 -------------
 
 Further instructions can be found at:
-https://docs.civicrm.org/webform-civicrm/en/latest/
+https://docs.civicrm.org/webform-civicrm/en/latest
 
 Issues
 ------

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -18,6 +18,7 @@
             toHide, {
             hintText: field.data('search-prompt'),
             noResultsText: field.data('none-prompt'),
+            resultsFormatter: formatChoices,
             searchingText: "Searching..."
           });
         }
@@ -37,6 +38,16 @@
         });
       });
 
+      /**
+       * Format the choices in the "Existing Contact widget", with a special format for the "No Results" item.
+       */
+      function formatChoices(item){
+        var string = item[this.propertyToSearch];
+        if (string == this.noResultsText) {
+          return "<li><em><i>" + string + "</i></em></li>";
+        }
+        return "<li>" + string + "</li>";
+      }
 
       function changeDefault() {
         var val = $(this).val().replace(/_/g, '-');

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -136,7 +136,7 @@ class ContactComponent implements ContactComponentInterface {
       }
       if (count($ret) < $limit && $element['#allow_create']) {
         // HTML hack to get prompt to show up different than search results
-        $ret[] = ['id' => "-$str", 'name' => '<em><i>' . Xss::filter($element['#none_prompt']) . '</i></em>'];
+        $ret[] = ['id' => "-$str", 'name' => Xss::filter($element['#none_prompt'])];
       }
     }
     // Select results

--- a/src/WebformAjax.php
+++ b/src/WebformAjax.php
@@ -91,7 +91,7 @@ class WebformAjax extends WebformCivicrmBase implements WebformAjaxInterface {
       if ($this->getParameter('load') == 'name') {
         if ($this->getParameter('cid')[0] === '-') {
           // HTML hack to get prompt to show up different than search results
-          $data = '<em><i>' . Xss::filter($element['#none_prompt']) . '</i></em>';
+          $data = Xss::filter($element['#none_prompt']);
         }
         else {
           $data = $name;

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -528,7 +528,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->waitForElementVisible('xpath', '//li[contains(@class, "token-input-dropdown")][1]');
     $this->createScreenshot($this->htmlOutputDirectory . '/autocomplete.png');
 
-    $page->find('xpath', '//li[contains(@class, "token-input-dropdown")]')->click();
+    $page->find('xpath', '//li[contains(@class, "token-input-dropdown")][1]')->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
   }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -528,7 +528,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertSession()->waitForElementVisible('xpath', '//li[contains(@class, "token-input-dropdown")][1]');
     $this->createScreenshot($this->htmlOutputDirectory . '/autocomplete.png');
 
-    $page->find('xpath', '//li[contains(@class, "token-input-dropdown")][1]')->click();
+    $page->find('xpath', '//li[contains(@class, "token-input-dropdown")]')->click();
     $this->assertSession()->assertWaitOnAjaxRequest();
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
On an "existing contact" widget. the "no results" option shows raw HTML where it previously rendered the HTML.

This site has the upgraded jquery.inputtoken (https://github.com/civicrm/civicrm-packages/pull/336) but I believe the bug exists regardless.

Before
----------------------------------------

![Selection_1354](https://user-images.githubusercontent.com/1796012/149236877-8e148b9e-7f84-4d18-92cc-33c4ca18e7d2.png)

After
----------------------------------------
![Selection_1353](https://user-images.githubusercontent.com/1796012/149236896-b2dc5b73-b429-4880-af88-51a0ee2faf95.png)


Technical Details
----------------------------------------
Passing `enableHTML: TRUE` is a simpler alternative but I feel like this offers stronger protection against accidentally introducing an XSS vuln in the future.