### PR TITLE
D8/9 - Allow loc types to be submitted as non primary from the webform

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -372,6 +372,10 @@ class AdminForm implements AdminFormInterface {
               (isset($field['contact_type']) && $field['contact_type'] != $c['contact'][1]['contact_type'])) {
               continue;
             }
+            // Make sure Primary field is only displayed for the 1st set.
+            if (strpos($fid, 'is_primary') !== false && $i > 1) {
+              continue;
+            }
             $fid = 'civicrm_' . $n . '_contact_' . $i . '_' . $fid;
             $fieldset[$fid] = $this->addItem($fid, $field);
           }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -354,6 +354,12 @@ class Fields implements FieldsInterface {
             'expose_list' => TRUE,
             'value' => '1',
           ];
+          $fields[$key . '_is_primary'] = [
+            'name' => 'Is Primary',
+            'type' => 'select',
+            'expose_list' => TRUE,
+            'value' => '1',
+          ];
         }
       }
       $fields['website_url'] = [

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -869,6 +869,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             if ($location == 'email' && $params['location_type_id'] == $is_primary_email_location_type) {
               $params['is_primary'] = 1;
             }
+            if (isset($this->settings["civicrm_{$c}_contact_1_{$location}_is_primary"]) && $this->settings["civicrm_{$c}_contact_1_{$location}_is_primary"] == 0) {
+              unset($params['is_primary']);
+            }
           }
           $this->utils->wf_civicrm_api($location, 'create', $params);
         }

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
+
+use Drupal\Core\Url;
+
+/**
+ * Tests submission of loc types.
+ *
+ * @group webform_civicrm
+ */
+final class LocationTypeTest extends WebformCivicrmTestBase {
+
+  protected function setUp() {
+    parent::setUp();
+    $this->utils->wf_civicrm_api('Address', 'create', [
+      'contact_id' => $this->rootUserCid,
+      'location_type_id' => "Main",
+      'is_primary' => 1,
+      'street_address' => "35th Street",
+      'city' => "Toronto",
+      'country_id' => "CA",
+      'state_province_id' => "Ontario",
+    ]);
+  }
+
+  /**
+   * Submit address with primary flag set to 0.
+   */
+  public function testAddressSubmissionNoPrimary() {
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_address', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->getSession()->getPage()->checkField('Country');
+    $this->getSession()->getPage()->selectFieldOption('Address Location', 'Home');
+    $this->getSession()->getPage()->selectFieldOption('Is Primary', 'No');
+
+    $this->saveCiviCRMSettings();
+
+    //Submit the form.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+
+    $edit = [
+      'First Name' => 'Frederick',
+      'Last Name' => 'Pabst',
+      'Street Address' => '9th Street',
+      'City' => 'Newark',
+      'Postal Code' => '12345',
+      'Country' => 1228,
+      'State/Province' => 'NJ',
+    ];
+    $this->postSubmission($this->webform, $edit);
+
+    $address = $this->utils->wf_civicrm_api('Address', 'get', [
+      'sequential' => 1,
+      'contact_id' => $this->rootUserCid,
+    ]);
+    // Verify if the new address is not marked as primary.
+    $this->assertEquals(2, $address['count']);
+    $this->assertEquals('Toronto', $address['values'][0]['city']);
+    $this->assertEquals(1, $address['values'][0]['is_primary']);
+
+    $this->assertEquals('Newark', $address['values'][1]['city']);
+    $this->assertEquals(0, $address['values'][1]['is_primary']);
+  }
+}

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -70,4 +70,5 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $this->assertEquals('Newark', $address['values'][1]['city']);
     $this->assertEquals(0, $address['values'][1]['is_primary']);
   }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Allow loc types to be submitted as non primary from the webform

Before
----------------------------------------
The first Address or other location types submitted va webform are forced to is_primary = 1. This doesn't allow admins to capture additional address values without overriding the primary record in civi contact.

After
----------------------------------------
Adds a setting on the form (default to 1). If selected as No - the location type will not be forced to be a primary record.

![image](https://user-images.githubusercontent.com/5929648/150640445-103cc9b1-d079-443f-89fa-ac3020fd9a4a.png)


Comments
----------------------------------------
@KarinG Tagging as wip to make sure it passes the tests and will also add a new test to check the same.