### PR TITLE
[D7] Allow existing contact autocompletes to be conditionally required

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -422,6 +422,25 @@ var wfCivi = (function ($, D) {
       $('div.civicrm-enabled[id*=contact-1-contact-image-url]:has(.file)', context).each(function() {
         pub.initFileField(getFieldNameFromClass($(this).parent()));
       });
+
+      // If an autocomplete-select widget is marked required while hidden, remove the "required" class.
+      var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+          if (mutation.target.offsetParent === null) {
+            mutation.target.removeAttribute('required');
+            mutation.target.classList.remove('required');
+          }
+        });
+      });
+
+      // Look for an autocomplete-select widgets being set to "required" or "style" changing (potentially to 'none').
+      $('.token-input-input-token').each(function() {
+        observer.observe($(this)[0], {
+          subtree: true,
+          attributes: true,
+          attributeFilter: ['required', 'style']
+        });
+      });
     }
   };
   return pub;


### PR DESCRIPTION
Overview
----------------------------------------
In D7, Autocomplete widgets for existing contacts can't be conditionally required.  This doesn't affect D8/9.

To replicate:
* Create a new webform, enable CiviCRM processing with the defaults (1 contact, fields are "Existing Contact", "First Name", "Last Name").
* Set the "Existing Contact" widget to "Autocomplete" and "Required" (this last part is necessary for making it conditionally required).
* Add a new textfield element "myfield".
* Create a conditional that says "when 'myfield' is filled, 'Existing Contact' is required".

Before
----------------------------------------
Now, when you press "Submit", nothing happens.

After
----------------------------------------
When you press "Submit" the form submits.

Technical Details
----------------------------------------
The autocomplete widget works by hiding the original field and putting its own field in its place.  However, the conditional sets the *hidden* field to be required.  So the form can never submit, and no reason given.

This PR monitors the element for a change to its "required" status and/or its being set to "display: none".  If the field isn't visible to the user, we remove the "required" class and attribute.

Note that when the hidden field is set to required, the overlaid field is also set to required - so removing it from the hidden field doesn't break the intended functionality.