### PR TITLE
Enable Webform submissions to count multiple participants

### DIFF
--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -175,6 +175,14 @@ class AdminHelp implements AdminHelpInterface {
     $this->fee();
   }
 
+  protected function participant_count() {
+    return '<p>' .
+      t('Total number of participants to be registered for this event upon submission of the form.') .
+      '</p><p>' .
+      t('Note that if a value is not given, the default Participant Count will be 1.') .
+      '</p>';
+  }
+
   protected function fee() {
     return '<p>' .
       t('Once added to the webform, this field can be configured in a number of ways by changing its settings.') .

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -860,6 +860,10 @@ class Fields implements FieldsInterface {
               'name' => t('Participant Fee'),
             ] + $moneyDefaults;
         }
+        $fields['participant_count'] = [
+          'name' => t('Participant Count'),
+          'type' => 'civicrm_number',
+        ];
       }
       if (isset($sets['membership'])) {
         $fields['membership_membership_type_id'] = [

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1196,7 +1196,18 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
                   if (empty($item['participant_id'])) {
                     $item['participant_id'] = $item['entity_id'] = $result['id'];
                   }
-                  $item['participant_count'] = wf_crm_aval($item, 'participant_count', 0) + 1;
+                  // Initialize the $participantCount as one.
+                  $participantCount = 1;
+                  // If there is a value set by the Participant Count field on the Webform, use that instead.
+                  if (isset($this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"]) && $this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"] !== '') {
+                    $participantCount = (int) $this->crmValues["civicrm_{$n}_participant_{$e}_participant_count"];
+                    // Get (or create if needed) a Price Set that has a value field that correctly counts the number of participants registered on submission.
+                    $participantPriceValueID = $this->utils->wf_crm_get_participant_price_set();
+                    // Set the price field value id to the result of the function that gets/creates the needed Price Set.
+                    $item['price_field_value_id'] = $participantPriceValueID;
+                  };
+                  // The participant count and qty should always be the same value.
+                  $item['participant_count'] = $item['qty'] = wf_crm_aval($item, 'participant_count', 0) + $participantCount;
                   break;
                 }
               }


### PR DESCRIPTION
Overview
----------------------------------------
This PR creates a new Participant Count field on the CiviCRM tab of Drupal Webform configuration so that users can enter the total amount of participants being registered. This code also introduces the functionality to ensure that, on submission, the Participant Count is handled correctly by creating and setting a hidden Price Field Value for the line item that corresponds to the event registration.

This PR resolves this [issue](https://www.drupal.org/project/webform_civicrm/issues/3328860) on the webform_civicrm project on Drupal.

Before
----------------------------------------
Previously, Webform submissions only counted as one participant registered, even if the form that was submitted intended to have multiple registrants.

After
----------------------------------------
With this PR, the Webform registers the correct amount of participants on submission.

Technical Details
----------------------------------------
Previously, the `processParticipants()` function within src/WebformCivicrmPostProcess.php did not accurately set the ‘participant_count` or `qty` columns within the civicrm_line_item table, nor did it pass in a value for the `price_field_value_id` column. To resolve this, a new function was made in the Utils class to get- or create if one doesn’t already exist- a hidden (reserved) Price Field Value that has a value of 1 in it’s `count` column. This Utils function (`wf_crm_get_participant_price_set()`)  is called just before the line items are looped through within `processParticipants()`  so that `$item['price_field_value_id']` can be set the Id of the created/fetched Price Field Value.  `$item['participant_count']`  and `$item['qty']` are adjusted by getting the value passed by the Participant Count field on the Webform.