### PR TITLE
Retrieve event financial type id for line items

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -522,10 +522,26 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $this->loadEvents();
     // Add event info to line items
     $format = wf_crm_aval($this->data['reg_options'], 'title_display', 'title');
+    if ($this->line_items) {
+      $eventFTId = $this->utils->wf_crm_apivalues('FinancialType', 'get', [
+        'sequential' => 1,
+        'return' => ["id"],
+        'name' => "Event Fee",
+        'is_active' => 1,
+      ])[0];
+      if (empty($eventFTId)) {
+        $eventFTId = $this->utils->wf_crm_apivalues('FinancialType', 'get', [
+          'sequential' => 1,
+          'return' => ["id"],
+          'is_active' => 1,
+          'options' => ['limit' => 1],
+        ])[0];
+      }
+    }
     foreach ($this->line_items as &$item) {
       $label = empty($item['contact_label']) ? '' : "{$item['contact_label']} - ";
       $item['label'] = $label . $this->utils->wf_crm_format_event($this->events[$item['event_id']], $format);
-      $item['financial_type_id'] = wf_crm_aval($this->events[$item['event_id']], 'financial_type_id', 'Event Fee');
+      $item['financial_type_id'] = wf_crm_aval($this->events[$item['event_id']], 'financial_type_id', $eventFTId);
     }
     // Form Validation
     if (!empty($this->data['reg_options']['validate'])) {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -522,7 +522,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $this->loadEvents();
     // Add event info to line items
     $format = wf_crm_aval($this->data['reg_options'], 'title_display', 'title');
-    //Get the Event Fee Finacial Type Id if active, otherwise get the first active Financial Type Id
+    // Get the Event Fee Financial Type Id if active, otherwise get the first active Financial Type Id
     if ($this->line_items) {
       $eventFTId = $this->utils->wf_crm_apivalues('FinancialType', 'get', [
         'sequential' => 1,

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -522,6 +522,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $this->loadEvents();
     // Add event info to line items
     $format = wf_crm_aval($this->data['reg_options'], 'title_display', 'title');
+    //Get the Event Fee Finacial Type Id if active, otherwise get the first active Financial Type Id
     if ($this->line_items) {
       $eventFTId = $this->utils->wf_crm_apivalues('FinancialType', 'get', [
         'sequential' => 1,


### PR DESCRIPTION
Overview
----------------------------------------
**This PR resolves this [known Drupal](https://www.drupal.org/project/webform_civicrm/issues/2930917#comment-14773436) issue.**

In a "perfect storm" situation, it is possible for a webform to be set up as a registration page for CiviCRM events that have a custom field that sets a cost for the event *without having the Fees section enabled*, which means that a Financial Type ID is not set. If an event such as this is selected and a user tries to submit payment, the user will receive a fatal error (which may also cause the user to resubmit the page and be charged for each refresh/submission). 

While the current code attempts to deal with a situation in which the Financial Type Id isn't set ,  the current syntax results in an error.

Before
----------------------------------------
Previously, the code tried to handle setting the Financial Type ID of the line item (event) in question by setting
`$item['financial_type_id'] = wf_crm_aval($this->events[$item['event_id']], 'financial_type_id', 'Event Fee');`.

However, passing in `Event Fee` as a string results in the error `CRM_Core_Exception: entity_id is not a valid integer`. 

After
----------------------------------------
In order to pass an integer to the above mentioned line of code, this PR adds an `if` block just before the `foreach` loop that iterates through the `$this->line_items` to retrieve the id of the Event Fee Financial Type Id, if active, via an APIv3 call. 

If the Event Fee Financial Type Id is *not* active, then a nested `if` block is entered to retrieve the first active Financial Type Id in order to prevent the user from encountering a different error. The resulting variable (`$eventFTId`) of this conditional block is then passed to `wf_crm_aval()` instead of `Event Fee`.

With those changes, a user is safeguarded from running into a fatal error in the case that an Event's Financial Type Id is not set.


