### PR TITLE
Update for use of FormState.

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -427,7 +427,7 @@ class AdminForm implements AdminFormInterface {
         $rule_field =& $this->form['contact_' . $n]['contact_subtype_wrapper']["contact_{$n}_settings_matching_rule"];
         // Reset to default if selected rule doesn't exist or isn't valid for this contact type
         if (!array_key_exists($rule_field['#default_value'], $rule_field['#options'])) {
-          $rule_field['#default_value'] = $this->form_state['input']["contact_{$n}_settings_matching_rule"] = 'Unsupervised';
+          $rule_field['#default_value'] = $this->form_state->getUserInput()["contact_{$n}_settings_matching_rule"] = 'Unsupervised';
         }
         $this->help($rule_field, 'matching_rule');
       }

--- a/tests/src/FunctionalJavascript/ContactDedupeTest.php
+++ b/tests/src/FunctionalJavascript/ContactDedupeTest.php
@@ -46,7 +46,7 @@ final class ContactDedupeTest extends WebformCivicrmTestBase {
 
     $result = civicrm_api4('DedupeRule', 'create', [
       'values' => [
-        'dedupe_rule_group_id' => $dedupe_rule_group_id,
+        'dedupe_rule_group_id' => $this->dedupeRuleGroupId,
         'rule_table' => 'civicrm_contact',
         'rule_field' => 'first_name',
         'rule_length' => '',
@@ -56,7 +56,7 @@ final class ContactDedupeTest extends WebformCivicrmTestBase {
 
     $result = civicrm_api4('DedupeRule', 'create', [
       'values' => [
-        'dedupe_rule_group_id' => $dedupe_rule_group_id,
+        'dedupe_rule_group_id' => $this->dedupeRuleGroupId,
         'rule_table' => 'civicrm_phone',
         'rule_field' => 'phone_numeric',
         'rule_length' => '',

--- a/tests/src/FunctionalJavascript/ContactDedupeTest.php
+++ b/tests/src/FunctionalJavascript/ContactDedupeTest.php
@@ -181,6 +181,23 @@ final class ContactDedupeTest extends WebformCivicrmTestBase {
     ]);
     $email = reset($api_result['values']);
     $this->assertEquals('frederick@pabst.io', $email['email']);
+
+    $this->drupalLogin($this->adminUser);
+
+    civicrm_api4('DedupeRule', 'delete', [
+      'where' => [['dedupe_rule_group_id.id', '=', $this->dedupeRuleGroupId]],
+    ]);
+
+    civicrm_api4('DedupeRuleGroup', 'delete', [
+      'where' => [['id', '=', $this->dedupeRuleGroupId]],
+    ]);
+
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+
+    $this->assertSession()->elementExists('css', 'input[data-drupal-selector="edit-nid"]');
+    $this->assertPageNoErrorMessages();
   }
 
 }

--- a/tests/src/FunctionalJavascript/ContactDedupeTest.php
+++ b/tests/src/FunctionalJavascript/ContactDedupeTest.php
@@ -11,6 +11,13 @@ use Drupal\Core\Url;
  */
 final class ContactDedupeTest extends WebformCivicrmTestBase {
 
+  /**
+   * The dedupe rule group ID.
+   *
+   * @var int
+   */
+  protected $dedupeRuleGroupId;
+
   private function createContactSubtype() {
     $params = [
         'name' => "Student",
@@ -35,7 +42,7 @@ final class ContactDedupeTest extends WebformCivicrmTestBase {
         ],
     ]);
     $result_DedupeRuleGroup = reset($result);
-    $dedupe_rule_group_id = $result_DedupeRuleGroup['id'];
+    $this->dedupeRuleGroupId = $result_DedupeRuleGroup['id'];
 
     $result = civicrm_api4('DedupeRule', 'create', [
       'values' => [


### PR DESCRIPTION
Overview
----------------------------------------
Have an existing CiviCRM webform with a selected "Matching Rule" that is not provided by core. When you delete that "Matching Rule" in CiviCRM, there would be an error saying when you visit the CiviCRM settings page:

> Error: Cannot use object of type Drupal\Core\Form\FormState as array in Drupal\webform_civicrm\AdminForm->buildContactTab() (line 426 of /app/web/modules/contrib/webform_civicrm/src/AdminForm.php)

Before
----------------------------------------
Could not access CiviCRM settings.

After
----------------------------------------
Add fix.

Comments
----------------------------------------
Yeah, will try to add tests as well.