### PR TITLE
test improvement - avoid having to hunt in screenshots for the error

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -260,6 +260,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->assertCount(0, $error_messages, implode(', ', array_map(static function(NodeElement $el) {
       return $el->getText();
     }, $error_messages)));
+    // Check for fatal errors. Doing it this way so that the text itself which
+    // contains the stack trace is automatically output to the github action
+    // log.
+    $the_text = $this->getSession()->getPage()->getText();
+    $this->assertStringNotContainsString('The website encountered an unexpected error', $the_text);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
When there's a fatal error and the browser goes to the stack trace page, the actions log just says "element missing" or something when the test tries to execute the next statement. Then you have to download all 100MB of screenshots and guess which screenshot contains the stack trace. This outputs the trace to the actions log directly.