### PR TITLE
Fix Exception when Donation financial type isn't available in civicrm

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1094,10 +1094,10 @@ class AdminForm implements AdminFormInterface {
     $this->checkSubmissionLimit();
     $financialType = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
     if (!$financialType && $this->settings['civicrm_1_contribution_1_contribution_financial_type_id'] != 'create_civicrm_webform_element') {
-      $financialType = $this->utils->wf_civicrm_api('FinancialType', 'getvalue', [
+      $financialType = current($this->utils->wf_crm_apivalues('FinancialType', 'get', [
         'return' => 'id',
         'name' => 'Donation',
-      ]);
+      ], 'id')) ?? NULL;
     }
     // Add contribution fields
     foreach ($this->sets as $sid => $set) {

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -718,10 +718,10 @@ class Fields implements FieldsInterface {
           'type' => 'textfield',
           'parent' => 'contribution_pagebreak',
         ];
-        $donationFinancialType = $this->utils->wf_civicrm_api('FinancialType', 'getvalue', [
+        $donationFinancialType = current($this->utils->wf_crm_apivalues('FinancialType', 'get', [
           'return' => 'id',
           'name' => 'Donation',
-        ]);
+        ], 'id')) ?? NULL;
         $fields['contribution_financial_type_id'] = [
           'name' => t('Financial Type'),
           'type' => 'select',


### PR DESCRIPTION
Overview
----------------------------------------
Fixes https://github.com/colemanw/webform_civicrm/pull/736#issuecomment-1121275626

Before
----------------------------------------
Exception when CiviCRM doesn't have `Donation` FT available.

`CiviCRM_API3_Exception: Expected one FinancialType but found 0 in civicrm_api3() (line 134 of /var/www/drupal/vendor/civicrm/civicrm-core/api/api.php).`

After
----------------------------------------

Looks like Donation FTs are pre-existing data in civicrm but are also not reserved ones so anyone can delete them 

![image](https://user-images.githubusercontent.com/5929648/168422423-4876a697-c160-4b8b-914c-7742aafb7736.png)

Fixed the exception by replacing the `getvalue` by a simple `get` api.

Comments
----------------------------------------
@KarinG 