### PR TITLE
Don't hide details of the deprecations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           cd ~/drupal/web
           ../vendor/bin/phpunit -c core modules/contrib/webform_civicrm
         env:
-          SYMFONY_DEPRECATIONS_HELPER: weak
+          SYMFONY_DEPRECATIONS_HELPER: 999999
           SIMPLETEST_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080
           MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'


### PR DESCRIPTION
Overview
----------------------------------------
The `SYMFONY_DEPRECATIONS_HELPER=weak` is hiding the details of the deprecations, so it just shows a number. I expect at the beginning when this was all set up the output was overwhelming, but it's useful to see these.

Before
----------------------------------------
Just a number like 127388

After
----------------------------------------
What this should show here is the following under self-deprecations:

* declaration of setUp() should have return type void
* something about tabbable, but can't be fixed here it needs fixing in the parent webform module
* deprecation of jquery.once

Technical Details
----------------------------------------
symfony phpunit-bridge

Comments
----------------------------------------

