### PR TITLE
D8/9: make Contact selectable for Contributions Extend #758

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -542,15 +542,19 @@ var wfCiviAdmin = (function (D, $, once) {
       }).change();
 
       function billingMessages() {
+        var contactId = $('[name=civicrm_1_contribution_1_contribution_contact_id]').val();
+        if (typeof contactId == 'undefined') {
+          contactId = 1;
+        }
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_enable_contribution]');
         // Warning about contribution page with no email
-        if ($pageSelect.val() !== '0' && ($('[name=civicrm_1_contact_1_email_email]:checked').length < 1 || $('[name=contact_1_number_of_email]').val() == '0')) {
-          var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(1)});
+        if ($pageSelect.val() !== '0' && ($('[name=civicrm_' + contactId + '_contact_1_email_email]:checked').length < 1 || $('[name=contact_' + contactId + '_number_of_email]').val() == '0')) {
+          var msg = Drupal.t('You must enable an email field for :contact in order to process transactions.', {':contact': getContactLabel(contactId)});
           if (!$('.wf-crm-billing-email-alert').length) {
             $pageSelect.after('<div class="messages error wf-crm-billing-email-alert">' + msg + ' <button>' + Drupal.t('Enable It') + '</button></div>');
             $('.wf-crm-billing-email-alert button').click(function() {
-              $('input[name=civicrm_1_contact_1_email_email]').prop('checked', true).change();
-              $('select[name=contact_1_number_of_email]').val('1').change();
+              $('input[name=civicrm_' + contactId + '_contact_1_email_email]').prop('checked', true).change();
+              $('select[name=contact_' + contactId + '_number_of_email]').val('1').change();
               return false;
             });
             if ($('.wf-crm-billing-email-alert').is(':hidden')) {
@@ -569,8 +573,12 @@ var wfCiviAdmin = (function (D, $, once) {
           $('#edit-participant').prepend('<div class="wf-crm-paid-entities-info messages status">' + Drupal.t('Configure the Contribution settings to enable paid events.') + '</div>');
         }
       }
-      $(once('email-alert', '[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_1_contact_1_email_email]', context)).change(billingMessages);
-      billingMessages();
+      // Get contact assigned to contribution
+      var contactIdForContrib = $('[name=civicrm_1_contribution_1_contribution_contact_id]').val();
+      if (contactIdForContrib !== "create_civicrm_webform_element") {
+        $(once('email-alert', '[name=civicrm_1_contribution_1_contribution_enable_contribution], [name=civicrm_' + contactIdForContrib + '_contact_1_email_email]', context)).change(billingMessages);
+        billingMessages();
+      }
 
       // Handlers for submit-limit & tracking-mode mini-forms
       $(once('wf-civi', '#configure-submit-limit', context)).click(function() {

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -543,7 +543,7 @@ var wfCiviAdmin = (function (D, $, once) {
 
       function billingMessages() {
         var contactId = $('[name=civicrm_1_contribution_1_contribution_contact_id]').val();
-        if (typeof contactId == 'undefined') {
+        if (typeof contactId == 'undefined' || (typeof contactId != 'undefined' && contactId == 'create_civicrm_webform_element')) {
           contactId = 1;
         }
         var $pageSelect = $('[name=civicrm_1_contribution_1_contribution_enable_contribution]');

--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -70,8 +70,18 @@ class AdminHelp implements AdminHelpInterface {
       '</p>';
   }
 
+  protected function contribution_contact_id() {
+    return '<p>' .
+      t('The contribution record created after webform submission is assigned to this contact.') .
+      '</p><p>' .
+      t('Enable "-User Select-" option if you want user to select the payment contact while submitting the form.') .
+      '</p><p>' .
+      t('Please enable respective email fields on the contact tab. Webform submission may lead to fatal error if email value is not sent to the selected payment processor.') .
+      '</p>';
+  }
+
   protected function contact_external_identifier() {
-    $this->contact_contact_id();
+    return $this->contact_contact_id();
   }
 
   protected function contact_source() {

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -672,6 +672,16 @@ class Fields implements FieldsInterface {
           'parent' => 'contribution_pagebreak',
         ];
         // @todo moved in order since we can't pass `weight`.
+        $fields['contribution_contact_id'] = [
+          'name' => t('Contact'),
+          'type' => 'select',
+          'expose_list' => TRUE,
+          'data_type' => 'ContactReference',
+          'extra' => [
+            'aslist' => 1,
+            'required' => TRUE
+          ],
+        ];
         $fields['contribution_total_amount'] = [
             'name' => 'Contribution Amount',
             'parent' => 'contribution_pagebreak',

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -538,6 +538,12 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
 
     $this->getSession()->getPage()->selectFieldOption('number_of_contacts', 2);
 
+    // Enable email field for contact 2.
+    $this->getSession()->getPage()->clickLink("Contact 2");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('contact_2_number_of_email', 1);
+    $this->assertSession()->assertWaitOnAjaxRequest();
+
     $params = [
       'payment_processor_id' => $payment_processor['id'],
     ];
@@ -571,6 +577,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     // Second contact to assign  the contribution
     $this->getSession()->getPage()->fillField('civicrm_2_contact_1_contact_first_name', 'Max');
     $this->getSession()->getPage()->fillField('civicrm_2_contact_1_contact_last_name', 'Plank');
+    $this->getSession()->getPage()->fillField('civicrm_2_contact_1_email_email', 'maxplank@example.com');
 
     $this->getSession()->getPage()->pressButton('Next >');
     $this->getSession()->getPage()->selectFieldOption('edit-civicrm-1-contribution-1-contribution-contact-id', 2);

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -336,3 +336,27 @@ function webform_civicrm_update_8004() {
     $webform->save();
   }
 }
+
+/**
+ * Set Contact 1 as the assigned for Contributions in all webforms
+ * (It keeps default behavior <= 6.2.0)
+ */
+function webform_civicrm_update_8005() {
+  \Drupal::service('civicrm')->initialize();
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $settings = &$config['webform_civicrm']['settings'];
+    // If Contribution enabled, set Contact 1 assigned as default behavior <= 6.2.0
+    if ($settings['civicrm_1_contribution_1_contribution_enable_contribution'] == "1") {
+      $settings['civicrm_1_contribution_1_contribution_contact_id'] = 1;
+      $settings['data']['contribution'][1]['contribution'][1]['contact_id'] = 1;
+      $handler->setConfiguration($config);
+      $webform->save();
+    }
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Extend #758 and fix the following issues with the PR

- Contact 1 is not created in civicrm when 2 contacts are submitted via webform.
- Console error on settings page when Contribution contact = User select.

Tested the following usecases -

- Contribution Contact = User Select; Payment Processor = Dummy. Submit the webform as anonymous user with payment contact = 2. 
**Result Obtained** = Payment record & Billing Address created on 2nd contact (Correct).

- Contribution Contact = User Select; Paayment processor = Pay later. Submit the webform as anonymous user with payment contact = 2. 
**Result Obtained** = Payment record created on 2nd contact (Correct).

Repeated the above test cases by submitting the webform as logged in user.

This seems to work fine for me now @rubofvil @sluc23. Can you please confirm if it works for you as well?

There are still some issues on admin js, eg there is no alert to enable email if Contribution Contact = `-User select-`. I've added a help text to ensure admins enable email fields for the contribution contact.

![image](https://user-images.githubusercontent.com/5929648/209800665-3f15de65-40df-42d7-84b6-b7365b0e1c70.png)



Thanks.

