### PR TITLE
Themes used in unit test are deprecated

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -11,7 +11,7 @@ use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 // @todo move into civicrm-drupal-8 package - DONE
 abstract class CiviCrmTestBase extends WebDriverTestBase {
 
-  protected $defaultTheme = 'classy';
+  protected $defaultTheme = 'starterkit_theme';
 
   protected static $modules = [
     'block',

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -59,10 +59,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
     // Make sure we are using distinct default and administrative themes for
     // the duration of these tests.
-    \Drupal::service('theme_installer')->install(['bartik', 'seven']);
+    \Drupal::service('theme_installer')->install(['olivero', 'claro']);
     $this->config('system.theme')
-      ->set('default', 'bartik')
-      ->set('admin', 'seven')
+      ->set('default', 'olivero')
+      ->set('admin', 'claro')
       ->save();
 
     $this->adminUser = $this->createUser([


### PR DESCRIPTION
Overview
----------------------------------------
I'm cherry-picking a few commits from my drupal 10 WIP. These themes don't exist in drupal 10 but their replacements do exist in 9.x so should be ok to do this now.
