### PR TITLE
Using API params only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '9.1.*'
+          - drupal: '9.3.*'
             civicrm: '5.35.*'
+          - drupal: '9.3.*'
+            civicrm: '5.45.*'
           - drupal: '9.3.*'
             civicrm: '5.46.*'
           - drupal: '9.3.*'
@@ -73,6 +75,8 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-updates
+          COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0' --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
             civicrm: '5.39.*'
           - drupal: '9.3.*'
             civicrm: '5.46.x-dev'
-          # - drupal: '9.2.*'
-          #   civicrm: 'dev-master'
+          - drupal: '9.3.*'
+            civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '9.1.*'
-            civicrm: '5.35.*'
           - drupal: '9.2.*'
-            civicrm: '5.39.*'
+            civicrm: '5.35.*'
           - drupal: '9.3.*'
-            civicrm: '5.46.x-dev'
+            civicrm: '5.46.*'
           - drupal: '9.3.*'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,10 +75,10 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
+          #these next two lines are necessary for D9.3 + CiviCRM 5.35.*
           COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0' --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist -W
-      # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
         run: |
           cd ~/drupal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '9.2.*'
+          - drupal: '9.1.*'
             civicrm: '5.35.*'
           - drupal: '9.3.*'
             civicrm: '5.46.*'
@@ -74,9 +74,6 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
-          # for D9.3.3
-          COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0'
-          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-updates
+          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0' --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,9 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
-          # COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
+          # for D9.3.3
+          COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0'
+          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0' --no-update
-          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist
+          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist -W
       # For some reason drupal/webform:5.x installs even if it is drupal:^9.0
       - name: Ensure Webform ^6.0
         run: |

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -719,16 +719,16 @@ class Utils implements UtilsInterface {
       ////$payParams['currencyID'] = $propertyBag->getCurrency();
       $params['amount'] = $params['total_amount'];
       // For legacy purposes (if payment processor does not use propertyBag)
-      if (isset($payParams['isRecur'])) {
-        $payParams['is_recur'] = $payParams['isRecur'];
-      }
+      ////if (isset($payParams['isRecur'])) {
+      ////  $payParams['is_recur'] = $payParams['isRecur'];
+      ////}
       $params['contribution_id'] = $order['id'];
       ////throw new \Exception(var_export($params, TRUE));
       $payParams = $params;
 
-      $params['payment_processor_id'] = $params['payment_processor'];
-      $params['contribution_id'] = $order['id'];
-      $params['currencyID'] = $params['currency'];
+      ////$params['payment_processor_id'] = $params['payment_processor'];
+      ////$params['contribution_id'] = $order['id'];
+      ////$params['currencyID'] = $params['currency'];
       $payResult = reset(civicrm_api3('PaymentProcessor', 'pay', $payParams)['values']);
 
       // webform_civicrm sends out receipts using Contribution.send_confirmation API if the contribution page is has is_email_receipt = TRUE.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -698,9 +698,9 @@ class Utils implements UtilsInterface {
     try {
       // Use the Payment Processor to attempt to take the actual payment. You may
       // pass in other params here, too.
-      $propertyBag = new \Civi\Payment\PropertyBag();
-      $propertyBag->mergeLegacyInputParams($params);
-      $propertyBag->setContributionID($order['id']);
+      ////$propertyBag = new \Civi\Payment\PropertyBag();
+      ////$propertyBag->mergeLegacyInputParams($params);
+      ////$propertyBag->setContributionID($order['id']);
       // @fixme: Class \Civi\Payment\CRM_Utils_Money not found (fixed in 5.28 via https://github.com/civicrm/civicrm-core/pull/17505
       //   But note we still return a localized format
       // $propertyBag->setAmount($params['total_amount']);
@@ -708,20 +708,27 @@ class Utils implements UtilsInterface {
       // We need the payment params as an array to pass to PaymentProcessor.Pay API3.
       // If https://github.com/civicrm/civicrm-core/pull/17507 was merged we wouldn't need this hack
       //   using ReflectionClass to access the array.
-      $reflectionClass = new \ReflectionClass($propertyBag);
-      $reflectionProperty = $reflectionClass->getProperty('props');
-      $reflectionProperty->setAccessible(TRUE);
-      $payParams = $reflectionProperty->getValue($propertyBag)['default'];
+      ////$reflectionClass = new \ReflectionClass($propertyBag);
+      ////$reflectionProperty = $reflectionClass->getProperty('props');
+      ////$reflectionProperty->setAccessible(TRUE);
+      ////$payParams = $reflectionProperty->getValue($propertyBag)['default'];
 
       // propertyBag has 'contributionID', we need 'contribution_id'.
-      $payParams['contribution_id'] = $propertyBag->getContributionID();
+      ////$payParams['contribution_id'] = $propertyBag->getContributionID();
       // propertyBag has 'currency', iATS uses `currencyID` until https://github.com/iATSPayments/com.iatspayments.civicrm/pull/350 is merged
-      $payParams['currencyID'] = $propertyBag->getCurrency();
-      $payParams['amount'] = $params['total_amount'];
+      ////$payParams['currencyID'] = $propertyBag->getCurrency();
+      $params['amount'] = $params['total_amount'];
       // For legacy purposes (if payment processor does not use propertyBag)
       if (isset($payParams['isRecur'])) {
         $payParams['is_recur'] = $payParams['isRecur'];
       }
+      $params['contribution_id'] = $order['id'];
+      ////throw new \Exception(var_export($params, TRUE));
+      $payParams = $params;
+
+      $params['payment_processor_id'] = $params['payment_processor'];
+      $params['contribution_id'] = $order['id'];
+      $params['currencyID'] = $params['currency'];
       $payResult = reset(civicrm_api3('PaymentProcessor', 'pay', $payParams)['values']);
 
       // webform_civicrm sends out receipts using Contribution.send_confirmation API if the contribution page is has is_email_receipt = TRUE.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -696,39 +696,9 @@ class Utils implements UtilsInterface {
 
     $order = civicrm_api3('Order', 'create', $params);
     try {
-      // Use the Payment Processor to attempt to take the actual payment. You may
-      // pass in other params here, too.
-      ////$propertyBag = new \Civi\Payment\PropertyBag();
-      ////$propertyBag->mergeLegacyInputParams($params);
-      ////$propertyBag->setContributionID($order['id']);
-      // @fixme: Class \Civi\Payment\CRM_Utils_Money not found (fixed in 5.28 via https://github.com/civicrm/civicrm-core/pull/17505
-      //   But note we still return a localized format
-      // $propertyBag->setAmount($params['total_amount']);
-
-      // We need the payment params as an array to pass to PaymentProcessor.Pay API3.
-      // If https://github.com/civicrm/civicrm-core/pull/17507 was merged we wouldn't need this hack
-      //   using ReflectionClass to access the array.
-      ////$reflectionClass = new \ReflectionClass($propertyBag);
-      ////$reflectionProperty = $reflectionClass->getProperty('props');
-      ////$reflectionProperty->setAccessible(TRUE);
-      ////$payParams = $reflectionProperty->getValue($propertyBag)['default'];
-
-      // propertyBag has 'contributionID', we need 'contribution_id'.
-      ////$payParams['contribution_id'] = $propertyBag->getContributionID();
-      // propertyBag has 'currency', iATS uses `currencyID` until https://github.com/iATSPayments/com.iatspayments.civicrm/pull/350 is merged
-      ////$payParams['currencyID'] = $propertyBag->getCurrency();
       $params['amount'] = $params['total_amount'];
-      // For legacy purposes (if payment processor does not use propertyBag)
-      ////if (isset($payParams['isRecur'])) {
-      ////  $payParams['is_recur'] = $payParams['isRecur'];
-      ////}
       $params['contribution_id'] = $order['id'];
-      ////throw new \Exception(var_export($params, TRUE));
       $payParams = $params;
-
-      ////$params['payment_processor_id'] = $params['payment_processor'];
-      ////$params['contribution_id'] = $order['id'];
-      ////$params['currencyID'] = $params['currency'];
       $payResult = reset(civicrm_api3('PaymentProcessor', 'pay', $payParams)['values']);
 
       // webform_civicrm sends out receipts using Contribution.send_confirmation API if the contribution page is has is_email_receipt = TRUE.
@@ -737,6 +707,7 @@ class Utils implements UtilsInterface {
 
       // Assuming the payment was taken, record it which will mark the Contribution
       // as Completed and update related entities.
+      // ToDo: check to see if payment actually completed first
       civicrm_api3('Payment', 'create', [
         'contribution_id' => $order['id'],
         'total_amount' => $payParams['amount'],

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -89,7 +89,7 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     ]));
     $this->enableCivicrmOnWebform();
 
-    //Enable Address fields.
+    // Enable Address fields.
     $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_address', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->getSession()->getPage()->checkField('Country');
@@ -264,7 +264,7 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertPageNoErrorMessages();
 
     if ($type == 'webform-radios-other' && !$changeTypeToOption) {
-      $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contribution-1-contribution-total-amount-operations', FALSE, FALSE, NULL, $type);
+      $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contribution-1-contribution-total-amount-operations', FALSE, FALSE, NULL, 'webform-radios-other');
       return;
     }
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -319,6 +319,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->htmlOutput();
     if ($type) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-change-type"]')->click();
+      $this->assertSession()->assertWaitOnAjaxRequest();
       $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-elements-{$type}-operation']", 5000)->click();
       $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-cancel']", 5000);
     }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -319,13 +319,13 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->htmlOutput();
     if ($type) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-change-type"]')->click();
-      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-elements-{$type}-operation']", 3000)->click();
-      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-cancel']", 3000);
+      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-elements-{$type}-operation']", 5000)->click();
+      $this->assertSession()->waitForElementVisible('css', "[data-drupal-selector='edit-cancel']", 5000);
     }
 
     if ($enableStatic) {
       $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
-      $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]', 3000);
+      $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]', 5000);
     }
     if ($default) {
       $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);


### PR DESCRIPTION
Overview
----------------------------------------
We ran into an issue where one of the iATS tests had started failing due to a change in propertybag in CiviCRM Core
[Add billingStateProvince and standardized property names by mattwire · Pull Request #21583 · civicrm/civicrm-core](https://github.com/civicrm/civicrm-core/pull/21583)

Before
----------------------------------------
Contains propertyBag references

After
----------------------------------------
propertyBag references are removed - using API params only.

Technical Details
----------------------------------------
**Note:** All payment processor tests including -> Stripe FunctionalJavascript test pass ✅
I've only commented out //// the propertyBag bits for now to clearly show what can be removed.
