### PR TITLE
Reset test-matrix.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,13 +20,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '9.4.x-dev'
+          - drupal: '9.3.*'
             civicrm: '5.45.*'
-          - drupal: '9.4.x-dev'
+          - drupal: '9.4.*'
             civicrm: '5.51.*'
-          - drupal: '9.4.x-dev'
-            civicrm: '5.52.x-dev'
-          - drupal: '9.4.x-dev'
+          - drupal: '9.4.*'
+            civicrm: '5.52.*'
+          - drupal: '9.4.*'
+            civicrm: '5.53.x-dev'
+          - drupal: '9.4.*'
             civicrm: 'dev-master'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:


### PR DESCRIPTION
Overview
----------------------------------------

Use Drupal releases. And use 9.3 for 5.45.* (old ESR - but still in use b/c there hasn't been a 5.51.* security update yet).