### PR TITLE
Add CRM resources more often - specifically to every webform that has a webform_civicrm handler

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -86,11 +86,13 @@ function webform_civicrm_datetime_set_format($element) {
  * Implements hook_form_alter().
  */
 function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id == 'webform_edit_form' && $form_state->getFormObject()->getEntity()->getHandlers()->has('webform_civicrm')) {
-    \Drupal::service('civicrm')->initialize();
-    \CRM_Core_Resources::singleton()->addCoreResources();
+  if (is_a($form_state->getFormObject(), '\Drupal\webform\WebformInterface') && is_a($form_state->getFormObject(), '\Drupal\Core\Entity\EntityFormInterface')) {
+    if ($form_state->getFormObject()->getEntity()->getHandlers()->has('webform_civicrm')) {
+      \Drupal::service('civicrm')->initialize();
+      \CRM_Core_Resources::singleton()->addCoreResources();
+    }
   }
-  //Do not load civicrm elements on the "Add element" form.
+  // Do not load civicrm elements on the "Add element" form.
   if ($form_id == 'webform_ui_element_type_select_form') {
     foreach ($form as $k => $fieldset) {
       if (is_array($fieldset) && !empty($fieldset['#title']) && strtolower($fieldset['#title']) == 'civicrm') {

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -86,10 +86,15 @@ function webform_civicrm_datetime_set_format($element) {
  * Implements hook_form_alter().
  */
 function webform_civicrm_form_alter(&$form, &$form_state, $form_id) {
-  if (is_a($form_state->getFormObject(), '\Drupal\webform\WebformInterface') && is_a($form_state->getFormObject(), '\Drupal\Core\Entity\EntityFormInterface')) {
-    if ($form_state->getFormObject()->getEntity()->getHandlers()->has('webform_civicrm')) {
-      \Drupal::service('civicrm')->initialize();
-      \CRM_Core_Resources::singleton()->addCoreResources();
+  $formObj = $form_state->getFormObject();
+  if (method_exists($formObj, 'getEntity')) {
+    $entityObj = $formObj->getEntity();
+    if (method_exists($entityObj, 'getHandlers')) {
+      $handlerObj = $entityObj->getHandlers();
+      if ($handlerObj->has('webform_civicrm')) {
+        \Drupal::service('civicrm')->initialize();
+        \CRM_Core_Resources::singleton()->addCoreResources();
+      }
     }
   }
   // Do not load civicrm elements on the "Add element" form.


### PR DESCRIPTION
Overview
----------------------------------------
We discovered that if you attach a webform to a node (e.g. with an entity reference, such as paragraphs) that there are moments where CiviCRM CRM JS are not loaded. This only happened for anonymous and was fixed consistently but only temporarily with a cache clear.

Technical Details
----------------------------------------
Add CRM resources more often - specifically to every webform that has a webform_civicrm handler

Symptom -> the tally at times does not work for anonymous users ->
This may well be specific to one page checkout forms (contact paging disabled)
Even if the tally does not work on the webform that is attached to the node, it always does work on the /form itself

<img width="879" alt="image" src="https://user-images.githubusercontent.com/5340555/196061272-21d8ba72-760f-4a68-85ae-5f717ac6cd39.png">
