### PR TITLE
Fix incorrect handling of contact subtypes when the subtype has more than one word

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -633,6 +633,23 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   }
 
   /**
+   * Normalize the Contact Subtype into a Camel_Case format.
+   * @param string $subtype
+   * @return string
+   */
+  private function normalizeContactSubtype($subtype) {
+    // the subtype is only made up of one word
+    if (stripos($subtype, '_') === FALSE) {
+      return ucfirst($subtype);
+    }
+
+    // the subtype is made up of multiple words concatenated with an underscore
+    $components = explode('_', $subtype);
+    $components = array_map('ucfirst', $components);
+    return implode('_', $components);
+  }
+
+  /**
    * Search for an existing contact using configured deupe rule
    * @param array $contact
    * @return int
@@ -642,7 +659,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $rule = wf_crm_aval($contact, 'matching_rule', 'Unsupervised', TRUE);
     if ($rule) {
       $contact['contact'][1]['contact_type'] = ucfirst($contact['contact'][1]['contact_type']);
-      $contact['contact'][1]['contact_sub_type'] = array_map('ucfirst', $contact['contact'][1]['contact_sub_type']);
+      $contact['contact'][1]['contact_sub_type'] = array_map(['self', 'normalizeContactSubtype'], $contact['contact'][1]['contact_sub_type']);
       $params = [
         'check_permission' => FALSE,
         'sequential' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
webform_civicrm does not interact correctly with Contact Subtypes with “Camel Case” formatted names.

Before
----------------------------------------
 Replication Steps:
1. Create new Contact Subtype called “First Contact”
2. Create new webform that creates new contact of this new Subtype
3. Enable CiviCRM Processing
4. Set the “Type of Individual” field in Contact 1 to be “User Select”
5. Add an “Email” field, ensuring the matching rule is kept as “Default Unsupervised”
6. Disable the “Existing Contact” field
7. Save settings
8. Go to “View” tab
9. Select “First Contact” as the “Type of Individual”
10. Add in values for “First Name”, “Last Name” and “Email”, press submit
11. Note “The website encountered an unexpected error. Please try again later.” Error message

Looking at the watchdog entry for this error message, you’ll be able to see the following error message: 
“CiviCRM_API3_Exception: Invalid Filter in civicrm_api3()”

The contact record does not get created.

After
----------------------------------------
No exception gets thrown and the contact is created successfully.

Technical Details
----------------------------------------

The ‘Invalid Filter’ exception is thrown in CiviCRM Core here: https://github.com/civicrm/civicrm-core/blob/b8f8e8206b742069bb40778e20ac1e0ec1634075/CRM/Core/BAO/CustomGroup.php#L658

If you add some Civi::log()->debug statements to this core function before the exception gets thrown, you’ll be able to see that the $subType value that gets passed in is “First_contact”, whereas the array key for this contact subtype in the $subTypes array is “First_Contact”. 

At present, the webform_civicrm module appears to lowercase all the data it receives from the form submission, and currently uses the ucfirst function before making the Contact.create API call. The proposed patch adds a normalizer function, that ucfirst’s each element of the contact subtype, using the underscore as a separator.

Comments
----------------------------------------
This patch does not handle the case where a contact subtype name is in all caps, and I’m not sure what the best approach would be for handling that case.
