### PR TITLE
Refs #3260975 replaces Deprecated call to drupal_set_message

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2085,9 +2085,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $paymentProcessor->doPayment($params);
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-        \Drupal::messenger()->addError(ts('Payment approval failed with message: %error ', [
-            '%error' =>  $e->getMessage(),
-        ]));
+      \Drupal::messenger()->addError(ts('Payment approval failed with message: %error ', [
+        '%error' =>  $e->getMessage(),
+      ]));
       \CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
     }
 

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2085,7 +2085,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $paymentProcessor->doPayment($params);
     }
     catch (\Civi\Payment\Exception\PaymentProcessorException $e) {
-      drupal_set_message(ts('Payment approval failed with message: ') . $e->getMessage(),'error');
+        \Drupal::messenger()->addError(ts('Payment approval failed with message: %error ', [
+            '%error' =>  $e->getMessage(),
+        ]));
       \CRM_Utils_System::redirect($this->getIpnRedirectUrl('cancel'));
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Replace deprecated call to drupal_set_message - as per https://www.drupal.org/project/webform_civicrm/issues/3260975

Before
----------------------------------------
As the function is now removed from 9.x fatal error occurs instead of displaying an error to the user.

After
----------------------------------------
Error message is passed through to the user.

