### PR TITLE
Remove older workarounds from unit test config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,17 +69,9 @@ jobs:
           composer config repositories.0 composer https://packages.drupal.org/8
           composer config repositories.1 path $GITHUB_WORKSPACE
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }}
-      - name: Deal with https://lab.civicrm.org/dev/drupal/-/issues/164
-        # This is temporary until no longer testing anything less than 5.41. A more sophisticated way would be to make this conditional on civi version so that for 5.41+ it doesn't do this, giving a closer approximation to real installs for 5.41+, but as far as I know this is only used by compile-lib to make some bootstrap css files.
-        run: |
-          cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require scssphp/scssphp:1.6.0
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          #these next two lines are necessary for D9.3 + CiviCRM 5.35.*
-          COMPOSER_MEMORY_LIMIT=-1 composer require pear/pear_exception:"1.0.2 as 1.0.1" --no-update
-          COMPOSER_MEMORY_LIMIT=-1 composer require --no-update phpoffice/phpword:'0.18.0 as 0.15.0' --no-update
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist -W
       - name: Ensure Webform ^6.0
         run: |


### PR DESCRIPTION
Overview
----------------------------------------
These workarounds _shouldn't_ be needed if only testing 5.45+, and without them will be closer to what a "normal" install would have.
