### PR TITLE
D9 - Replace state abbreviation with id on normal address state field

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -294,7 +294,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
       fillOptions(stateSelect, stateProvinceCache[countryId]);
     }
     else {
-      $.getJSON(setting.callbackPath+'/stateProvince/' + countryId + '/' + is_billing, function(data) {
+      $.getJSON(setting.callbackPath+'/stateProvince/' + countryId, function(data) {
         fillOptions(stateSelect, data);
         stateProvinceCache[countryId] = data;
       });

--- a/src/Controller/AjaxController.php
+++ b/src/Controller/AjaxController.php
@@ -40,11 +40,10 @@ class AjaxController implements ContainerInjectionInterface {
    * @param string $operation
    *   The operation to perform: stateProvince or county
    */
-  public function handle($key, $input = '', $isBilling = FALSE) {
+  public function handle($key, $input = '') {
     $this->civicrm->initialize();
     if ($key === 'stateProvince') {
-      $isBilling = ($isBilling === 'false') ? FALSE : $isBilling;
-      return $this->stateProvince($input, $isBilling);
+      return $this->stateProvince($input);
     }
     elseif ($key === 'county') {
       return $this->county($input);
@@ -55,12 +54,12 @@ class AjaxController implements ContainerInjectionInterface {
     }
   }
 
-  protected function stateProvince($input, $isBilling = FALSE) {
+  protected function stateProvince($input) {
     if (!$input || ((int) $input != $input && $input != 'default')) {
       $data = ['' => t('- first choose a country')];
     }
     else {
-      $data = \Drupal::service('webform_civicrm.utils')->wf_crm_get_states($input, $isBilling);
+      $data = \Drupal::service('webform_civicrm.utils')->wf_crm_get_states($input);
     }
 
     // @todo use Drupal's cacheable response?
@@ -74,7 +73,7 @@ class AjaxController implements ContainerInjectionInterface {
       list($state, $country) = explode('-', $input);
       $params = [
         'field' => 'county_id',
-        'state_province_id' => $utils->wf_crm_state_abbr($state, 'id', $country)
+        'state_province_id' => $state
       ];
       $data = $utils->wf_crm_apivalues('address', 'getoptions', $params);
     }

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -61,11 +61,10 @@ class Utils implements UtilsInterface {
   }
 
   /**
-   * Get list of states, keyed by abbreviation rather than ID.
+   * Get list of states, keyed by ID.
    * @param null|int|string $param
-   * @param bool $isBilling
    */
-  public function wf_crm_get_states($param = NULL, $isBilling = FALSE) {
+  public function wf_crm_get_states($param = NULL) {
     $ret = [];
     if (!$param || $param == 'default') {
       $settings = $this->wf_civicrm_api('Setting', 'get', [
@@ -93,8 +92,7 @@ class Utils implements UtilsInterface {
       'country_id' => ['IN' => $param],
     ]);
     foreach ($states as $state) {
-      $key = $isBilling ? 'id' : 'abbreviation';
-      $ret[strtoupper($state[$key])] = $state['name'];
+      $ret[$state['id']] = $state['name'];
     }
     // Localize the state/province names if in an non-en_US locale
     $tsLocale = \CRM_Utils_System::getUFLocale();
@@ -112,7 +110,7 @@ class Utils implements UtilsInterface {
    * @param $input
    *   User input (state province id or abbr)
    * @param $ret
-   *   String: 'abbreviation' or 'id'
+   *   String: 'id'
    * @param $country_id
    *   Int: (optional) must be supplied if fetching id from abbr
    *

--- a/src/UtilsInterface.php
+++ b/src/UtilsInterface.php
@@ -45,7 +45,7 @@ interface UtilsInterface {
   public function wf_crm_get_fields($var = 'fields');
 
   /**
-   * Get list of states, keyed by abbreviation rather than ID.
+   * Get list of states, keyed by ID.
    * @param null|int|string $param
    */
   public function wf_crm_get_states($param = NULL);

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -184,10 +184,6 @@ abstract class WebformCivicrmBase {
           // Extra processing for addresses
           if ($ent == 'address') {
             foreach ($result as &$address) {
-              // Translate to abbr
-              if (!empty($address['state_province_id'])) {
-                $address['state_province_id'] = $this->utils->wf_crm_state_abbr($address['state_province_id']);
-              }
               // Load custom data
               if (isset($address['id'])){
                 $custom = $this->getCustomData($address['id'], 'address');

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -412,8 +412,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           else {
             $country_id = (int) $this->utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
           }
-          $isBilling = (strpos($element['#name'], 'billing_address_') !== false) ?? FALSE;
-          $states = $this->utils->wf_crm_get_states($country_id, $isBilling);
+          $states = $this->utils->wf_crm_get_states($country_id);
           if ($states && !array_key_exists(strtoupper($element['#value']), $states)) {
             $countries = $this->utils->wf_crm_apivalues('address', 'getoptions', ['field' => 'country_id']);
             $this->form_state->setError($element, t('Mismatch: "@state" is not a state/province of %country. Please enter a valid state/province abbreviation for %field.', ['@state' => $element['#value'], '%country' => $countries[$country_id], '%field' => $element['#title']]));
@@ -818,17 +817,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $existing = array_merge([[]], $result['values']);
         }
         foreach ($contact[$location] as $i => $params) {
-          $stateIsID = FALSE;
-          if (!empty($existing[$i]['state_province_id']) && $existing[$i]['state_province_id'] == $params['state_province_id']) {
-            $stateIsID = TRUE;
-          }
-          // Translate state/prov abbr to id
-          if (!$stateIsID && !empty($params['state_province_id']) && $params['location_type_id'] != $billingLocTypeID) {
-            $default_country = $this->utils->wf_crm_get_civi_setting('defaultContactCountry', 1228);
-            if (!($params['state_province_id'] = $this->utils->wf_crm_state_abbr($params['state_province_id'], 'id', wf_crm_aval($params, 'country_id', $default_country)))) {
-              $params['state_province_id'] = '';
-            }
-          }
           // Substitute county stub ('-' is a hack to get around required field when there are no available counties)
           if (isset($params['county_id']) && $params['county_id'] === '-') {
             $params['county_id'] = '';

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -529,22 +529,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
           if (is_array($field_value_key)) {
             foreach ($field_value_key as $value_key) {
               if (isset($contact_values[$field_group][$key][$value_key])) {
-                switch ($value_key) {
-                  case 'state_province_id':
-                    $state = $this
-                      ->utils
-                      ->wf_civicrm_api('StateProvince', 'getvalue', [
-                        'return' => "abbreviation",
-                        'id' => $result_entity[$value_key],
-                      ]);
-
-                    $this->assertEquals($contact_values[$field_group][$key][$value_key], $state);
-                    break;
-
-                  default:
-                    $this->assertEquals($contact_values[$field_group][$key][$value_key], $result_entity[$value_key]);
-                    break;
-                }
+                $this->assertEquals($contact_values[$field_group][$key][$value_key], $result_entity[$value_key]);
               }
             }
           }
@@ -607,8 +592,8 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
             'street_address' => 'Test',
             'city' => 'Adamsville',
             'postal_code' => '35005',
-            'country_id' => '1228',
-            'state_province_id' => 'AL',
+            'country_id' => '1228', // United States
+            'state_province_id' => '1000', // Alabama
             'county_id' => '7',
           ]
         ],

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -54,7 +54,7 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'City' => 'Newark',
       'Postal Code' => '12345',
       'Country' => 1228,
-      'State/Province' => 'NJ',
+      'State/Province' => $this->utils->wf_crm_state_abbr('NJ', 'id'), // New Jersey
     ];
     $this->postSubmission($this->webform, $edit);
 

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -334,7 +334,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Street Address', '39 Street');
     $this->getSession()->getPage()->fillField('City', 'City');
     $this->getSession()->getPage()->fillField('Postal Code', 'A0B 1C2');
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_address_state_province_id', 'AB');
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_address_state_province_id', $this->utils->wf_crm_state_abbr('AB', 'id', 1039));
     $this->getSession()->getPage()->fillField('Email', $province . '@example.com');
 
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_financial_type_id', $financial_type_id);


### PR DESCRIPTION
Overview
----------------------------------------
State dropdown has odd behaviour based on if its included in billing or normal address fields. Fix it to have consistent behaviour.

Before
----------------------------------------
State dropdown in normal address fields has abbreviation in values.
 
<img width='50%' height='50%' src="https://user-images.githubusercontent.com/5929648/205435071-57d61362-af46-474e-beb5-e13b0447f291.png">


whereas billing populated ids in the select values.

<img width='50%' height='50%' src="https://user-images.githubusercontent.com/5929648/205435079-75ea5919-88e5-4ce4-9f7a-90b6a80e21cc.png">


After
----------------------------------------
Consistent behaviour between billing and normal address state field - ID is populated in values for both the fields.


Comments
----------------------------------------
@KarinG @MegaphoneJon You might be interested in reviewing this?