### PR TITLE
once function not existing

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -1,5 +1,5 @@
 // Webform payment processing using CiviCRM's jQuery
-(function ($, D, drupalSettings) {
+(function ($, D, drupalSettings, once) {
   'use strict';
   var setting = drupalSettings.webform_civicrm;
 
@@ -141,8 +141,8 @@
         $.extend(CRM.payment, payment);
       }
 
-      $('.webform-submission-form #edit-actions', context).once('wf-civi').detach().appendTo('.webform-submission-form');
+      jQuery('.webform-submission-form #edit-actions', context).once('wf-civi').detach().appendTo('.webform-submission-form');
     }
   }
 
-})(CRM.$, Drupal, drupalSettings);
+})(CRM.$, Drupal, drupalSettings, once);

--- a/webform_civicrm.libraries.yml
+++ b/webform_civicrm.libraries.yml
@@ -18,6 +18,7 @@ payment:
     js/webform_civicrm_payment.js: {}
   dependencies:
     - core/jquery
+    - core/once
     - core/drupal
     - core/drupalSettings
     - webform_civicrm/forms


### PR DESCRIPTION
Overview
----------------------------------------
This is in related to #710. Most of the time the `jquery.once` library is being loaded although there was an instance where it wasn't attached as a library and the contribution page shown an error:

> TypeError: $(...).once is not a function

Before
----------------------------------------
Error saying:

> TypeError: $(...).once is not a function

After
----------------------------------------
Added `jquery.once` as a dependency.