### PR TITLE
Suppress htmloutput links in actions run output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,6 +83,12 @@ jobs:
           composer config repositories.1 path $GITHUB_WORKSPACE
           composer install --no-interaction
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }}
+      - name: Suppress links to screenshots
+        # There's so many! They can be useful locally if running one test, but they aren't useful here and cause massive scrolling.
+        run: |
+          cd ~/drupal
+          curl -L -O https://raw.githubusercontent.com/colemanw/webform_civicrm/def72b3dce1ea4bc7dd2cdd28a72844885727789/DrupalHtmlOutputTrait.diff
+          git apply DrupalHtmlOutputTrait.diff
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal


### PR DESCRIPTION
Overview
----------------------------------------
There's soooo maaaaanny.

Before
----------------------------------------
Massive scrolling whenever you open an actions run log. Useless links to screenshots that give 404s.

After
----------------------------------------
No links displayed. Can still download the artifacts file if desired.

Technical Details
----------------------------------------
Could maybe also subclass the trait, but this seems easier. It's not meant to be a part of webform itself.

Comments
----------------------------------------
The links are sometimes useful locally if only running one or two tests, but they're not useful here.
