### PR TITLE
Fix output in github actions so it shows you the actual errors in drupal error textboxes at the top of pages

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -257,7 +257,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   protected function assertPageNoErrorMessages() {
     $error_messages = $this->getSession()->getPage()->findAll('css', '.messages.messages--error');
     $this->assertCount(0, $error_messages, implode(', ', array_map(static function(NodeElement $el) {
-      return $el->getValue();
+      return $el->getText();
     }, $error_messages)));
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Wrong function used to get the contents of the drupal error textboxes that appear at top of pages.

Before
----------------------------------------
Just a limited stack trace that points to the generic error function, so you don't know what the actual error is without hunting down the screenshot.

After
----------------------------------------
Gives you the text contents of the error boxes in the github action output directly.

Technical Details
----------------------------------------
getValue() only works on form elements. The textbox is just a div.

Comments
----------------------------------------
Ahhhhhhhhh

See https://github.com/colemanw/webform_civicrm/actions/runs/1786370647 for an example where I fudged the code to make such an error.
