### PR TITLE
Update paylater test

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -75,6 +75,13 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertStringContainsString('Payment by Direct Credit to: ABC. Please quote invoice number and name.', $sent_email);
     $this->assertStringContainsString('Thank you for your contribution', $sent_email);
 
+    // "Hack" for versions before 5.54 - it doesn't pick up the setting we set earlier.
+    if (version_compare(\CRM_Core_BAO_Domain::version(), '5.54.alpha1', '<')) {
+      $mb = \Civi::settings()->get('mailing_backend');
+      $mb['outBound_option'] = \CRM_Mailing_Config::OUTBOUND_OPTION_REDIRECT_TO_DB;
+      \Civi::settings()->set('mailing_backend', $mb);
+    }
+
     // Complete the contribution and recheck receipt.
     civicrm_api3('Contribution', 'completetransaction', [
       'id' => $contribution['id'],


### PR DESCRIPTION
Overview
----------------------------------------
Some recent fails because a couple wrongs used to make a right.

Before
----------------------------------------
Short version: For the second email on completetransaction, it was being sent out by php mail not redirect-to-database, so when the test checked the "most recent email" in the db it was checking the first email again not the second.

After
----------------------------------------
A sequence of changes in core means the email is now being sent to redirect-to-database. The email from completetransaction is not the same email as the first one.

Technical Details
----------------------------------------
Short version: Somewhere in here it "fixes" something about how the mailer picks which mailer in the situation in the test: https://github.com/civicrm/civicrm-core/compare/22a3e45ba2..d1f11af

It doesn't seem like it should but git bisect says so. It's difficult to pin down the exact commit because some of the intermediate commits introduce other bugs which are fixed in later commits that prevent getting far enough in the test to tell.

Comments
----------------------------------------

