### PR TITLE
D9 - Default relationships list for sub type contacts doesn't populate

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -396,7 +396,7 @@ class Utils implements UtilsInterface {
   function wf_crm_get_contact_relationship_types($type_a, $type_b, $sub_type_a, $sub_type_b) {
     $ret = [];
     foreach ($this->wf_crm_get_relationship_types() as $t) {
-      $reciprocal = ($t['label_a_b'] != $t['label_b_a'] && $t['label_b_a'] || $t['type_a'] != $t['type_b']);
+      $reciprocal = ($t['label_a_b'] != $t['label_b_a'] && $t['label_b_a'] || $t['type_a'] != $t['type_b'] || $t['sub_type_a'] != $t['sub_type_b']);
       if (($t['type_a'] == $type_a || !$t['type_a'])
         && ($t['type_b'] == $type_b || !$t['type_b'])
         && (in_array($t['sub_type_a'], $sub_type_a) || !$t['sub_type_a'])


### PR DESCRIPTION
Overview
----------------------------------------
Specify relationships list for sub type contacts doesn't populate properly

Before
----------------------------------------
Adding a default value of type 'relationship to' for contacts that have a subtype does not populate the list of relationships properly both ways.
When retrieving the relationship entries it will only match when the subtype order is the a to b way around.
Otherwise due to the reciprocal variable it doesn't check the subtype relationship b to a and the relationship is not available for the user to select.

Details steps to reproduce - https://www.drupal.org/project/webform_civicrm/issues/3319506

After
----------------------------------------
Relationship types are loaded correctly.

Comments
----------------------------------------
Drupal Ticket. - https://www.drupal.org/project/webform_civicrm/issues/3319506