### PR TITLE
missing `use` statement

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
 use Behat\Mink\Element\NodeElement;
 use Drupal\Tests\webform\Traits\WebformBrowserTestTrait;
 use Behat\Mink\Exception\ElementNotFoundException;
+use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Url;
 
 abstract class WebformCivicrmTestBase extends CiviCrmTestBase {


### PR DESCRIPTION
Overview
----------------------------------------
In 9.x ckeditor is always present, so the error never triggers. In drupal 10 the error tries to happen on line 678, but it can't find the class because the `use` statement is missing.