### PR TITLE
Correctly handle custom fields with 'multi-select' checkbox checked

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -1010,6 +1010,9 @@ class Fields implements FieldsInterface {
           $fields[$id]['extra']['description_above'] = (int) empty($custom_field['help_pre']);
           $fields[$id]['has_help'] = TRUE;
         }
+        if ($custom_field['serialize'] || FALSE) {
+          $fields[$id]['extra']['multiple'] = 1;
+        }
         // Conditional rule - todo: support additional entities
         if ($sets[$set]['entity_type'] == 'contact' && !empty($sets[$set]['sub_types'])) {
           $fields[$id]['civicrm_condition'] = [

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -1010,7 +1010,7 @@ class Fields implements FieldsInterface {
           $fields[$id]['extra']['description_above'] = (int) empty($custom_field['help_pre']);
           $fields[$id]['has_help'] = TRUE;
         }
-        if ($custom_field['serialize'] || FALSE) {
+        if (!empty($custom_field['serialize'])) {
           $fields[$id]['extra']['multiple'] = 1;
         }
         // Conditional rule - todo: support additional entities


### PR DESCRIPTION
Overview
----------------------------------------
Custom fields with the "multi-select" checkbox aren't treated as multi-select fields.

### Steps to replicate
* Create a new custom field on a contact of data type "Alphanumeric", HTML type of "Autocomplete-Select", and the "Multi-Select" box checked.
* Create a new webform with this field.
* Submit this field with multiple values selected.

Before
----------------------------------------
Only the first value is saved.

After
----------------------------------------
All values are saved.

Comments
----------------------------------------
https://github.com/civicrm/civicrm-core/pull/16992 added a new field to `civicrm_custom_field` called `serialize`, and all fields with this set to `TRUE` are multi-select fields.  WFC was unaware of this field and didn't create the fields `extra` array accordingly.