### PR TITLE
Add sorting when finding memberships.

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -608,6 +608,7 @@ abstract class WebformCivicrmBase {
       'membership_type_id' => ['IN' => $membership_types],
       // skip membership through Inheritance.
       'owner_membership_id' => ['IS NULL' => 1],
+      'options' => ['sort' => 'end_date DESC'],
     ]);
     if (!$existing) {
       return [];
@@ -621,8 +622,9 @@ abstract class WebformCivicrmBase {
       $membership['is_active'] = $status_types[$membership['status_id']]['is_current_member'];
       $membership['status'] = $status_types[$membership['status_id']]['label'];
       $list = $membership['is_active'] ? 'active' : 'expired';
-      array_unshift($$list, $membership);
+      $$list[] = $membership;
     }
+
     return array_merge($active, $expired);
   }
 

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -135,7 +135,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     // Create two memberships with the same status with the first membership
     // having an end date after the second membership's end date.
-    \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'create', [
+    $this->utils->wf_civicrm_api('membership', 'create', [
       'membership_type_id' => 'Basic',
       'contact_id' => 2,
       'join_date' => '08/10/21',
@@ -145,7 +145,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
       'status_id' => 'Expired',
     ]);
 
-    \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'create', [
+    $this->utils->wf_civicrm_api('membership', 'create', [
       'membership_type_id' => 'Basic',
       'contact_id' => 2,
       'join_date' => '01/01/21',

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -156,7 +156,9 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     ]);
 
     $this->drupalGet($this->webform->toUrl('canonical'));
-    $this->assertSession()->statusMessageContains('Basic membership for ' . mb_strtolower($this->adminUser->getEmail()) . ' has a status of "Expired". Expired ' . \CRM_Utils_Date::customFormat('2022-08-10'));
+    $this->assertSession()->elementExists('xpath', $this->assertSession()->buildXPathQuery('//div[@data-drupal-messages]//div[contains(., :message)]', [
+      ':message' => 'Basic membership for ' . mb_strtolower($this->adminUser->getEmail()) . ' has a status of "Expired". Expired ' . \CRM_Utils_Date::customFormat('2022-08-10'),
+    ]));
 
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -133,6 +133,31 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
 
+    // Create two memberships with the same status with the first membership
+    // having an end date after the second membership's end date.
+    \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'create', [
+      'membership_type_id' => 'Basic',
+      'contact_id' => 2,
+      'join_date' => '08/10/21',
+      'start_date' => '08/10/21',
+      'end_date' => '08/10/22',
+      'is_override' => 1,
+      'status_id' => 'Expired',
+    ]);
+
+    \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'create', [
+      'membership_type_id' => 'Basic',
+      'contact_id' => 2,
+      'join_date' => '01/01/21',
+      'start_date' => '01/01/21',
+      'end_date' => '01/01/22',
+      'is_override' => 1,
+      'status_id' => 'Expired',
+    ]);
+
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->statusMessageContains('Basic membership for ' . mb_strtolower($this->adminUser->getEmail()) . ' has a status of "Expired". Expired ' . \CRM_Utils_Date::customFormat('2022-08-10'));
+
     $this->drupalLogout();
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
@@ -149,15 +174,15 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $api_result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('membership', 'get', [
       'sequential' => 1,
+      'options' => ['sort' => 'id DESC'],
     ]);
-    $this->assertEquals(1, $api_result['count']);
+    $this->assertEquals(3, $api_result['count']);
     $membership = reset($api_result['values']);
 
     $this->assertEquals('Basic', $membership['membership_name']);
     $this->assertEquals('1', $membership['status_id']);
 
     $today = date('Y-m-d');
-    // throw new \Exception(var_export($today, TRUE));
 
     $this->assertEquals($today,  $membership['join_date']);
     $this->assertEquals($today,  $membership['start_date']);


### PR DESCRIPTION
Overview
----------------------------------------
If you have a multiple memberships with the same status for a contact, the displayed membership when viewing the webform can be unpredictable (or perhaps it's being loaded by ID in descending order). An example is when you have a membership 1 and 2 wherein membership 1 has the latest end date instead of membership 2. This can happen if membership 1 was overridden at some point.

The PR loads the membership in descending order by "end_date" to have the membership loaded with the latest end date.

Before
----------------------------------------
Wrong membership is being displayed on the page.

After
----------------------------------------
Membership with the latest end date is loaded.
