### PR TITLE
D8/9 - Fix source field to display on the contact widget using v4 api

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -225,7 +225,7 @@ class ContactComponent implements ContactComponentInterface {
       }
     }
     // Fetch contact name with filters applied
-    $result = $this->utils->wf_civicrm_api4('Contact', 'get', $filters, 0);
+    $result = $this->utils->wf_civicrm_api4('Contact', 'get', $filters)[0] ?? [];
     return $this->wf_crm_format_contact($result, /*$component['#extra']['results_display']*/ ['display_name']);
   }
 
@@ -358,7 +358,12 @@ class ContactComponent implements ContactComponentInterface {
       else {
         $filterVal = $contact_element->getElementProperty($component, $filter);
         if ($filterVal) {
-          $params['where'][] = [$filter, '=', $filterVal];
+          $op = '=';
+          if (in_array($filter, ['group', 'tag'])) {
+            $filter .= 's';
+            $op = 'IN';
+          }
+          $params['where'][] = [$filter, $op, $filterVal];
         }
       }
     }

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -114,11 +114,10 @@ class ContactComponent implements ContactComponentInterface {
         }
       }
     }
-    $search_field = 'display_name';
     $sort_field = 'sort_name';
     // Search and sort based on the selected display field
     if (!in_array('display_name', $display_fields)) {
-      $search_field = $sort_field = $display_fields[0];
+      $sort_field = $display_fields[0];
     }
     $params += [
       'limit' => $limit,
@@ -140,7 +139,11 @@ class ContactComponent implements ContactComponentInterface {
     }
     unset($params['relationship']);
     if ($str) {
-      $params['where'][] = [$search_field, 'CONTAINS', $str];
+      $searchFields = [];
+      foreach ($display_fields as $fld) {
+        $searchFields[] = [$fld, 'CONTAINS', $str];
+      }
+      $params['where'][] = ['OR', $searchFields];
     }
     $result = $this->utils->wf_civicrm_api4('Contact', 'get', $params);
     // Autocomplete results

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -632,6 +632,29 @@ class Utils implements UtilsInterface {
   }
 
   /**
+   * Wrapper for all CiviCRM APIv4 calls
+   *
+   * @param string $entity
+   *   API entity
+   * @param string $operation
+   *   API operation
+   * @param array $params
+   *   API params
+   * @param string|int|array $index
+   *   Controls the Result array format.
+   *
+   * @return array
+   *   Result of API call
+   */
+  function wf_civicrm_api4($entity, $operation, $params, $index = NULL) {
+    if (!$entity) {
+      return [];
+    }
+    $result = civicrm_api4($entity, $operation, $params, $index);
+    return $result;
+  }
+
+  /**
    * Wrapper for all CiviCRM API calls
    * For consistency, future-proofing, and error handling
    *

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -173,6 +173,49 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Check if autocomplete widget results is
+   * searchable with all display field values.
+   */
+  public function testDisplayFields() {
+    $this->createIndividual([
+      'first_name' => 'James',
+      'last_name' => 'Doe',
+      'source' => 'Webform Testing',
+    ]);
+
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->saveCiviCRMSettings();
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    // Edit contact element and add source to display fields.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'results_display' => ['display_name', 'source'],
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
+
+    // Search on first name and verify if the contact is selected.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'James');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
+
+    // Search on source value and verify if the contact is selected.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'Webform Testing');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
+  }
+
+  /**
    * Test submission of hidden fields.
    */
   public function testHiddenField() {
@@ -191,7 +234,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
      $this->saveCiviCRMSettings();
      $this->drupalGet($this->webform->toUrl('edit-form'));
 
-     // Edit contact element and hide email field.
+    // Edit contact element and hide email field.
     $editContact = [
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Autocomplete',

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -484,6 +484,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       }
     }
     $this->htmlOutput();
+    if (!empty($params['results_display'])) {
+      $this->addFieldValue('properties[results_display][]', $params['results_display']);
+    }
 
     if (!empty($params['default'])) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();


### PR DESCRIPTION
Overview
----------------------------------------
Fix source field to display on the contact widget using v4 api

Before
----------------------------------------
Source field fails to load on the contact widget. To replicate -

- Add Existing contact element to the webform.
- Update widget to Autocomplete. Select Source in the `Contact Display Field(s)` input.
- Load the webform and search for a contact.
- No source is displayed

![image](https://user-images.githubusercontent.com/5929648/169643990-d445e5d1-18fe-4906-92ba-32240e7e41d6.png)

After
----------------------------------------
Source value is displayed -

![image](https://user-images.githubusercontent.com/5929648/169643970-54b08867-63d4-48e7-bb1c-62fb21befcb1.png)

Technical Details
----------------------------------------
It looks like a core bug in civicrm api v3. It does not return the source value when contact get api is called. But we do get the source using v4. This PR uses the v4 api instead and displays the values on the contact widget. 

Comments
----------------------------------------
@KarinG 