### PR TITLE
D8/9 - Store free membership in line item table

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2271,7 +2271,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
 
     // Save line-items
     foreach ($this->line_items as &$item) {
-      if (empty($item['line_total'])) {
+      if (empty($item['line_total']) && $item['entity_table'] != 'civicrm_membership') {
         continue;
       }
       if (empty($item['entity_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Store free membership in line item table

Before
----------------------------------------
0 membership amount is not stored in line items. To replicate

- Create a free membership type in civicrm.
- Add this membership to contactA.
- Create a webform with this membership type and a line item.
- Load the webform with cid1 = contactA.
- The 0 membership is loaded as default on the webform.
- Submit the webform with line item.

![image](https://user-images.githubusercontent.com/5929648/156912512-3f27a680-5b60-4d03-b393-4d428ba187ca.png)

- The contribution created has only single line item and no mention of free membership.

![image](https://user-images.githubusercontent.com/5929648/156912539-b70cf4d9-607f-4a0b-9522-f407bb9fb6c1.png)

After
----------------------------------------
Free membership is stored in line item table and is also displayed on View contribution page -

![image](https://user-images.githubusercontent.com/5929648/156912558-32e2baea-545d-4db7-a77f-c811a1580e73.png)

