### PR TITLE
[Unit tests] "branches" no longer valid syntax

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,6 @@ on:
     # Run Monday/Thursday at 12:13 GMT
     - cron: '13 12 * * 1,4'
   workflow_dispatch:
-    branches:
-      - 6.x
     inputs:
       coreprurl:
         description: (optional) Core PR URL


### PR DESCRIPTION
Overview
----------------------------------------
As of less than a couple hours ago this no longer seems to be a valid parameter to the actions workflow script.