### PR TITLE
test improvement - store civi logs in artifacts

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -93,6 +93,14 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     ]);
   }
 
+  protected function tearDown(): void {
+    // store the civi log in the downloadable artifacts
+    $logfile = \Civi::$statics['CRM_Core_Error']['logger_file'] ?? NULL;
+    if ($logfile && file_exists($logfile)) {
+      copy($logfile, '/home/runner/drupal/web/sites/simpletest/browser_output/' . \CRM_Utils_File::makeFilenameWithUnicode($this->getName()) . '.log');
+    }
+    parent::tearDown();
+  }
 
   /**
    * Redirect civicrm emails to database.


### PR DESCRIPTION
Overview
----------------------------------------
The ConfigAndLog folder is inaccessible after a test finishes. This copies any log files that were created during the test into the artifacts folder so that they get included in the downloadable artifacts. Can be useful sometimes. Or you can use it directly in a test you're debugging by sprinkling in some `\Civi::log()->info('something');` and then looking at it after.