### PR TITLE
Update data-amount with .attr() function

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -57,7 +57,7 @@ cj(function($) {
   function getTotalAmount() {
     var totalAmount = 0.0;
     $('.line-item:visible', '#wf-crm-billing-items').each(function() {
-      totalAmount += parseFloat($(this).data('amount'));
+      totalAmount += parseFloat($(this).attr('data-amount'));
     });
     return totalAmount;
   }
@@ -65,6 +65,7 @@ cj(function($) {
   function tally() {
     var total = 0;
     total = getTotalAmount();
+    $('#wf-crm-billing-total').attr('data-amount', total);
 
     $('td+td', '#wf-crm-billing-total').html(CRM.formatMoney(total));
     if (total > 0) {
@@ -90,7 +91,7 @@ cj(function($) {
         taxPara = 1 + (tax / 100);
       }
       $('td+td', $lineItem).html(CRM.formatMoney(amount * taxPara));
-      $lineItem.data('amount', amount * taxPara);
+      $lineItem.attr('data-amount', amount * taxPara);
     }
     tally();
   }


### PR DESCRIPTION
Overview
----------------------------------------
Webform CiviCRM uses HTML attribute `data-amount` to store the amounts (line items amount, total amount). `webform_civcrm_payment.js ` does use` jQuery.data() ` function, which only stores the associated new value in the memory. It does not change the attribute in the DOM when the price is changing, i.e. dynamic contribution amount which is causing the issue when the form is relying on the `data-amount`  attribute 

Changed `data()` function to `attr()` function, addressed this issue. 

See https://api.jquery.com/data/#data-html5

Before
----------------------------------------
![webform_issue](https://user-images.githubusercontent.com/208713/176450309-1b7d96a4-1bc1-40af-ab1e-3ff0b2510285.gif)

After
----------------------------------------
![webform_issue_fixed](https://user-images.githubusercontent.com/208713/176450325-a42e1403-fa9e-4358-b471-fc4e3d975f7c.gif)
