### PR TITLE
Fix duplicate actions.

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -140,7 +140,7 @@
         $.extend(CRM.payment, payment);
       }
 
-      $('.webform-submission-form #edit-actions').detach().appendTo('.webform-submission-form');
+      $('.webform-submission-form #edit-actions', context).once('wf-civi').detach().appendTo('.webform-submission-form');
     }
   }
 


### PR DESCRIPTION
Overview
----------------------------------------
Buttons are duplicated when you enable contribution and have another webform (non-Civi/Civi webform) in the same page.

To reproduce:

1. Create a CiviCRM webform with *contribution* enabled.
2. Create another simple webform.
3. Place the simple webform in any region on a block to be visible on any page.
4. Visit the CiviCRM webform where these two webforms are visible - https://take.ms/8jPon.

Before
----------------------------------------
Duplicate buttons.

After
----------------------------------------
No more duplicate buttons.