### PR TITLE
D8/9 - Fix required error on static widget

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -345,17 +345,4 @@ class ContactComponent implements ContactComponentInterface {
     return $params;
   }
 
-
-  /**
-   * Validation callback
-   *
-   * @param array $element
-   * @param array $form_state
-   */
-  function wf_crm_contact_component_required($element, &$form_state) {
-    if (empty($element['#value'])) {
-      form_error($element, t('@name field is required.', ['@name' => $element['#title']]));
-    }
-  }
-
 }

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -614,4 +614,33 @@ class CivicrmContact extends WebformElementBase {
     return $value;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function prepareElementValidateCallbacks(array &$element, WebformSubmissionInterface $webform_submission = NULL) {
+    parent::prepareElementValidateCallbacks($element, $webform_submission);
+    if ($element['#type'] == 'hidden' && !empty($element['#required'])) {
+      $element['#element_validate'][] = [get_class($this), 'validateRequired'];
+    }
+  }
+
+  /**
+   * Form API callback. Validate static widget #required attribute.
+   */
+  public static function validateRequired(&$element, FormStateInterface &$form_state) {
+    if (empty($element['#required'])) {
+      return;
+    }
+
+    if (empty($element['#value'])) {
+      $args = [
+        '%name' => empty($element['#title']) ? $element['#parents'][0] : $element['#title'],
+      ];
+      // Avoid error while calling form_state which expects '#group' as a string value :(.
+      $static_element = $element;
+      unset($static_element['#group']);
+      $form_state->setError($static_element, t('%name field is required.', $args));
+    }
+  }
+
 }

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -326,6 +326,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Static',
       'default' => 'Current User',
+      'required' => TRUE,
     ];
     $this->editContactElement($editContact);
     $this->assertSession()->pageTextContains('Existing Contact has been updated');
@@ -351,6 +352,15 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Submit');
     $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
     $this->assertPageNoErrorMessages();
+
+    $this->drupalLogout();
+
+    // Submit the form as an anonymous user.
+    // Empty static widget should throw an error on submission.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertSession()->pageTextContains('Existing Contact field is required');
   }
 
   /**

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -508,6 +508,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if (!empty($params['remove_default_url'])) {
       $this->getSession()->getPage()->uncheckField('properties[allow_url_autofill]');
     }
+    if (!empty($params['required'])) {
+      $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-validation"]')->click();
+      $this->getSession()->getPage()->checkField('properties[required]');
+    }
 
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();


### PR DESCRIPTION
Overview
----------------------------------------
Fix required error on static widget

Before
----------------------------------------
Static Widget does not display a required error on empty webform submission. To replicate:

- Create a webform with existing contact field.
- Edit the existing contact field as Widget = Static and required = true.
- Submit the webform as an anonymous user.
- Webform is submitted without any validation error.
 
After
----------------------------------------
Validation Error is displayed -

![image](https://user-images.githubusercontent.com/5929648/169695250-792a9323-bab8-462c-b5d6-f61a9f562629.png)

Technical Details
----------------------------------------
Removes the d7 code and add a validate callback for the static widget.

Comments
----------------------------------------
@KarinG 