### PR TITLE
Make TextFormat the default widget for Activity Details.

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -405,7 +405,8 @@ class Fields implements FieldsInterface {
       ];
       $fields['activity_details'] = [
         'name' => t('Activity # Details'),
-        'type' => \Drupal::moduleHandler()->moduleExists('webform_html_textarea') ? 'html_textarea' : 'textarea',
+        'type' => 'text_format',
+        'allowed_formats' => [],
       ];
       $fields['activity_status_id'] = [
         'name' => t('Activity # Status'),

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -406,7 +406,7 @@ class Fields implements FieldsInterface {
       $fields['activity_details'] = [
         'name' => t('Activity # Details'),
         'type' => 'text_format',
-        'allowed_formats' => [],
+        'allowed_formats' => 'html',
       ];
       $fields['activity_status_id'] = [
         'name' => t('Activity # Status'),

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -406,7 +406,7 @@ class Fields implements FieldsInterface {
       $fields['activity_details'] = [
         'name' => t('Activity # Details'),
         'type' => 'text_format',
-        'allowed_formats' => 'html',
+        'allowed_formats' => [],
       ];
       $fields['activity_status_id'] = [
         'name' => t('Activity # Status'),

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -76,9 +76,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_duration");
 
-    // KG take sceenshot
-    // $this->createScreenshot($this->htmlOutputDirectory . 'KG2.png');
-
     $this->saveCiviCRMSettings();
   }
 
@@ -103,9 +100,6 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
       $this->getSession()->getPage()->fillField("civicrm_{$i}_contact_1_contact_first_name", $this->_contacts[$i]['first_name']);
       $this->getSession()->getPage()->fillField("civicrm_{$i}_contact_1_contact_last_name", $this->_contacts[$i]['last_name']);
     }
-
-    // KG take sceenshot
-    // $this->createScreenshot($this->htmlOutputDirectory . 'KG.png');
 
     $this->getSession()->getPage()->fillField('Activity Subject', 'Awesome Activity');
     $this->getSession()->getPage()->fillField('Activity Details', 'Lorem ipsum dolor sit amet.');

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -76,6 +76,9 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_activity_date_time");
     $this->assertSession()->checkboxChecked("civicrm_1_activity_1_activity_duration");
 
+    // KG take sceenshot
+    // $this->createScreenshot($this->htmlOutputDirectory . 'KG2.png');
+
     $this->saveCiviCRMSettings();
   }
 
@@ -100,6 +103,9 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
       $this->getSession()->getPage()->fillField("civicrm_{$i}_contact_1_contact_first_name", $this->_contacts[$i]['first_name']);
       $this->getSession()->getPage()->fillField("civicrm_{$i}_contact_1_contact_last_name", $this->_contacts[$i]['last_name']);
     }
+
+    // KG take sceenshot
+    // $this->createScreenshot($this->htmlOutputDirectory . 'KG.png');
 
     $this->getSession()->getPage()->fillField('Activity Subject', 'Awesome Activity');
     $this->getSession()->getPage()->fillField('Activity Details', 'Lorem ipsum dolor sit amet.');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -19,7 +19,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     'webform_ui',
     'webform_civicrm',
     'token',
-    'CKEditor',
+    'ckeditor',
   ];
 
   /**

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -19,6 +19,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     'webform_ui',
     'webform_civicrm',
     'token',
+    'CKEditor',
   ];
 
   /**


### PR DESCRIPTION
Before
----------------------------------------
Activity Details default widget is text area (no HTML)

After
----------------------------------------
Now it's a text format -> so with HTML!

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/5340555/155651668-7357cc24-9266-4ee1-bd73-bf53e71e6806.png">

Comments
----------------------------------------
It looks like this also removed some old code that was trying to do this - but didn't.
