### PR TITLE
D8/9 - Add test for stripe recur payment

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1966,7 +1966,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       foreach ($this->line_items as $key => $k) {
         $this->line_items[$key]['unit_price'] = round(($k['unit_price'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
         $this->line_items[$key]['line_total'] = round(($k['line_total'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
-        $this->line_items[$key]['tax_amount'] = round(($k['tax_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+        if (isset($k['tax_amount'])) {
+          $this->line_items[$key]['tax_amount'] = round(($k['tax_amount'] / $numInstallments), 2, PHP_ROUND_HALF_UP);
+        }
       }
     }
 

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -23,6 +23,9 @@ final class StripeTest extends WebformCivicrmTestBase {
     $this->utils->wf_civicrm_api('Extension', 'download', [
       'key' => "com.drastikbydesign.stripe",
     ]);
+    $this->utils->wf_civicrm_api('Extension', 'download', [
+      'key' => "contributiontransactlegacy",
+    ]);
     $params = [];
     $result = $this->utils->wf_civicrm_api('Stripe', 'setuptest', $params);
     $this->paymentProcessorID = $result['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Add test for stripe recur payment

Before
----------------------------------------
No test.

After
----------------------------------------
Test Added. But it fails and seems to be a bug (not sure in wc or in stripe). The error is:

![image](https://user-images.githubusercontent.com/5929648/153752489-cd6e1b6a-5ed0-4bba-8f24-ec9d012eb826.png)

To replicate

- Create a webform with recur enabled (Frequency = month).
- Submit the webform.
- Error.

@mattwire Any quick thoughts on why is it failing?

