### PR TITLE
Sub types with spaces causes "Invalid Filter" error.

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -642,6 +642,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $rule = wf_crm_aval($contact, 'matching_rule', 'Unsupervised', TRUE);
     if ($rule) {
       $contact['contact'][1]['contact_type'] = ucfirst($contact['contact'][1]['contact_type']);
+      $contact['contact'][1]['contact_sub_type'] = array_map(function ($str) {
+        return ucwords($str, '_');
+      }, $contact['contact'][1]['contact_sub_type']);
+
       $params = [
         'check_permission' => FALSE,
         'sequential' => TRUE,


### PR DESCRIPTION
Overview
----------------------------------------
When including "Sub Types" as part of the webform and your subtypes include spaces e.g. "Partner Organization", you get the error:

> Drupal\Core\Entity\EntityStorageException: Invalid Filter in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 811 of /var/www/html/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).

webform_civicrm converts the subtypes using uc_words which CiviCRM API3 expects although if it has spaces, it would convert it to e.g. "Partner_organization". CiviCRM API3 expects "Partner_Organization".

Before
----------------------------------------
Throws exception of "Invalid Filter" for subtypes with spaces.

After
----------------------------------------
No more errors.

Comments
----------------------------------------
This is only for subtypes and the method findDuplicateContact(). I think it needs more updates than just this section.
