### PR TITLE
D9 - Financial Type ID submits the default value, not the selected one

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -193,7 +193,7 @@ class CivicrmOptions extends OptionsBase {
       $element['#options'] = $new;
     }
 
-    if (!empty($element['#default_option'])) {
+    if (empty($element['#default_value']) && !empty($element['#default_option'])) {
       $element['#default_value'] = $element['#default_option'];
     }
 

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -24,7 +24,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->enableCivicrmOnWebform();
 
     $params = [
-      'pp' => $payment_processor['id'],
+      'payment_processor_id' => $payment_processor['id'],
     ];
     $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField("Contribution Amount");
@@ -94,7 +94,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_2_contact_1_contact_existing");
 
     $params = [
-      'pp' => $payment_processor['id'],
+      'payment_processor_id' => $payment_processor['id'],
     ];
     $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField("Contribution Amount");
@@ -267,7 +267,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->checkField("civicrm_2_contact_1_contact_existing");
 
     $params = [
-      'pp' => $payment_processor['id'],
+      'payment_processor_id' => $payment_processor['id'],
     ];
     $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField('Contribution Amount');
@@ -326,7 +326,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->enableCivicrmOnWebform();
 
     $params = [
-      'pp' => $payment_processor['id'],
+      'payment_processor_id' => $payment_processor['id'],
     ];
     $this->configureContributionTab($params);
     $this->getSession()->getPage()->checkField('Contribution Amount');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -292,7 +292,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     // Configure Contribution tab.
     $params = [
-      'pp' => $payment_processor['id'],
+      'payment_processor_id' => $payment_processor['id'],
       'financial_type_id' => 2,
     ];
     $this->configureContributionTab($params);

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -219,8 +219,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('Financial Type', $params['financial_type_id'] ?? 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
 
-    if (!empty($params['pp'])) {
-      $this->getSession()->getPage()->selectFieldOption('Payment Processor', $params['pp']);
+    if (!empty($params['payment_processor_id'])) {
+      $this->getSession()->getPage()->selectFieldOption('Payment Processor', $params['payment_processor_id']);
     }
 
     if (!empty($params['receipt'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Financial Type ID submits the default value, not the selected one

Before
----------------------------------------
When a financial type id selector is used, and there is a default value on any page but the last, the contribution is submitted with the default financial type and not the selected one.

2.0 Detailed steps to reproduce (embed screenshots)
* Create a new webform, enable CiviCRM processing, and select the bare minimum to get a page with payments (contact, email, enable contributions, set currency and "test mode").
* Set "Financial Type" to user select.
* Move the Financial Type to the first page of the webform, set a default.
* Make a contribution, selecting a financial type other than the default.


After
----------------------------------------
Fixed. Selected value is submitted to civicrm.


Comments
----------------------------------------
Drupal Issue - https://www.drupal.org/project/webform_civicrm/issues/3309556

@MegaphoneJon @KarinG 