### PR TITLE
D8/D9 - Javascript error causing form to not load properly: webformId.replace is not a function

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -137,7 +137,7 @@ var wfCivi = (function ($, D, drupalSettings) {
   var stateProvinceCache = {};
 
   function getFormClass(webformId) {
-    return '.webform-submission-' + webformId.replace(/_/g, '-') + '-form'
+    return '.webform-submission-' + webformId.toString().replace(/_/g, '-') + '-form';
   }
 
   function resetFields(num, nid, clear, op, toHide, hideOrDisable, showEmpty, speed, defaults) {


### PR DESCRIPTION
Overview
----------------------------------------
A js error causing form to not load properly.

Before
----------------------------------------
JS error: Uncaught TypeError: webformId.replace is not a function.
<img width="926" alt="image" src="https://user-images.githubusercontent.com/3448551/167898508-7a94d740-69b6-41e0-84f9-bb91c7b0d8fc.png">

After
----------------------------------------
No error after fixing the responsbile js code.

Technical Details
----------------------------------------
webformId.replace throws a js error when webformId is a number, and works fine on a string.

