### PR TITLE
ID should not be 0.

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -880,7 +880,6 @@ class Fields implements FieldsInterface {
           'name' => t('Membership Financial Type'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 0,
           'exposed_empty_option' => '- ' . t('Automatic') . ' -',
         ];
         $fields['membership_status_id'] = [


### PR DESCRIPTION
Overview
----------------------------------------

From @demeritcowboy ->

If I comment out this line, then it works. I also notice the other financial_type_id fields in the file don't have this.

```
$fields['membership_financial_type_id'] = [
          'name' => t('Membership Financial Type'),
          'type' => 'select',
          'expose_list' => TRUE,
          // 'value' => 0,
          'exposed_empty_option' => '- ' . t('Automatic') . ' -',
        ];

```