### PR TITLE
[TESTS] Put composer version back and add scheduled runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - 6.x
+  schedule:
+    # Run Monday/Thursday at 12:13 GMT
+    - cron: '13 12 * * 1,4'
 
 jobs:
   phpunit:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
             php-version: 7.4
             extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, soap, intl, gd, exif, iconv
             coverage: none
-            tools: composer:2.2
+            tools: composer:v2
       - name: Get composer cache directory
         id: composercache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
* Restricted to composer 2.2.x because of temporary issue.
* Not run on a schedule

After
----------------------------------------
* Allow composer 2.x
* Add a schedule

Technical Details
----------------------------------------


Comments
----------------------------------------
The schedule seems to take a while to kick in, but the first one is scheduled for Monday. Also depending on github resources, it may run some time after the scheduled time.