### PR TITLE
translate "Existing Contact" element's properties

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -130,8 +130,17 @@ class CivicrmContact extends WebformElementBase {
       $element['#options'] = [];
       $element['#attributes']['data-is-select'] = 1;
     }
-    $element['#attributes']['data-search-prompt'] = $this->getElementProperty($element, 'search_prompt') ?? '- Choose existing -';
-    $element['#attributes']['data-none-prompt'] = $this->getElementProperty($element, 'none_prompt') ?? '+ Create new +';
+    // get translated properties used for autocomplete widget
+    $element['#attributes']['data-search-prompt'] = $this->getTranslatedElementProperty($element, 'search_prompt') ?? t('- Choose existing -');
+    $element['#attributes']['data-none-prompt'] = $this->getTranslatedElementProperty($element, 'none_prompt') ?? t('+ Create new +');
+    // translate search_prompt, which later is copied as #empty_value, and then created as first <option> if element is select widget
+    if(!empty($element['#search_prompt'])){
+      $element['#search_prompt'] = t($element['#search_prompt']);
+    }
+    // translate none_prompt, which later is created as second <option> if element is select widget (if user has privilegies to create new contacts)
+    if(!empty($element['#none_prompt'])){
+      $element['#none_prompt'] = t($element['#none_prompt']);
+    }
     if (!empty($cid)) {
       $webform = $webform_submission->getWebform();
       $contactComponent = \Drupal::service('webform_civicrm.contact_component');
@@ -641,6 +650,27 @@ class CivicrmContact extends WebformElementBase {
       unset($static_element['#group']);
       $form_state->setError($static_element, t('%name field is required.', $args));
     }
+  }
+
+  /**
+   * Get an element's property value with translation.
+   *
+   * @param array $element
+   *   An element.
+   * @param string $property_name
+   *   An element's property name.
+   *
+   * @return mixed
+   *   A translated element's property value, translated default value, or NULL if
+   *   property does not exist.
+   */
+  public function getTranslatedElementProperty(array $element, $property_name) {
+    $prop = $this->getElementProperty($element, $property_name);
+    if (!empty($prop) && is_string($prop)) {
+      return t($prop);
+    }
+
+    return $prop;
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Apply `Drupal.t()` function to some properties from **Existing Contact** element, to be able to translate them in the Drupal translation strings

Before
----------------------------------------
Following **Existing Contact** element are not translated:
- `$element['#attributes']['data-search-prompt']` (used by Autocomplete widget)
- `$element['#attributes']['data-none-prompt']` (used by Autocomplete widget)
- `$element['#search_prompt']` (used by Select widget)
- `$element['#none_prompt']` (used by Selecte widget)

After
----------------------------------------
Drupal `t()` function is applied to those properties

Technical Details
----------------------------------------
It's tricky to find exactly where to apply `t()` function for **Existing Contact** element, due to different widgets that could be used, and Drupal / Webform implementation for those elements
Proper parse of string empty or NULL values is important since you cannot send empty or NULL string to `t()` function, to avoid Exceptions.
