### PR TITLE
Handle phone_type_id if overwritten to NULL in civicrm_phone table

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -380,10 +380,13 @@ abstract class WebformCivicrmBase {
       $valueFound = false;
       foreach($values as $key => $value){
         if ((in_array($ent, ['address', 'email']) && $value['location_type_id'] == $setting['location_type_id'])
-          || (
-             $value['location_type_id'] == $setting['location_type_id'] &&
-             (!isset($setting[$ent.'_type_id']) || $value[$ent.'_type_id'] == $setting[$ent.'_type_id'])
-             )
+            || (
+              $value['location_type_id'] == $setting['location_type_id'] &&
+              (
+                !isset($setting[$ent.'_type_id']) ||
+                (isset($value[$ent.'_type_id'])) && $value[$ent.'_type_id'] == $setting[$ent.'_type_id']
+              )
+            )
         ) {
             $reorderedArray[$key] = $value;
             $valueFound = true;


### PR DESCRIPTION
https://www.drupal.org/project/webform_civicrm/issues/3264156

Resolve e-notice for missing array element.

It seems from comments that this part of code shouldn't apply in
situation causing error however I'm unclear what it's actually doing
so this needs review/testing before merging.

