### PR TITLE
Allow sorting events by title

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -858,7 +858,6 @@ class AdminForm implements AdminFormInterface {
       '#type' => 'select',
       '#title' => t('Title Display'),
       '#default_value' => wf_crm_aval($this->data, 'reg_options:title_display', 'title'),
-      '#suffix' => '</div>',
       '#parents' => ['reg_options', 'title_display'],
       '#tree' => TRUE,
       '#options' => [
@@ -879,6 +878,18 @@ class AdminForm implements AdminFormInterface {
       '#title' => t('Show Full Events'),
       '#default_value' => (bool) wf_crm_aval($this->data, 'reg_options:show_full_events', 1, TRUE),
       '#parents' => ['reg_options', 'show_full_events'],
+    ];
+    $this->form['participant']['event_sort_field'] = [
+      '#type' => 'select',
+      '#title' => t('Sort Events By'),
+      '#default_value' => wf_crm_aval($this->data, 'reg_options:event_sort_field', 'start_date'),
+      '#suffix' => '</div>',
+      '#parents' => ['reg_options', 'event_sort_field'],
+      '#tree' => TRUE,
+      '#options' => [
+        'start_date' => t('Start Date'),
+        'title' => t('Title'),
+      ],
     ];
     $this->help($this->form['participant']['title_display'], 'reg_options_title_display');
     $this->form['participant']['reg_options'] = [
@@ -936,6 +947,7 @@ class AdminForm implements AdminFormInterface {
     $this->addAjaxItem('participant', 'show_public_events', 'participants');
     $this->addAjaxItem('participant', 'title_display', 'participants');
     $this->addAjaxItem('participant', 'show_full_events', 'participants');
+    $this->addAjaxItem('participant', 'event_sort_field', 'participants');
 
     for ($n = 1; $reg_type && (($n <= count($this->data['contact']) && $reg_type != 'all') || $n == 1); ++$n) {
       $this->form['participant']['participants'][$n] = [

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -145,6 +145,8 @@ class Utils implements UtilsInterface {
   function wf_crm_get_events($reg_options, $context) {
     $ret = [];
     $format = wf_crm_aval($reg_options, 'title_display', 'title');
+    $sort_field = wf_crm_aval($reg_options, 'event_sort_field', 'start_date');
+    $sort_order = ($context == 'config_form' && $sort_field === 'start_date') ? ' DESC' : '';
     $params = [
       'is_template' => 0,
       'is_active' => 1,
@@ -156,7 +158,7 @@ class Utils implements UtilsInterface {
     if (is_numeric(wf_crm_aval($reg_options, 'show_public_events'))) {
       $params['is_public'] = $reg_options['show_public_events'];
     }
-    $params['options'] = ['sort' => 'start_date' . ($context == 'config_form' ? ' DESC' : '')];
+    $params['options'] = ['sort' => $sort_field . $sort_order];
     $values = $this->wf_crm_apivalues('Event', 'get', $params);
     // 'now' means only current events, 1 means show all past events, other values are relative date strings
     $date_past = wf_crm_aval($reg_options, 'show_past_events', 'now');


### PR DESCRIPTION
Overview
----------------------------------------
Currently, webforms with User Select for events always sorts by start date.  This allows sorting by title, and opens the door to trivially allowing sort by other fields.

Before
----------------------------------------
Events sorted by start date.

After
----------------------------------------
Events sorted by sort date by default; sorting by title is also available.

Comments
----------------------------------------
On the config form, sorting was reversed from the actual webform.  I've maintained this when sorting by start date.
