### PR TITLE
D8/9 - Added check to see if $elements['managed_file'] exists

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -195,7 +195,7 @@ class Fields implements FieldsInterface {
         'type' => 'select',
         'value' => $this->utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
       ];
-      if (!$elements['managed_file']->isDisabled() && !$elements['managed_file']->isHidden()) {
+      if (isset($elements['managed_file']) && !$elements['managed_file']->isDisabled() && !$elements['managed_file']->isHidden()) {
         $fields['contact_image_URL'] = [
           'name' => t('Upload Image'),
           'type' => 'managed_file',


### PR DESCRIPTION
Fixes: Error: Call to a member function isDisabled() on null in Drupal\webform_civicrm\Fields->wf_crm_get_fields() (line 198 of /var/www/html/web/modules/contrib/webform_civicrm/src/Fields.php)