### PR TITLE
D8/9: make Contact selectable for Contributions

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -542,15 +542,19 @@ var wfCiviAdmin = (function (D, $, once) {
       }).change();
 
       function billingMessages() {
+        var contactId = $('[name=civicrm_1_contribution_1_contribution_contact_id]').val();
+        if (typeof contactId == 'undefined') {
+          contactId = 1;
+        }
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_enable_contribution]');
         // Warning about contribution page with no email
-        if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
-          var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(1)});
+        if ($pageSelect.val() !== '0' && ($('[name=civicrm_' + contactId + '_contact_1_email_email]:checked').length < 1 || $('[name=contact_' + contactId + '_number_of_email]').val() == '0')) {
+          var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(contactId)});
           if (!$('.wf-crm-billing-email-alert').length) {
             $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
             $('.wf-crm-billing-email-alert button').click(function() {
-              $('input[name=civicrm_1_contact_1_email_email]').prop('checked', true).change();
-              $('select[name=contact_1_number_of_email]').val('1').change();
+              $('input[name=civicrm_' + contactId + '_contact_1_email_email]').prop('checked', true).change();
+              $('select[name=contact_' + contactId + '_number_of_email]').val('1').change();
               return false;
             });
             if ($('.wf-crm-billing-email-alert').is(':hidden')) {
@@ -569,8 +573,12 @@ var wfCiviAdmin = (function (D, $, once) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $(once('email-alert', '[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_1_contact_1_email_email]', context)).change(billingMessages);
-      billingMessages();
+      // Get contact assigned to contribution
+      var contactIdForContrib = $('[name=civicrm_1_contribution_1_contribution_contact_id]').val();
+      if (contactIdForContrib !== "create_civicrm_webform_element") {
+        $(once('email-alert', '[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_' + contactIdForContrib + '_contact_1_email_email]', context)).change(billingMessages);
+        billingMessages();
+      }
 
       // Handlers for submit-limit & tracking-mode mini-forms
       $(once('wf-civi', '#configure-submit-limit', context)).click(function() {

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -672,6 +672,16 @@ class Fields implements FieldsInterface {
           'parent' => 'contribution_pagebreak',
         ];
         // @todo moved in order since we can't pass `weight`.
+        $fields['contribution_contact_id'] = [
+          'name' => t('Contact'),
+          'type' => 'select',
+          'expose_list' => TRUE,
+          'data_type' => 'ContactReference',
+          'extra' => [
+            'aslist' => 1,
+            'required' => TRUE
+          ],
+        ];
         $fields['contribution_total_amount'] = [
             'name' => 'Contribution Amount',
             'parent' => 'contribution_pagebreak',

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -336,3 +336,27 @@ function webform_civicrm_update_8004() {
     $webform->save();
   }
 }
+
+/**
+ * Set Contact 1 as the assigned for Contributions in all webforms
+ * (It keeps default behavior <= 6.2.0)
+ */
+function webform_civicrm_update_8005() {
+  \Drupal::service('civicrm')->initialize();
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $settings = &$config['webform_civicrm']['settings'];
+    // If Contribution enabled, set Contact 1 assigned as default behavior <= 6.2.0
+    if ($settings['civicrm_1_contribution_1_contribution_enable_contribution'] == "1") {
+      $settings['civicrm_1_contribution_1_contribution_contact_id'] = 1;
+      $settings['data']['contribution'][1]['contribution'][1]['contact_id'] = 1;
+      $handler->setConfiguration($config);
+      $webform->save();
+    }
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Adds a new feature for D9 version,  included in iXiam's D7 fork, to be able to select for the Contribution, which Contact in the webform (if there are more than 1) will the owner of it.
This opens many new use cases that can be used in Webforms with multiple contacts (father/son, individual/company, etc.. where not always the contribution must be assigned to Contact 1)

![webform_civicrm](https://user-images.githubusercontent.com/2589799/176203447-a991711a-cb22-4554-8dee-8ae12e5fdc66.gif)


Before
----------------------------------------
If the Webform contains Contribution and several Contacts, **ALWAYS** the contribution is created for **Contact 1**

After
----------------------------------------
User can select which Contact added in the Webform would be the one assigned to the contribution, or even could be selected by the **End User** in the same Webform with the option `- User Select -`

Technical Details
----------------------------------------
This feature was offered to be included in D7 main repo in [PR #360](https://github.com/colemanw/webform_civicrm/pull/360) , but we didn't succeed, so we started using [iXiam's fork](https://github.com/ixiam/webform_civicrm/pull/1) with this feature included

Comments
----------------------------------------
This new feature takes in account default historically `webform_civicrm` behavior.. so by design always **Contact 1** is the selected by default in the Contribution Tab

Following the new validation added of checking that Email field is mandatory for the **Contact 1**, if Contribution is enabled, this new feature checks that Email field is mandatory for the **Contact x** selected as the assigned.
If the option selected is `- User Select -`, there's no email checking
