### PR TITLE
D8/9 - Fix default load of custom value when it is set to null in civicrm

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -540,6 +540,19 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
               $options = $this->utils->wf_crm_field_options($element, '', $this->data);
               $val = wf_crm_aval($options, $val);
             }
+            //Ensure value from webform default is loaded when the field is null in civicrm.
+            if (!empty($element['#options']) && isset($val)) {
+              if (!is_array($val) && !isset($element['#options'][$val])) {
+                $val = NULL;
+              }
+              if ((empty($val) || (is_array($val) && empty(array_filter($val)))) && !empty($this->form['#attributes']['data-form-defaults'])) {
+                $formDefaults = Json::decode($this->form['#attributes']['data-form-defaults']);
+                $key = str_replace('_', '-', $element['#form_key']);
+                if (isset($formDefaults[$key])) {
+                  $val = $formDefaults[$key];
+                }
+              }
+            }
             // Contact image & custom file fields
             if ($dt == 'File') {
               $fileInfo = $this->getFileInfo($name, $val, $ent, $n);

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -496,6 +496,58 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Ensure webform default values are loaded when the contact
+   * in civicrm does not have a value set on it.
+   */
+  public function testCustomFieldWebformDefaults() {
+    $this->createCustomFields();
+    $createParams = [
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+      'custom_' . $this->_customFields['text'] => 'Lorem Ipsum',
+    ];
+    $contactID = $this->createIndividual($createParams)['id'];
+
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_cg1', 'Yes');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    // Enable custom fields.
+    foreach ($this->_customFields as $name => $id) {
+      $this->getSession()->getPage()->checkField("civicrm_1_contact_1_cg1_custom_{$id}");
+      $this->assertSession()->checkboxChecked("civicrm_1_contact_1_cg1_custom_{$id}");
+    }
+    $this->saveCiviCRMSettings();
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    $this->setDefaultValue("edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-{$this->_customFields['test_radio_2']}-operations", 3);
+    $this->setDefaultValue("edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-{$this->_customFields['color_checkboxes']}-operations", 2);
+    $this->setDefaultValue("edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-{$this->_customFields['fruits']}-operations", 'Mango, Orange');
+
+    $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contactID]]));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    //Ensure default values are loaded.
+    $this->assertFieldValue("edit-civicrm-1-contact-1-cg1-custom-{$this->_customFields['text']}", 'Lorem Ipsum');
+
+    // This is loaded from webform default since no value is set in civi.
+    $this->assertSession()->checkboxNotChecked("Red");
+    $this->assertSession()->checkboxChecked("Green");
+
+    $this->assertSession()->checkboxChecked("Mango");
+    $this->assertSession()->checkboxChecked("Orange");
+    $this->assertSession()->checkboxNotChecked("Apple");
+  }
+
+  /**
    * Test Contact Values loaded via ajax, i.e,
    * on selecting a contact from autocomplete, select, etc.
    */

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -535,7 +535,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
 
-    //Ensure default values are loaded.
+    // Ensure default values are loaded.
     $this->assertFieldValue("edit-civicrm-1-contact-1-cg1-custom-{$this->_customFields['text']}", 'Lorem Ipsum');
 
     // This is loaded from webform default since no value is set in civi.


### PR DESCRIPTION
Overview
----------------------------------------
Fix default load of custom value when it is set to null in CiviCRM

Before
----------------------------------------
To replicate -

- Create a custom set with text, radio and checkbox custom fields.
- Create a contact in CiviCRM with a value in only the text custom field. Radio & checkbox value is empty/null.
- Enable all three fields on a webform.
- Set a default value on the radio and checkbox custom field.
- Load the webform with cid1=contact id from step 2.
- The value of radio and checkbox custom field is not loaded.

Expected Result - If there is no value set in CiviCRM, the webform defaults should be loaded on the element.

After
----------------------------------------
Fixed.


