### PR TITLE
D9 - Avoid pay later option to be selected by default

### DIFF
--- a/src/Element/CivicrmSelectOptions.php
+++ b/src/Element/CivicrmSelectOptions.php
@@ -163,6 +163,14 @@ class CivicrmSelectOptions extends FormElement {
         '#parents' => array_merge($element['#parents'], ['default']),
         '#return_value' => $key,
       ];
+      // Avoid 0 value to be selected as default. The patch from https://www.drupal.org/project/drupal/issues/1381140
+      // renders 0 as the default option due to some casting equation check in preRenderRadio() function.
+      // Pay later holds the value 0 and is always loaded as default on the edit element page.
+      // Setting false for the #value key mitigates this problem.
+      // https://www.drupal.org/project/drupal/issues/2908602 is an open ticket on drupal which looks similar.
+      if ($key === 0 && $element['#default_option'] != $key) {
+        $element['options'][$row_key]['default_option']['#value'] = FALSE;
+      }
       $element['options'][$row_key]['weight'] = [
         '#type' => 'weight',
         '#title' => t('Weight for @option', ['@option' => $option]),


### PR DESCRIPTION
Overview
----------------------------------------
Avoid pay later option to be selected by default

Before
----------------------------------------
Pay Later option is rendered as default option even if other is selected as default.

To replicate -

- Add Payment processor to a webform with `-User Select-`.
- Edit the element from the Build page and set any payment processor as default. Save.
- Open the edit page again. Note that the pay later option is still displayed as the default option.

![image](https://user-images.githubusercontent.com/5929648/193439975-734103b3-b42e-43e9-9d9e-fa1077b45761.png)

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Looks related to this open ticket in drupal - https://www.drupal.org/project/drupal/issues/2908602

0 value option is enabled as default in the `preRenderRadio()` function of `core/lib/Drupal/Core/Render/Element/Radio.php` as a result of list of condition checks. The problem is literally with the last check -
      
    ((empty($element['#value']) && empty($element['#return_value'])) || (string) $element['#value'] === (string) $element['#return_value'])) {

 In case of pay later the `#value` is NULL and `#return_value` is set to 0 due to which the statement is evaluated to true and the pay later is enabled on the page.

Setting `#value` to false in case of pay later option mitigates this problem as done in the PR.

Comments
----------------------------------------
@KarinG 