### PR TITLE
fix deprecated function warnings on wf_crm_get_relationship_types

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -361,16 +361,10 @@ class Utils implements UtilsInterface {
     static $types = [];
     if (!$types) {
       foreach ($this->wf_crm_apivalues('relationship_type', 'get', ['is_active' => 1]) as $r) {
-        $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a'));
-        $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b'));
-        $r['sub_type_a'] = wf_crm_aval($r, 'contact_sub_type_a');
-        if (!is_null($r['sub_type_a'])) {
-          $r['sub_type_a'] = $r['sub_type_a'];
-        }
-        $r['sub_type_b'] = wf_crm_aval($r, 'contact_sub_type_b');
-        if (!is_null($r['sub_type_b'])) {
-          $r['sub_type_b'] = $r['sub_type_b'];
-        }
+        $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a', ''));
+        $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b', ''));
+        $r['sub_type_a'] = strtolower(wf_crm_aval($r, 'contact_sub_type_a', ''));
+        $r['sub_type_b'] = strtolower(wf_crm_aval($r, 'contact_sub_type_b', ''));
         $types[$r['id']] = $r;
       }
     }


### PR DESCRIPTION
Overview
----------------------------------------
When loading a webform_civicrm page, I get a lot of "Deprecated function" warnings in PHP 8 because I'm passing `NULL` to `strlower()`.  You can replicate this by creating a new relationship type which has "All Contacts" as its contact type (which is stored in the db as `NULL`).

Before
----------------------------------------
Watchdog noise.

After
----------------------------------------
Less noise.

Technical Details
----------------------------------------
`wf_crm_aval` lets us specify the default value, so we can just return an empty string instead of `NULL`.

Comments
----------------------------------------
There was already handling for this for contact subtypes but this is more concise, so I also updated the subtype code.