### PR TITLE
D8/9 - Fix token to render contact name in webform email

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -583,10 +583,15 @@ class CivicrmContact extends WebformElementBase {
   /**
    * {@inheritdoc}
    */
-  protected function formatHtmlItem(array $element, WebformSubmissionInterface $webform_submission, array $options = []) {
-    $value = parent::formatHtmlItem($element, $webform_submission, $options);
+  protected function format($type, array &$element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    $value = parent::format($type, $element, $webform_submission, $options);
     $format = $this->getItemFormat($element);
-    $cid = $value['#plain_text'] ?? NULL;
+    if ($type === 'Text') {
+      $cid = $value;
+    }
+    else {
+      $cid = $value['#plain_text'] ?? NULL;
+    }
 
     if ($format === 'raw' || empty($cid) || !is_numeric($cid)) {
       return $value;
@@ -594,6 +599,9 @@ class CivicrmContact extends WebformElementBase {
     $utils = \Drupal::service('webform_civicrm.utils');
     $contact = $utils->wf_crm_apivalues('contact', 'get', ['id' => $cid], 'display_name');
     if (!empty($contact[$cid])) {
+      if ($type === 'Text') {
+        return $contact[$cid];
+      }
       if (empty($options['email']) && \Drupal::currentUser()->hasPermission('access CiviCRM')) {
         unset($value['#plain_text']);
         $cidURL = Url::fromUri('internal:/civicrm/contact/view', ['query' => ['reset' => 1, 'cid' => $cid]])->toString();

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -252,7 +252,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
    * Test Tokens in Email.
    */
   public function testTokensInEmail() {
-    //Create 2 meeting activities for the contact.
+    // Create 2 meeting activities for the contact.
     $actID1 = $this->utils->wf_civicrm_api('Activity', 'create', [
       'source_contact_id' => $this->rootUserCid,
       'activity_type_id' => "Meeting",

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -285,7 +285,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
 
     $email = [
       'to_mail' => '[webform_submission:values:civicrm_1_contact_1_email_email:raw]',
-      'body' => 'Existing Contact - [webform_submission:values:civicrm_1_contact_1_contact_existing]. Activity 1 ID - [webform_submission:activity-id:1]. Activity 2 ID - [webform_submission:activity-id:2]. Webform CiviCRM Contacts IDs - [webform_submission:contact-id:1]. Webform CiviCRM Contacts Links - [webform_submission:contact-link:1].',
+      'body' => 'Submitted Values Are - [webform_submission:values] Existing Contact - [webform_submission:values:civicrm_1_contact_1_contact_existing]. Activity 1 ID - [webform_submission:activity-id:1]. Activity 2 ID - [webform_submission:activity-id:2]. Webform CiviCRM Contacts IDs - [webform_submission:contact-id:1]. Webform CiviCRM Contacts Links - [webform_submission:contact-link:1].',
     ];
     $this->addEmailHandler($email);
     $this->drupalGet($this->webform->toUrl('handlers'));
@@ -313,11 +313,24 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     $this->assertStringContainsString('frederick@pabst.io', $sent_email[0]['to']);
 
     // Verify tokens are rendered correctly.
-    $this->assertStringContainsString('Existing Contact - Frederick Pabst.', $sent_email[0]['body']);
-    $this->assertStringContainsString("Activity 1 ID - {$actID1}", $sent_email[0]['body']);
-    $this->assertStringContainsString("Activity 2 ID - {$actID2}", $sent_email[0]['body']);
-    $this->assertStringContainsString("Webform CiviCRM Contacts IDs - {$this->rootUserCid}", $sent_email[0]['body']);
-    $this->assertStringContainsString($cidURL, $sent_email[0]['body']);
+    $this->assertEquals("Submitted Values Are -
+-------- Contact 1 
+-----------------------------------------------------------
+
+*Existing Contact*
+Frederick Pabst
+*First Name*
+Frederick
+*Last Name*
+Pabst
+*Email*
+frederick@pabst.io [1]
+Existing Contact - Frederick Pabst. Activity 1 ID - {$actID1}. Activity 2 ID - {$actID2}.
+Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Links -
+{$cidURL}.
+
+[1] mailto:frederick@pabst.io
+", $sent_email[0]['body']);
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix `[webform_submission:values]` token to render contact name in webform email

Before
----------------------------------------
The token  [webform_submission:values] does not render the contact name for existing contact field. To replicate -

- Add Contact to webform.
- Ensure Existing contact field is selected.
- Add an email handler with body - `[webform_submission:values]`.
- The email content renders the contact id for existing contact field.

After
----------------------------------------
Contact Name is rendered instead of id for existing contact field

