### PR TITLE
D8/9 - Fix fatal error if subtype has more than one word

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -331,7 +331,7 @@ class Utils implements UtilsInterface {
           $contact_types[strtolower($type['name'])] = $type['label'];
           continue;
         }
-        $sub_types[strtolower($data[$type['parent_id']]['name'])][strtolower($type['name'])] = $type['label'];
+        $sub_types[strtolower($data[$type['parent_id']]['name'])][$type['name']] = $type['label'];
       }
     }
     return [$contact_types, $sub_types];
@@ -367,11 +367,11 @@ class Utils implements UtilsInterface {
         $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b'));
         $r['sub_type_a'] = wf_crm_aval($r, 'contact_sub_type_a');
         if (!is_null($r['sub_type_a'])) {
-          $r['sub_type_a'] = strtolower($r['sub_type_a']);
+          $r['sub_type_a'] = $r['sub_type_a'];
         }
         $r['sub_type_b'] = wf_crm_aval($r, 'contact_sub_type_b');
         if (!is_null($r['sub_type_b'])) {
-          $r['sub_type_b'] = strtolower($r['sub_type_b']);
+          $r['sub_type_b'] = $r['sub_type_b'];
         }
         $types[$r['id']] = $r;
       }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -642,7 +642,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $rule = wf_crm_aval($contact, 'matching_rule', 'Unsupervised', TRUE);
     if ($rule) {
       $contact['contact'][1]['contact_type'] = ucfirst($contact['contact'][1]['contact_type']);
-      $contact['contact'][1]['contact_sub_type'] = array_map('ucfirst', $contact['contact'][1]['contact_sub_type']);
       $params = [
         'check_permission' => FALSE,
         'sequential' => TRUE,

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -364,6 +364,52 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Submit webform with subtype value.
+   */
+  public function testSubmitWebformWithContactSubtype() {
+    $params = [
+      'name' => "First Contact",
+      'is_active' => 1,
+      'parent_id' => "Individual",
+    ];
+    $result = $this->utils->wf_civicrm_api('ContactType', 'create', $params);
+    $this->assertEquals(0, $result['is_error']);
+    $this->assertEquals(1, $result['count']);
+
+    $this->drupalLogin($this->adminUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_contact_contact_sub_type[]', 'create_civicrm_webform_element');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
+    $this->saveCiviCRMSettings();
+
+    $this->drupalLogout();
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+
+    $this->getSession()->getPage()->checkField('First Contact');
+    $this->assertSession()->checkboxChecked("First Contact");
+    $this->getSession()->getPage()->fillField('First Name', 'Frederick');
+    $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
+
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    $api_result = $this->utils->wf_civicrm_api('Contact', 'get', [
+      'sequential' => 1,
+      'first_name' => 'Frederick',
+      'last_name' => 'Pabst',
+    ]);
+    $this->assertEquals(1, $api_result['count']);
+    $contact = reset($api_result['values']);
+    $this->assertEquals('First_Contact', implode($contact['contact_sub_type']));
+  }
+
+  /**
    * Test submitting a contact.
    *
    * @dataProvider dataContactValues
@@ -378,12 +424,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'webform' => $this->webform->id(),
     ]));
     // The label has a <div> in it which can cause weird failures here.
-    $this->assertSession()->waitForText('Enable CiviCRM Processing');
-    $this->assertSession()->waitForField('nid');
-    $this->htmlOutput();
-    $this->getSession()->getPage()->checkField('nid');
-    $this->getSession()->getPage()->selectFieldOption('1_contact_type', strtolower($contact_type));
-    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->enableCivicrmOnWebform();
 
     // @see wf_crm_location_fields().
     $configurable_contact_field_groups = [
@@ -421,8 +462,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       }
     }
 
-    $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->saveCiviCRMSettings();
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error if subtype has more than one word

Before
----------------------------------------
See issue described at https://github.com/colemanw/webform_civicrm/pull/765

After
----------------------------------------
Fixed.


Comments
----------------------------------------
cc @MattTrim1