### PR TITLE
D8/9 - Custom fields for participant role not available at page load

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -88,6 +88,17 @@ var wfCiviAdmin = (function (D, $, once) {
   };
 
   /**
+   * Load custom fields related to participant fields.
+   */
+  $('.cf-participant-fields').each(function() {
+    $(this).on("change", function(event) {
+      var fs = '#' + $(this).closest('.event-fs').attr('id');
+      pub.participantConditional(fs)
+    });
+    $(this).trigger('change');
+  });
+
+  /**
    * Private methods.
    */
 

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -978,7 +978,7 @@ class AdminForm implements AdminFormInterface {
         $this->form['participant']['participants'][$n]['div'][$fs] = [
           '#type' => 'fieldset',
           '#title' => t('Event :num', [':num' => $e]),
-          '#attributes' => ['id' => $fs],
+          '#attributes' => ['id' => $fs, 'class' => ['event-fs']],
         ];
         foreach ($this->sets as $sid => $set) {
           if ($set['entity_type'] == 'participant') {
@@ -1011,8 +1011,7 @@ class AdminForm implements AdminFormInterface {
                 $item['#suffix'] = '</div>';
               }
               if ($fid == 'participant_event_id' || $fid == 'participant_role_id') {
-                $item['#attributes']['onchange'] = "wfCiviAdmin.participantConditional('#$fs');";
-                $item['#attributes']['class'][] = $fid;
+                $item['#attributes']['class'][] = "cf-participant-fields {$fid}";
                 $$fid = wf_crm_aval($item, '#default_value');
               }
               $this->form['participant']['participants'][$n]['div'][$fs][$sid][$id] = $item;


### PR DESCRIPTION
Overview
----------------------------------------
Custom fields specific to a certain participant role are only available for selection after selecting a different participant role.

Before
----------------------------------------
Given an existing webform with one contact that has event registration enabled with Participant Role Attendee. Now if I navigate to the CiviCRM settings of this webform and want to select additional fields that are specific to the Attendee role, I cannot see them. Only if I select - User Select - first and then Attendee again they become available dynamically.


After
----------------------------------------
Custom set is loaded on page load.

Technical Details
----------------------------------------
The js to trigger the change event was not called on page load.

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3323528