### PR TITLE
Fix warning for missing theme hook.

### DIFF
--- a/src/Plugin/WebformHandler/CivicrmWebformHandler.php
+++ b/src/Plugin/WebformHandler/CivicrmWebformHandler.php
@@ -44,6 +44,13 @@ class CivicrmWebformHandler extends WebformHandlerBase {
   /**
    * {@inheritdoc}
    */
+  public function getSummary() {
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form['link'] = [
       '#type' => 'link',


### PR DESCRIPTION
Overview
----------------------------------------
If you visit the handlers settings page e.g. https://drupal9.lndo.site/admin/structure/webform/manage/test/handlers, you get this error:

> Theme hook webform_handler_webform_civicrm_summary not found.

The error might be due to the latest updates of webform.

Before
----------------------------------------
Produces a warning of missing theme hook in logs.

After
----------------------------------------
No more error in logs.