### PR TITLE
allow correct loading of 'Show Public Events'

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -838,7 +838,7 @@ class AdminForm implements AdminFormInterface {
     $this->form['participant']['show_public_events'] = [
       '#type' => 'select',
       '#title' => t('Show Public Events'),
-      '#default_value' => wf_crm_aval($this->data, 'reg_options:show_public_events', 'title'),
+      '#default_value' => wf_crm_aval($this->data, 'reg_options:show_public_events', 'title', TRUE),
       // This is breaking HTML in D8.
       // '#suffix' => '</div>',
       '#parents' => ['reg_options', 'show_public_events'],


### PR DESCRIPTION
Overview
----------------------------------------
If you go to the Events tab of WFC, and select **Private** for *Show Public Events*, then reload the page, your setting isn't respected.

Before
----------------------------------------
Selecting "Private" doesn't work.

After
----------------------------------------
Selecting "Private" works.

Technical Details
----------------------------------------
Unlike the other settings on this page, this setting can have a value of `0` and needs `wf_crm_aval`'s strict mode to avoid a truthiness bug.