### PR TITLE
Skip test for 5.49 since will never pass

### DIFF
--- a/tests/src/FunctionalJavascript/CaseSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CaseSubmissionTest.php
@@ -58,6 +58,10 @@ final class CaseSubmissionTest extends WebformCivicrmTestBase {
    * Test Case Submission and update with non admin user.
    */
   public function testCaseSubmissionWithNonAdminUser() {
+    if (!\CRM_Core_BAO_Domain::isDBVersionAtLeast('5.50.4')) {
+      $this->markTestSkipped('Test requires core fix that is only in 5.50.4+');
+    }
+
     $this->testUser = $this->createUser([
       'access content',
     ]);


### PR DESCRIPTION
Overview
----------------------------------------
While there'll probably be a 5.50 release with a fix for #756, I don't think there'll be a 5.49 version, so this test will never pass for 5.49. Next ESR should be 5.51 next month.