### PR TITLE
fix saving multi-record custom field create mode

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1946,10 +1946,6 @@ class AdminForm implements AdminFormInterface {
           $component['value'] = $val;
           $enabled[$key] = $component;
         }
-        elseif (substr($key, -11) === '_createmode') {
-          // Update webform's settings with 'Create mode' value for custom group.
-          $this->settings['data']['config']['create_mode'][$key] = $val;
-        }
         else {
           // Try to "update" options for existing fields via ::insertComponent
           // Always insert fieldsets, as there are checks to see if the
@@ -1959,6 +1955,10 @@ class AdminForm implements AdminFormInterface {
           }
           $field += ['form_key' => $key];
           self::insertComponent($field, $enabled, $this->settings);
+        }
+        if (substr($key, -11) === '_createmode') {
+          // Update webform's settings with 'Create mode' value for custom group.
+          $this->settings['data']['config']['create_mode'][$key] = $val;
         }
       }
       // add empty fieldsets for custom civicrm sets with no fields, if "add dynamically" is checked


### PR DESCRIPTION
Overview
----------------------------------------
Multi-record custom fields have a "create mode" which determines whether the webform submission can overwrite existing data or must always create a new record.

#### Steps to replicate
* Create a multi-record custom field set in CiviCRM.
* In Webform, enable that field set on a contact.
* Set the *Create Mode* to **Create Only**.
* Press **Save**.
![Selection_1391](https://user-images.githubusercontent.com/1796012/153070488-290afe12-016d-44e8-9f6c-cbd46990daba.png)


Before
----------------------------------------
When the form reloads, the **Create Only** setting is lost.

After
----------------------------------------
When the form reloads, the **Create Only** setting is respected.

Technical Details
----------------------------------------
On save, there's a giant `if..elseif..elseif...` etc. block that handles special cases.  However, the first `if` statement will always evaluate to `TRUE`, so the `elseif` that handles saving the `create_mode` setting is never evaluated.

I moved the `createmode` value into its own `if` statement so that it's certain to be evaluated.