### PR TITLE
D8/9 - Fix locked field submission of state_province

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -818,8 +818,12 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $existing = array_merge([[]], $result['values']);
         }
         foreach ($contact[$location] as $i => $params) {
+          $stateIsID = FALSE;
+          if (!empty($existing[$i]['state_province_id']) && $existing[$i]['state_province_id'] == $params['state_province_id']) {
+            $stateIsID = TRUE;
+          }
           // Translate state/prov abbr to id
-          if (!empty($params['state_province_id']) && $params['location_type_id'] != $billingLocTypeID) {
+          if (!$stateIsID && !empty($params['state_province_id']) && $params['location_type_id'] != $billingLocTypeID) {
             $default_country = $this->utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
             if (!($params['state_province_id'] = $this->utils->wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $default_country)))) {
               $params['state_province_id'] = '';

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -71,4 +71,62 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $this->assertEquals(0, $address['values'][1]['is_primary']);
   }
 
+  /**
+   * Test webform submission with locked address fields.
+   */
+  public function testLockedAddressSubmission() {
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_address', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->htmlOutput();
+
+    $this->getSession()->getPage()->checkField('Country');
+    $this->getSession()->getPage()->selectFieldOption('Address Location', 'Main');
+    $this->getSession()->getPage()->selectFieldOption('Is Primary', 'No');
+
+    $this->saveCiviCRMSettings();
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    // Edit contact element and enable select widget.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'hide_fields' => 'address',
+    ];
+    $this->editContactElement($editContact);
+
+    //Submit the form.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $edit = [
+      'First Name' => 'Frederick',
+      'Last Name' => 'Pabst',
+    ];
+    $this->postSubmission($this->webform, $edit);
+
+    $countryID = $this->utils->wf_civicrm_api('Country', 'getvalue', [
+      'return' => "id",
+      'name' => "Canada",
+    ]);
+    $stateID = $this->utils->wf_civicrm_api('StateProvince', 'getvalue', [
+      'return' => "id",
+      'name' => "Ontario",
+    ]);
+    $address = $this->utils->wf_civicrm_api('Address', 'get', [
+      'sequential' => 1,
+      'contact_id' => $this->rootUserCid,
+    ]);
+    // Verify if the address is not modified on the contact.
+    $this->assertEquals(1, $address['count']);
+    $this->assertEquals('Toronto', $address['values'][0]['city']);
+    $this->assertEquals($stateID, $address['values'][0]['state_province_id']);
+    $this->assertEquals($countryID, $address['values'][0]['country_id']);
+    $this->assertEquals(1, $address['values'][0]['is_primary']);
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
Fix locked field submission of state_province element.

Before
----------------------------------------
State Province field submission removes the state value from civicrm if the element is locked under existing contact settings. To replicate - see https://www.drupal.org/project/webform_civicrm/issues/3294150

After
----------------------------------------
Fixed. Address values are unchanged on locked field submission.

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3294150