### PR TITLE
constrain to 2.2 for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             php-version: 7.4
             extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
             coverage: none
-            tools: composer:v2
+            tools: composer:2.2
       - name: Get composer cache directory
         id: composercache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"


### PR DESCRIPTION
Overview
----------------------------------------
Constrain composer to v2.2 because CiviCRM can not be installed with v2.3 at the moment.
