### PR TITLE
D8/9 - Fix reqd error on File upload field

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -116,8 +116,8 @@ var wfCivi = (function ($, D, drupalSettings) {
         }
       }
       else {
-        $(':visible', container).hide();
-        container.append('<input type="submit" class="button form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Remove') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
+        $(container).children().hide();
+        container.append('<input type="submit" class="button form-submit ajax-processed civicrm-remove-file" value="' + Drupal.t('Change') + '" onclick="wfCivi.clearFileField(\'' + field + '\'); return false;">');
       }
       container.prepend('<span class="file civicrm-file-icon file--'+info.icon+'">' + (info.name ? ('<a href="'+ info.file_url+ '" target="_blank">'+info.name +'</a>') : '') + '</span>');
     }
@@ -127,7 +127,7 @@ var wfCivi = (function ($, D, drupalSettings) {
     var element = 'div#edit-' + field.replace(/_/g, '-') + '.civicrm-enabled';
     var container = $(element.toLowerCase());
     $('.civicrm-remove-file, .civicrm-file-icon', container).remove();
-    $('input[type=file], input[type=submit]', container).show();
+    $(container).children().show();
   };
 
   /**

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -549,6 +549,11 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
                   'eid' => $eid,
                   'fileInfo' => $fileInfo
                 ];
+                // Unset required attribute on the file if its loaded from civicrm.
+                if (!empty($val)) {
+                  $element['#required'] = FALSE;
+                  unset($element['#states']['required']);
+                }
               }
             }
             // Set value for "secure value" elements


### PR DESCRIPTION
Overview
----------------------------------------
Fix Require error on File field 

Before
----------------------------------------
If File upload field is pre-loaded with a default value, submitting the webform leads to a validation error of "field is required"

https://www.drupal.org/project/webform_civicrm/issues/3277834

![image](https://user-images.githubusercontent.com/5929648/167250204-7e39dc95-cbfb-4c74-8dd8-a5f96c57ec0c.png)

After
----------------------------------------
Fixed. No error is displayed on submission.

Technical Details
----------------------------------------
Webform CiviCRM has a special handling with File upload fields. Looks like when a user uploads a file, wc copies the file to civicrm directory and copies/creates a new file to store in civi. So there are technically 2 files with separate ids.

When the file is pre-loaded with a default civi file id, webform civi simply hides the upload field using js and displays the civi file name to let user know that the file for this entity is already present in civi.

The problem arises when the field is configured as required in webform. Since the file is already present in civi, i think removing the required field attribute from the field makes sense. 

Thoughts @KarinG 


Comments
----------------------------------------
I've done the following testing and the results seems to be as expected.

- Submit the form with default value selected. The field in civicrm is unaffected.
- Click "Change" and submit the form. The field in civicrm is unaffected.
- Click "Change" and upload a new file. The field in civicrm is updated with the new uploaded file.
- Click "Change" => upload a new file => Remove the file => Submit. The webform gives a validation error. 