### PR TITLE
New contact not attached to contact reference custom field

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2822,7 +2822,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $updateParams = [
       'id' => $cid,
     ];
-    $skipKeys = [];
+
     foreach ($params['update_contact_ref'] as $n => $refKeys) {
       foreach ($refKeys as $refKey => $val) {
         // Skip contact ref that doesn't have a valid contact ids.
@@ -2831,7 +2831,12 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         }
         foreach ($params['contact'] as $contactParams) {
           foreach ($contactParams as $key => $value) {
-            if (strpos($key, "{$refKey}_") === 0 && !isset($updateParams[$key]) && !in_array($key, $skipKeys)) {
+            // for multi-value contact ref its custom_18_-1 for new
+            // custom_18_3 for existing record
+            // For non multi-value contact ref its custom_18
+            if ((strpos($key, "{$refKey}_") === 0 || $refKey === $key)
+              && !isset($updateParams[$key])
+            ) {
               $updateParams[$key] = $value;
             }
           }


### PR DESCRIPTION
Overview
----------------------------------------
Contact reference custom field not saved for new creation

Steps to replicate:

1. Create custom field of type contact reference
2. include it in a webform