### PR TITLE
d10 test - picky about version specification

### DIFF
--- a/.github/workflows/d10.yml
+++ b/.github/workflows/d10.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist -W
+          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-core:${{ matrix.civicrm }} civicrm/civicrm-{packages,drupal-8}:dev-master -W
       - name: Ensure Webform ^6.0
         run: |
           cd ~/drupal


### PR DESCRIPTION
Overview
----------------------------------------
In my original gist I had these separated because when using virtual repos it's picky about the version specification and dev-master doesn't work, but then an alpha number doesn't work with repos pulled from the real packagist.