### PR TITLE
Small ad-hoc commit needed to allow negative amounts on the same page.

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -92,7 +92,7 @@
         }
         total += isNaN(amount) ? 0 : amount;
       });
-    return total < 0 ? 0 : total;
+    return total;
   }
 
   function calculateLineItemAmount() {


### PR DESCRIPTION
Necessary to allow negative amounts (like e.g. line items representing discounts) to update if the checkout is on the same webform page as the discount is added [e.g. a one page checkout].