### PR TITLE
D8/9 - billing state is not saved on webform submission

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -800,6 +800,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     // Check which location_type_id is to be set as is_primary=1;
     $is_primary_address_location_type = wf_crm_aval($contact, 'address:1:location_type_id');
     $is_primary_email_location_type = wf_crm_aval($contact, 'email:1:location_type_id');
+    $billingLocTypeID = $this->utils->wf_civicrm_api('LocationType', 'get', [
+      'name' => "Billing",
+    ])['id'] ?? NULL;
 
     foreach ($this->utils->wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
@@ -816,7 +819,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         }
         foreach ($contact[$location] as $i => $params) {
           // Translate state/prov abbr to id
-          if (!empty($params['state_province_id']) && !is_numeric($params['state_province_id'])) {
+          if (!empty($params['state_province_id']) && $params['location_type_id'] != $billingLocTypeID) {
             $default_country = $this->utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
             if (!($params['state_province_id'] = $this->utils->wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $default_country)))) {
               $params['state_province_id'] = '';

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -816,7 +816,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         }
         foreach ($contact[$location] as $i => $params) {
           // Translate state/prov abbr to id
-          if (!empty($params['state_province_id'])) {
+          if (!empty($params['state_province_id']) && !is_numeric($params['state_province_id'])) {
             $default_country = $this->utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
             if (!($params['state_province_id'] = $this->utils->wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $default_country)))) {
               $params['state_province_id'] = '';

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -93,8 +93,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     // $this->assertPageNoErrorMessages();
 
     // Assert if recur is attached to the created membership.
-    $utils = \Drupal::service('webform_civicrm.utils');
-    $api_result = $utils->wf_civicrm_api('membership', 'get', [
+    $api_result = $this->utils->wf_civicrm_api('membership', 'get', [
       'sequential' => 1,
       'return' => 'contribution_recur_id',
     ]);
@@ -102,7 +101,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->assertNotEmpty($membership['contribution_recur_id']);
 
     // Let's make sure we have a Contribution by ensuring we have a Transaction ID
-    $api_result = $utils->wf_civicrm_api('contribution', 'get', [
+    $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
       'sequential' => 1,
     ]);
     $contribution = reset($api_result['values']);
@@ -291,7 +290,6 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
   }
 
   public function purchaseMembershipProvince($province) {
-    $utils = \Drupal::service('webform_civicrm.utils');
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
 
@@ -335,6 +333,14 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
       'sequential' => 1,
     ]);
+    $addresses = $this->utils->wf_crm_apivalues('address', 'get', [
+      'sequential' => 1,
+    ]);
+    foreach ($addresses as $address) {
+      if ($address['location_type_id'] == 5) {
+        $this->assertEquals(1048, $address['state_province_id']);
+      }
+    }
 
     if ($province == 'Alberta') {
       $this->assertEquals(1, $api_result['count']);
@@ -381,7 +387,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
       $this->assertEquals(2, $api_result['count']);
       $line_items = next($api_result['values']);
     }
-    $priceFieldID = $utils->wf_civicrm_api('PriceField', 'get', [
+    $priceFieldID = $this->utils->wf_civicrm_api('PriceField', 'get', [
       'sequential' => 1,
       'price_set_id' => 'default_membership_type_amount',
       'options' => ['limit' => 1],


### PR DESCRIPTION
Overview
----------------------------------------
Fix storage of billing state on webform submission.

Before
----------------------------------------
Billing state is not saved on webform submission. To replicate:

- Create a webform => Enable address section.
- From Contribution tab => Enable billing address.
- Submit the webform.
- The state field from the billing address is not saved in civicrm.   

https://www.drupal.org/project/webform_civicrm/issues/2854717

After
----------------------------------------
Billing state is saved on webform submission.

Technical Details
----------------------------------------
Billing Address is saved during the validation phase while creating a billing contact. The code then overrides the value thinking that its an abbreviation from the normal address field. A billing check with an if statement avoids the removal .

Comments
----------------------------------------
@KarinG @MegaphoneJon 