### PR TITLE
D9 - Fatal error on billing address submission

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -816,9 +816,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     // Check which location_type_id is to be set as is_primary=1;
     $is_primary_address_location_type = wf_crm_aval($contact, 'address:1:location_type_id');
     $is_primary_email_location_type = wf_crm_aval($contact, 'email:1:location_type_id');
-    $billingLocTypeID = $this->utils->wf_civicrm_api('LocationType', 'get', [
-      'name' => "Billing",
-    ])['id'] ?? NULL;
 
     foreach ($this->utils->wf_crm_location_fields() as $location) {
       if (!empty($contact[$location])) {
@@ -826,6 +823,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         $params = ['contact_id' => $cid];
         if ($location != 'website') {
           $params['options'] = ['sort' => 'is_primary DESC'];
+        }
+        // If billing address is submitted during validation phase, ignore updating that value.
+        if ($location == 'address' && !empty($this->billing_params['billing_address_id'])) {
+          $params['id'] = ['!=' => $this->billing_params['billing_address_id']];
         }
         $result = $this->utils->wf_civicrm_api($location, 'get', $params);
         if (!empty($result['values'])) {
@@ -1919,10 +1920,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $address['contact_id'] = $email['contact_id'] = $this->ent['contact'][1]['id'] = $cid;
       // Don't create a blank billing address.
       if ($address['street_address'] || $address['city'] || $address['country_id'] || $address['state_province_id'] || $address['postal_code']) {
-        $this->utils->wf_civicrm_api('address', 'create', $address);
+        $this->billing_params['billing_address_id'] = $this->utils->wf_civicrm_api('address', 'create', $address)['id'] ?? NULL;
       }
       if ($email['email'] ?? FALSE) {
-        $this->utils->wf_civicrm_api('email', 'create', $email);
+        $this->billing_params['billing_email_id'] = $this->utils->wf_civicrm_api('email', 'create', $email)['id'] ?? NULL;
       }
     }
     return $cid;

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -42,10 +42,7 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     ]);
   }
 
-  /**
-   * Submit address with primary flag set to 0.
-   */
-  public function testAddressSubmissionNoPrimary() {
+  public function createWebformWithAddress($locType = 'Home') {
     $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
@@ -57,11 +54,13 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     $this->getSession()->getPage()->checkField('Country');
-    $this->getSession()->getPage()->selectFieldOption('Address Location', 'Home');
+    $this->getSession()->getPage()->selectFieldOption('Address Location',$locType);
     $this->getSession()->getPage()->selectFieldOption('Is Primary', 'No');
 
     $this->saveCiviCRMSettings();
+  }
 
+  public function submitAndVerifyAddressSubmission() {
     //Submit the form.
     $this->drupalGet($this->webform->toUrl('canonical'));
 
@@ -90,25 +89,26 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Submit address with primary flag set to 0.
+   */
+  public function testAddressSubmissionNoPrimary() {
+    $this->createWebformWithAddress('Home');
+    $this->submitAndVerifyAddressSubmission();
+  }
+
+  /**
+   * Test submission of billing address without enabling contribution.
+   */
+  public function testBillingAddressWithoutContribution() {
+    $this->createWebformWithAddress('Billing');
+    $this->submitAndVerifyAddressSubmission();
+  }
+
+  /**
    * Test webform submission with locked address fields.
    */
   public function testLockedAddressSubmission() {
-    $this->drupalLogin($this->rootUser);
-    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
-      'webform' => $this->webform->id(),
-    ]));
-    $this->enableCivicrmOnWebform();
-
-    $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_address', 1);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->htmlOutput();
-
-    $this->getSession()->getPage()->checkField('Country');
-    $this->getSession()->getPage()->selectFieldOption('Address Location', 'Main');
-    $this->getSession()->getPage()->selectFieldOption('Is Primary', 'No');
-
-    $this->saveCiviCRMSettings();
-
+    $this->createWebformWithAddress('Main');
     $this->drupalGet($this->webform->toUrl('edit-form'));
 
     // Edit contact element and enable select widget.
@@ -197,7 +197,6 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'id' => $contact['id'],
     ]);
     $result_debug = var_export($contact_result, TRUE);
-
     $this->assertArrayHasKey('count', $contact_result, $result_debug);
     $this->assertEquals(1, $contact_result['count'], $result_debug);
 


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error on billing address submission

Before
----------------------------------------
Address with Loc type = Billing returns a fatal error. To replicate

- Create a webform with address and select type = Billing.
- Save the webform and submit.
- Error.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/2854717#comment-14718058