### PR TITLE
Record fee if available

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -727,6 +727,7 @@ class Utils implements UtilsInterface {
         civicrm_api3('Payment', 'create', [
           'contribution_id' => $order['id'],
           'total_amount' => $payParams['amount'],
+          'fee_amount' => $payResult['fee_amount'] ?? 0,
           'payment_instrument_id' => $order['values'][$order['id']]['payment_instrument_id'],
           'payment_processor_id' => $payParams['payment_processor_id'],
           'is_send_contribution_notification' => $params['is_email_receipt'],
@@ -736,6 +737,7 @@ class Utils implements UtilsInterface {
         civicrm_api3('Contribution', 'create', [
           'id' => $order['id'],
           'total_amount' => $payParams['amount'],
+          'fee_amount' => $payResult['fee_amount'] ?? 0,
           'payment_instrument_id' => $order['values'][$order['id']]['payment_instrument_id'],
           'payment_processor_id' => $payParams['payment_processor_id'],
           'trxn_id' => $payResult['trxn_id'] ?? NULL,

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -162,6 +162,7 @@ final class StripeTest extends WebformCivicrmTestBase {
     $this->assertEquals($this->webform->label(), $contribution['contribution_source']);
     $this->assertEquals('Donation', $contribution['financial_type']);
     $this->assertEquals('59.50', $contribution['total_amount']);
+    $this->assertEquals('2.03', $contribution['fee_amount']);
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
 


### PR DESCRIPTION
Overview
----------------------------------------
The payment processing fee is not known until payment is made. If a `fee_amount` is returned record that too.

Before
----------------------------------------
Fee not recorded.

After
----------------------------------------
Fee recorded.

Technical Details
----------------------------------------


Comments
----------------------------------------
@KarinG If @jitendrapurohit has time it would be nice to see a test to validate this?
