### PR TITLE
D9 - Avoid sending recur fields for one time payments

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1927,6 +1927,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $result = $this->contributionRecur($contributionParams);
     }
     else {
+      // Not a recur payment, remove any recur fields if present.
+      unset($contributionParams['frequency_unit'], $contributionParams['frequency_interval'], $contributionParams['is_recur']);
       $result = $this->utils->wf_civicrm_api('contribution', 'transact', $contributionParams);
     }
 
@@ -2083,6 +2085,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $params['total_amount'] = round($this->totalContribution, 2);
     // Some processors want this one way, some want it the other
     $params['amount'] = $params['total_amount'];
+    $frequencyUnit = wf_crm_aval($params, 'frequency_unit');
+    if (empty($frequencyUnit)) {
+      unset($params['frequency_unit'], $params['frequency_interval'], $params['is_recur']);
+    }
 
     $params['financial_type_id'] = wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id');
 

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2085,8 +2085,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $params['total_amount'] = round($this->totalContribution, 2);
     // Some processors want this one way, some want it the other
     $params['amount'] = $params['total_amount'];
-    $frequencyUnit = wf_crm_aval($params, 'frequency_unit');
-    if (empty($frequencyUnit)) {
+    $numInstallments = wf_crm_aval($params, 'installments', NULL, TRUE);
+    $frequencyInterval = wf_crm_aval($params, 'frequency_unit');
+    if ($numInstallments == 1 || empty($frequencyInterval)) {
       unset($params['frequency_unit'], $params['frequency_interval'], $params['is_recur']);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
Related to https://www.drupal.org/project/webform_civicrm/issues/3231305

Before
----------------------------------------
![image](https://user-images.githubusercontent.com/5929648/190895855-2173caa1-1a1d-445f-850e-76ac677c4ed3.png)

Error if frequency unit is set to 0 on the form.

After
----------------------------------------
Submits the webform without any error and a normal one time payment is processed.


