### PR TITLE
D9 - Expose communication style field to webform

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -254,6 +254,17 @@ class Fields implements FieldsInterface {
         'type' => 'select',
         'value' => $this->utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
       ];
+      $default_communication_style = $this->utils->wf_crm_apivalues('OptionValue', 'get', [
+        'sequential' => 1,
+        'option_group_id' => "communication_style",
+        'is_default' => 1,
+      ], 'value')[0] ?? NULL;
+      $fields['contact_communication_style_id'] = [
+        'name' => t('Communication Style'),
+        'type' => 'select',
+        'civicrm_live_options' => 1,
+        'default_value' => $default_communication_style,
+      ];
       if (isset($elements['managed_file']) && !$elements['managed_file']->isDisabled() && !$elements['managed_file']->isHidden()) {
         $fields['contact_image_url'] = [
           'name' => t('Upload Image'),


### PR DESCRIPTION
Overview
----------------------------------------
Expose communication style field to webform

Before
----------------------------------------
Communication style id field is not exposed to webform

Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3306704

After
----------------------------------------
Added.

![Screenshot 2022-09-03 at 12 35 24 PM](https://user-images.githubusercontent.com/5929648/188260019-cf0fa443-f2c5-4561-aa10-a241a60b5009.jpg)


Comments
----------------------------------------
@KarinG 