### PR TITLE
D8/9 - Make Amount Requested default + required on Grant section

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1293,6 +1293,9 @@ class AdminForm implements AdminFormInterface {
     ];
     $this->addAjaxItem("grantTab", "grant_number_of_grant", "grant");
     for ($n = 1; $n <= $num; ++$n) {
+      $this->settings += [
+        'civicrm_' . $n . '_grant_1_grant_amount_total' => 'create_civicrm_webform_element',
+      ];
       $fs = "grant_grant_{$n}_fieldset";
       $this->form['grantTab']['grant'][$fs] = [
         '#type' => 'fieldset',

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -914,6 +914,9 @@ class Fields implements FieldsInterface {
         ];
         $fields['grant_amount_total'] = [
             'name' => t('Amount Requested'),
+            'attributes' => [
+              'required' => 1,
+            ],
           ] + $moneyDefaults;
         $fields['grant_amount_granted'] = [
             'name' => t('Amount Granted'),


### PR DESCRIPTION
Overview
----------------------------------------
Make Amount Requested field as default + required on Grant section

Before
----------------------------------------
Amount Requested is a required field for CiviCRM to create Grant, but is not selected by default on the webform settings page.

Results in a fatal error while submitting the webform. Related - https://www.drupal.org/project/webform_civicrm/issues/3212184



After
----------------------------------------
Amount Requested field is enabled by default and is also made a required field.

![image](https://user-images.githubusercontent.com/5929648/155884200-295aec17-b069-40c6-b147-70f58619c1da.png)


