### PR TITLE
D8/9 - Fix checkbox display when rendering using Gin

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -54,10 +54,14 @@
         return "<li>" + string + "</li>";
       }
 
+      /**
+       * TODO: Remove this function and use states api instead once
+       * https://www.drupal.org/project/drupal/issues/1149078 is fixed in core webform module.
+       */
       function changeDefault() {
         var val = $(this).val().replace(/_/g, '-');
 
-        $('[data-drupal-selector=edit-contact-defaults] > div > .form-item', context).not('[class$=properties-default], [class$=properties-allow-url-autofill]').each(function() {
+        $('[data-drupal-selector=edit-contact-defaults] > div > .form-item', context).not('[class$=properties-default], [class*=properties-allow-url-autofill]').each(function() {
           if (val.length && $(this).is('[class*=form-item-properties-default-'+val+']')) {
             $(this).removeAttr('style');
           }


### PR DESCRIPTION
Overview
----------------------------------------
Fix checkbox display when rendering using Gin

Drupal Ticket - https://www.drupal.org/project/gin/issues/3280725

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/5929648/169648567-7c7de4bd-043e-44a1-bb4e-26f720ffd0ce.png)

After
----------------------------------------
![image](https://user-images.githubusercontent.com/5929648/169648374-cdb426ff-c085-4ad1-a534-3494fce306b3.png)

Technical Details
----------------------------------------
There's a bug in core webform module https://www.drupal.org/project/drupal/issues/1149078 due to which multiple options are not supported in states api. Hence we still need to use the js to manipulate the display of fields in the default section on the config form. 

Comments
----------------------------------------
@KarinG 