### PR TITLE
D8/9 - Fix source field to display on the contact widget using v4 api

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -632,6 +632,29 @@ class Utils implements UtilsInterface {
   }
 
   /**
+   * Wrapper for all CiviCRM APIv4 calls
+   *
+   * @param string $entity
+   *   API entity
+   * @param string $operation
+   *   API operation
+   * @param array $params
+   *   API params
+   * @param string|int|array $index
+   *   Controls the Result array format.
+   *
+   * @return array
+   *   Result of API call
+   */
+  function wf_civicrm_api4($entity, $operation, $params, $index = NULL) {
+    if (!$entity) {
+      return [];
+    }
+    $result = civicrm_api4($entity, $operation, $params, $index);
+    return $result;
+  }
+
+  /**
    * Wrapper for all CiviCRM API calls
    * For consistency, future-proofing, and error handling
    *

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -173,6 +173,49 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Check if autocomplete widget results is
+   * searchable with all display field values.
+   */
+  public function testDisplayFields() {
+    $this->createIndividual([
+      'first_name' => 'James',
+      'last_name' => 'Doe',
+      'source' => 'Webform Testing',
+    ]);
+
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->saveCiviCRMSettings();
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    // Edit contact element and add source to display fields.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'results_display' => ['display_name', 'source'],
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
+
+    // Search on first name and verify if the contact is selected.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'James');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
+
+    // Search on source value and verify if the contact is selected.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'Webform Testing');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
+  }
+
+  /**
    * Test submission of hidden fields.
    */
   public function testHiddenField() {
@@ -191,7 +234,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
      $this->saveCiviCRMSettings();
      $this->drupalGet($this->webform->toUrl('edit-form'));
 
-     // Edit contact element and hide email field.
+    // Edit contact element and hide email field.
     $editContact = [
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Autocomplete',

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -484,6 +484,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       }
     }
     $this->htmlOutput();
+    if (!empty($params['results_display'])) {
+      $this->addFieldValue('properties[results_display][]', $params['results_display']);
+    }
 
     if (!empty($params['default'])) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();


### PR DESCRIPTION
Overview
----------------------------------------
Resubmission of https://github.com/colemanw/webform_civicrm/pull/742

Fix source field to display on the contact widget using v4 api

Before
----------------------------------------
Source field fails to load on the contact widget. To replicate -

- Add Existing contact element to the webform.
- Update widget to Autocomplete. Select Source in the `Contact Display Field(s)` input.
- Load the webform and search for a contact.
- No source is displayed

![image](https://user-images.githubusercontent.com/5929648/169643990-d445e5d1-18fe-4906-92ba-32240e7e41d6.png)

After
----------------------------------------
Source value is displayed -

![image](https://user-images.githubusercontent.com/5929648/169643970-54b08867-63d4-48e7-bb1c-62fb21befcb1.png)

Technical Details
----------------------------------------
It looks like a core bug in civicrm api v3. It does not return the source value when contact get api is called. But we do get the source using v4. This PR uses the v4 api instead and displays the values on the contact widget. 

Comments
----------------------------------------
@KarinG 