### PR TITLE
Remove special handling for transact API and return the expected result

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -744,13 +744,9 @@ class Utils implements UtilsInterface {
       return ['error_message' => $e->getMessage()];
     }
 
-    $contribution = civicrm_api3('Contribution', 'getsingle', ['id' => $order['id']]);
-    // Transact API works a bit differently because we are actually adding the payment and updating the contribution status.
-    // A "normal" transaction (eg. using doPayment() or just PaymentProcessor.pay) would not update the contribution and would
-    // rely on the caller to do so. The caller relies on the `payment_status_id` (Pending or Completed) to know whether the payment
-    // was successful or not.
-    $contribution['payment_status_id'] = $contribution['contribution_status_id'];
-    return $contribution;
+    // Contribution.transact is expected to return an API3 result containing the contribution
+    //   eg. [ 'id' => X, 'values' => [ X => [ contribution details ] ]    return $contribution;
+    return civicrm_api3('Contribution', 'get', ['id' => $order['id']]);
   }
 
   /**

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1994,15 +1994,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         'id' => $resultRecur['id'],
         'currency' => $contributionParams['currency'],
         'next_sched_contribution_date' => date("Y-m-d H:i:s", strtotime('+' . $contributionRecurParams['frequency_interval'] . ' ' . $contributionRecurParams['frequency_unit'])),
-       ];
-      if ($APIAction == 'transact') {
-        // Now that we include Transact within webform_civicrm module it comes back flattened:
-        $recurParams['invoice_id'] = $result['invoice_id'];
-        $recurParams['payment_instrument_id'] = $result['payment_instrument_id'];
-      } else {
-        $recurParams['invoice_id'] = $result['values'][$result['id']]['invoice_id'];
-        $recurParams['payment_instrument_id'] = $result['values'][$result['id']]['payment_instrument_id'];
-      }
+      ];
+      $recurParams['invoice_id'] = $result['values'][$result['id']]['invoice_id'];
+      $recurParams['payment_instrument_id'] = $result['values'][$result['id']]['payment_instrument_id'];
       $this->utils->wf_civicrm_api('ContributionRecur', 'create', $recurParams);
     }
     return $result;


### PR DESCRIPTION
Overview
----------------------------------------
@KarinG This will fix one of the PHP notices you're seeing on #696

Before
----------------------------------------
transact not returning results in expected format. Special handling for that.

After
----------------------------------------
transact returning results in expected format. Remove special handling.

Technical Details
----------------------------------------
Note that this was an error when I wrote the contributiontransactlegacy extension where this code came from. The original core transact API returned an API3 Contribution.get result per this PR.

Comments
----------------------------------------

