### PR TITLE
D7 - Fix PHP notices when there are no billing address fields

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1748,11 +1748,11 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
       $cid = $this->findDuplicateContact($contact);
     }
     $address = [
-      'street_address' => $this->billing_params['street_address'],
-      'city' => $this->billing_params['city'],
-      'country_id' => $this->billing_params['country_id'],
+      'street_address' => $this->billing_params['street_address'] ?? '',
+      'city' => $this->billing_params['city'] ?? '',
+      'country_id' => $this->billing_params['country_id'] ?? '',
       'state_province_id' => wf_crm_aval($this->billing_params, 'state_province_id'),
-      'postal_code' => $this->billing_params['postal_code'],
+      'postal_code' => $this->billing_params['postal_code'] ?? '',
       'location_type_id' => 'Billing',
     ];
     $email = [


### PR DESCRIPTION
Overview
----------------------------------------
Stripe does not use billing address fields but webform_civicrm expects them to be there so you get PHP notices if they are not.

Before
----------------------------------------
php notices for address fields

After
----------------------------------------
No php notices for address fields

Technical Details
----------------------------------------


Comments
----------------------------------------

