### PR TITLE
Stripe now also requires Firewall extension.

### DIFF
--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -21,8 +21,12 @@ final class StripeTest extends WebformCivicrmTestBase {
       'key' => "mjwshared",
     ]);
     $this->utils->wf_civicrm_api('Extension', 'download', [
+      'key' => "firewall",
+    ]);
+    $this->utils->wf_civicrm_api('Extension', 'download', [
       'key' => "com.drastikbydesign.stripe",
     ]);
+
     $params = [];
     $result = $this->utils->wf_civicrm_api('Stripe', 'setuptest', $params);
     $this->paymentProcessorID = $result['id'];


### PR DESCRIPTION
Overview
----------------------------------------
Stripe Extension now also requires Firewall Extension

Before
----------------------------------------
Tests Fail b/c 👆

After
----------------------------------------
Tests run again
