### PR TITLE
D8/9 - Add hash to file name before saving the uploaded attachment

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -784,7 +784,8 @@ abstract class WebformCivicrmBase {
     $file = File::load($id);
     if ($file) {
       $config = \CRM_Core_Config::singleton();
-      $path = \Drupal::service('file_system')->copy($file->getFileUri(), $config->customFileUploadDir);
+      $destination = $config->customFileUploadDir . DIRECTORY_SEPARATOR . \CRM_Utils_File::makeFileName($file->getFilename());
+      $path = \Drupal::service('file_system')->copy($file->getFileUri(), $destination);
       if ($path) {
         $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'create', [
           'uri' => str_replace($config->customFileUploadDir, '', $path),


### PR DESCRIPTION
Overview
----------------------------------------
File filename before saving to civicrm

Before
----------------------------------------
Filename is not hashed before saving to civicrm database.

After
----------------------------------------
Filename is hashed.

Technical Details
----------------------------------------
Call to core function CRM_Utils_File::makeFileName().

Alternative fix could have been the usage of Attachment api but it requires an entity id to be passed in params. We dont necessarily have entity id at this point in every case so can't use this.
 
Api4 doesn't have attachment api and `File` api doesn't really changes the uri param as of now.

Seems like we still need to use the CRM function.

Comments
----------------------------------------
@KarinG @stesi561 fyi