### PR TITLE
D8/9 - Fatal error on webform submission if it has a radio button element wi…

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -265,11 +265,7 @@ class CivicrmOptions extends OptionsBase {
    * {@inheritdoc}
    */
   public function hasMultipleValues(array $element) {
-    if (!empty($element['#extra']['multiple']) ||
-      (empty($element['#civicrm_live_options']) && !empty($element['#options']) && count($element['#options']) === 1)) {
-      return TRUE;
-    }
-    return FALSE;
+    return \Drupal::service('webform_civicrm.utils')->hasMultipleValues($element);
   }
 
   /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1008,4 +1008,17 @@ class Utils implements UtilsInterface {
     return $params;
   }
 
+  /**
+   * Does an element support multiple values
+   *
+   * @param array $element
+   */
+  public function hasMultipleValues($element) {
+    if (!empty($element['#extra']['multiple']) ||
+      (empty($element['#civicrm_live_options']) && !empty($element['#options']) && count($element['#options']) === 1)) {
+      return TRUE;
+    }
+    return FALSE;
+  }
+
 }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2470,6 +2470,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             $val = \CRM_Utils_Array::implodePadded($val);
           }
         }
+        // If this is a single-static radio button, set it to a non array value
+        // since civicrm api doesn't expect array for a radio field.
+        elseif (empty($component['#extra']['multiple']) && $this->utils->hasMultipleValues($component)) {
+          $val = $val[0] ?? NULL;
+        }
         elseif ($name === 'image_url') {
           if (empty($val[0]) || !($val = $this->getDrupalFileUrl($val[0]))) {
             // This field can't be emptied due to the nature of file uploads

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -275,6 +275,7 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
 
     if ($changeTypeToOption) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-change-type"]')->click();
+      $this->assertSession()->assertWaitOnAjaxRequest();
       $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-elements-civicrm-options-operation']", 3000)->click();
       $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-cancel']", 3000);
     }

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -347,8 +347,26 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('_qf_Field_done-bottom');
     $this->assertSession()->assertWaitOnAjaxRequest();
 
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
     // Verify if the custom field is back on the page.
     $this->assertSession()->pageTextContains('Label for Custom Checkbox field');
+
+    //Change single radio to static.
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    // Enable static option on radio field.
+    $this->editCivicrmOptionElement("edit-webform-ui-elements-civicrm-1-contact-1-cg1-custom-{$this->_customFields['single_radio']}-operations", FALSE, TRUE);
+
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->checkboxNotChecked("Yes");
+
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
   }
 
   /**


### PR DESCRIPTION
…th single option

Overview
----------------------------------------
Fatal error on webform submission if it has a radio button element with single static option

Before
----------------------------------------
To replicate

- Create a custom field of type radio and 1 option.
- Enable it on a webform.
- Edit the radio element from the build page and set the option to static.

![image](https://user-images.githubusercontent.com/5929648/151136917-8b008e13-f496-4fac-b1fd-48b3f979226b.png)

- Load the webform. The radio element is rendered as a checkbox (Correct).
- Submit the webform without selecting the checkbox value. Fatal error is returned on the next page.



```
Drupal\Core\Entity\EntityStorageException: '' is not a valid option for field custom_3 
in Drupal\Core\Entity\Sql\SqlContentEntityStorage-
>save() (line 811 of /Users/jitendra/www/d9unit/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).
```

From log

```
CiviCRM_API3_Exception: '' is not a valid option for field custom_3 
in civicrm_api3() (line 134 of /Users/jitendra/www/d9unit/vendor/civicrm/civicrm-core/api/api.php).
```


After
----------------------------------------
Fixed.


