### PR TITLE
D8/9 - Allow -User Select- on Contribution Financial type field

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1579,8 +1579,8 @@ class AdminForm implements AdminFormInterface {
         $item['#default_value'] = self::$method($fid, $options);
       }
       // 4: From field default
-      elseif (isset($field['value'])) {
-        $item['#default_value'] = $field['value'];
+      elseif (isset($field['value']) || isset($field['default_value'])) {
+        $item['#default_value'] = $field['value'] ?? $field['default_value'];
       }
       // 5: For required fields like phone type, default to the first option
       elseif (empty($field['extra']['multiple']) && !isset($field['empty_option'])) {

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -91,6 +91,7 @@ class AdminForm implements AdminFormInterface {
 
     // Sort fields by set
     foreach ($this->fields as $fid => $field) {
+      $fid = $field['fid'] ?? $fid;
       if (isset($field['set'])) {
         $set = $field['set'];
       }

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1092,6 +1092,12 @@ class AdminForm implements AdminFormInterface {
     // Make sure webform is set-up to prevent credit card abuse.
     $this->checkSubmissionLimit();
     $financialType = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
+    if (!$financialType && $this->settings['civicrm_1_contribution_1_contribution_financial_type_id'] != 'create_civicrm_webform_element') {
+      $financialType = $this->utils->wf_civicrm_api('FinancialType', 'getvalue', [
+        'return' => 'id',
+        'name' => 'Donation',
+      ]);
+    }
     // Add contribution fields
     foreach ($this->sets as $sid => $set) {
       if ($set['entity_type'] == 'contribution' && (empty($set['sub_types']) || in_array($financialType, $set['sub_types']) )) {
@@ -1126,17 +1132,6 @@ class AdminForm implements AdminFormInterface {
         }
       }
     }
-    //Add financial type config.
-    $ft_options = (array) $this->utils->wf_crm_apivalues('Contribution', 'getoptions', [
-      'field' => "financial_type_id",
-    ]);
-    $this->form['contribution']['sets']['contribution']['civicrm_1_contribution_1_contribution_financial_type_id'] = [
-      '#type' => 'select',
-      '#title' => t('Financial Type'),
-      '#default_value' => $financialType,
-      '#options' => $ft_options,
-      '#required' => TRUE,
-    ];
     $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_financial_type_id", "..:custom");
 
     //Add Currency.

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -718,12 +718,16 @@ class Fields implements FieldsInterface {
           'type' => 'textfield',
           'parent' => 'contribution_pagebreak',
         ];
+        $donationFinancialType = $this->utils->wf_civicrm_api('FinancialType', 'getvalue', [
+          'return' => 'id',
+          'name' => 'Donation',
+        ]);
         $fields['contribution_financial_type_id'] = [
           'name' => t('Financial Type'),
           'type' => 'select',
           'expose_list' => TRUE,
           'civicrm_live_options' => TRUE,
-          'default' => 1,
+          'default_value' => $donationFinancialType,
           'parent' => 'contribution_pagebreak',
           'extra' => ['required' => 1],
         ];
@@ -738,7 +742,7 @@ class Fields implements FieldsInterface {
           'type' => 'select',
           'expose_list' => TRUE,
           'civicrm_live_options' => TRUE,
-          'default' => 1,
+          'default_value' => $donationFinancialType,
           'parent' => 'contribution_pagebreak',
           'set' => 'line_items',
           'fid' => 'contribution_financial_type_id',

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -729,10 +729,9 @@ class Fields implements FieldsInterface {
           'type' => 'select',
           'expose_list' => TRUE,
           'civicrm_live_options' => TRUE,
-          'value' => 1,
           'default' => 1,
-          'set' => 'line_items',
           'parent' => 'contribution_pagebreak',
+          'extra' => ['required' => 1],
         ];
         $sets['contributionRecur'] = ['entity_type' => 'contribution', 'label' => t('Recurring Contribution')];
         $fields['contribution_frequency_unit'] = [

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -718,12 +718,6 @@ class Fields implements FieldsInterface {
           'type' => 'textfield',
           'parent' => 'contribution_pagebreak',
         ];
-        // Line items
-        $fields['contribution_line_total'] = [
-            'name' => t('Line Item Amount'),
-            'set' => 'line_items',
-            'parent' => 'contribution_pagebreak',
-          ] + $moneyDefaults;
         $fields['contribution_financial_type_id'] = [
           'name' => t('Financial Type'),
           'type' => 'select',
@@ -732,6 +726,22 @@ class Fields implements FieldsInterface {
           'default' => 1,
           'parent' => 'contribution_pagebreak',
           'extra' => ['required' => 1],
+        ];
+        // Line items
+        $fields['contribution_line_total'] = [
+            'name' => t('Line Item Amount'),
+            'set' => 'line_items',
+            'parent' => 'contribution_pagebreak',
+          ] + $moneyDefaults;
+        $fields['lineitem_financial_type_id'] = [
+          'name' => t('Financial Type'),
+          'type' => 'select',
+          'expose_list' => TRUE,
+          'civicrm_live_options' => TRUE,
+          'default' => 1,
+          'parent' => 'contribution_pagebreak',
+          'set' => 'line_items',
+          'fid' => 'contribution_financial_type_id',
         ];
         $sets['contributionRecur'] = ['entity_type' => 'contribution', 'label' => t('Recurring Contribution')];
         $fields['contribution_frequency_unit'] = [

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -993,10 +993,10 @@ class Utils implements UtilsInterface {
   public function getReceiptParams($data, $contributionID) {
     $contributionData = wf_crm_aval($data, 'contribution:1:contribution:1');
     $params = ['id' => $contributionID];
-    $params['payment_processor_id'] = $contributionData['payment_processor_id'];
+    $params['payment_processor_id'] = $contributionData['payment_processor_id'] ?? $data['civicrm_1_contribution_1_contribution_payment_processor_id'] ?? NULL;
     unset($params['payment_processor']);
 
-    $params['financial_type_id'] = $contributionData['financial_type_id'];
+    $params['financial_type_id'] = $contributionData['financial_type_id'] ?? $data['civicrm_1_contribution_1_contribution_financial_type_id_raw'] ?? NULL;
     $params['currency'] = wf_crm_aval($data, "contribution:1:currency");
 
     //Assign receipt values set on the webform config page.

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -54,7 +54,8 @@ function webform_civicrm_civicrm_alterMailParams(&$params, $context) {
           }
           $settings = &$config['webform_civicrm']['settings'];
           $utils = \Drupal::service('webform_civicrm.utils');
-          $receiptParams = $utils->getReceiptParams($settings['data'], $params['tplParams']['contributionID']);
+          $submissionData = array_merge($settings['data'], $submission->getData());
+          $receiptParams = $utils->getReceiptParams($submissionData, $params['tplParams']['contributionID']);
           $params['tplParams']= array_merge($params['tplParams'], $receiptParams);
         }
       }
@@ -197,11 +198,13 @@ function _fillCiviCRMData($data, $webformSubmission) {
       if (!empty($element['#webform_multiple'])) {
         foreach ($val as $k => $v) {
           if (isset($element['#options'][$v])) {
+            $data[$key]["{$k}_raw"] = $data[$key][$k];
             $data[$key][$k] = $element['#options'][$v];
           }
         }
       }
       elseif (isset($element['#options'][$val])) {
+        $data["{$key}_raw"] = $data[$key];
         $data[$key] = $element['#options'][$val];
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
Allow `-User Select-` on contribution financial type field.

Before
----------------------------------------
Admins need to set Financial Type on the settings form (Contribution Tab).

![image](https://user-images.githubusercontent.com/5929648/166110967-83aec954-5509-456b-91df-b490aa0180cb.png)


After
----------------------------------------
Can be set to `-User Select-` -

![Screenshot 2022-04-30 at 8 33 52 PM](https://user-images.githubusercontent.com/5929648/166110957-f1c71398-62ce-4a14-86a4-e1c800b57656.jpg)



Comments
----------------------------------------
FYI @KarinG @MegaphoneJon 