### PR TITLE
Change PostProcess methods visibility to be able to decorate them in a custom module

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -33,8 +33,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   private $multiPageDataLoaded;
   private $billing_params = [];
   private $totalContribution = 0;
-  private $contributionIsIncomplete = FALSE;
-  private $contributionIsPayLater = FALSE;
+  protected $contributionIsIncomplete = FALSE;
+  protected $contributionIsPayLater = FALSE;
 
   // During validation this contains an array of known contact ids and the placeholder 0 for valid contacts
   // During submission processing this contains an array of known contact ids
@@ -1091,7 +1091,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * @param $cid2
    *   Contact id
    */
-  private function processRelationship($params, $cid1, $cid2) {
+  public function processRelationship($params, $cid1, $cid2) {
     if (!empty($params['relationship_type_id']) && $cid2 && $cid1 != $cid2) {
       [$type, $side] = explode('_', $params['relationship_type_id']);
       $existing = $this->getRelationship([$params['relationship_type_id']], $cid1, $cid2);
@@ -1127,7 +1127,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * @param int $c
    * @param int $cid
    */
-  private function processParticipants($c, $cid) {
+  public function processParticipants($c, $cid) {
     static $registered_by_id = [];
     $n = $this->data['participant_reg_type'] == 'separate' ? $c : 1;
     if ($p = wf_crm_aval($this->data, "participant:$n:participant")) {
@@ -1226,7 +1226,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * @param int $c
    * @param int $cid
    */
-  private function processMemberships($c, $cid) {
+  public function processMemberships($c, $cid) {
     static $types;
     if (!isset($types)) {
       $types = $this->utils->wf_crm_apivalues('membership_type', 'get');
@@ -1326,7 +1326,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   /**
    * Process shared addresses
    */
-  private function processSharedAddresses() {
+  public function processSharedAddresses() {
     foreach ($this->shared_address as $cid => $shared) {
       foreach ($shared as $i => $addr) {
         if (!empty($this->ent['contact'][$addr['mc']]['id'])) {
@@ -1355,7 +1355,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   /**
    * Save case data
    */
-  private function processCases() {
+  public function processCases() {
     foreach (wf_crm_aval($this->data, 'case', []) as $n => $data) {
       if (is_array($data) && !empty($data['case'][1]['client_id'])) {
         $params = $data['case'][1];
@@ -1464,7 +1464,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   /**
    * Save activity data
    */
-  private function processActivities() {
+  public function processActivities() {
     $activities = wf_crm_aval($this->data, 'activity', []);
     foreach ($activities as $n => $data) {
       if (is_array($data)) {


### PR DESCRIPTION
Overview
----------------------------------------
This is a very specific PR, and probably needs debate to get to a happy ending!
Since `webform_civicrm` moved to D9 version, it includes the Symfony approach using Services. This is a really good approach, but I think it could be improved.

We have a real use case where we need to change the default behaviour of `webform_civicrm` regarding how it process Memberships. 
We don't think we will get a consensus to move forwards to merge a PR into core with this feature (old discussion for D7 version could be found here [382](https://github.com/colemanw/webform_civicrm/pull/382) / [383](https://github.com/colemanw/webform_civicrm/pull/383) ) so using the new D9 features, we should be able to develop our D9 custom module to [override/decorate](https://www.axelerant.com/blog/drupal-8-service-decorators) the methods of the service `webform_civicrm.postprocess` and add our custom code.
But to be able to decorate some parts of the code.. the visibility of the methods we need to change, need to be at least `protected` instead of `private`.
Decorators are classes that extends the ones that will override some methods, but needs to be able to access those methods to be "decorated", so that's our proposal, to change that visibility. The Decorators could implement an Interface, instead of extending the class decorated, but that will demand to implement every method specified in the interface, duplicating much of the code from the existing service

This idea could be spread around all `webform_civicrm` services, and we can discuss which methods of all `webform_civicrm` could be available for "decoration" in external custom modules, I guess specially those methods that have a very **strict** business logic inside, which could not fit for some real use cases.

So this is an example on how to develop a custom module to decorate, i.e.: method `Drupal\webform_civicrm\WebformCivicrmPostProcess->processMemberships($c, $cid)` (once it's been changed to `protected` in core..)

- `webform_civicrm_extras.services.yml`:
```php
services:
  webform_civicrm_extras.postprocess:
    class: Drupal\webform_civicrm_extras\PostProcess
    decorates: webform_civicrm.postprocess
    decoration_priority: 5
    public: false
    arguments: ['@webform_civicrm_extras.postprocess.inner', '@webform_civicrm.utils']
```
- `src/PostProcess.php`:
```php
<?php

namespace Drupal\webform_civicrm_extras;

class PostProcess extends \Drupal\webform_civicrm\WebformCivicrmPostProcess {

  protected $originalService;

  public function __construct(\Drupal\webform_civicrm\WebformCivicrmPostProcess $originalService, \Drupal\webform_civicrm\UtilsInterface $utils) {
    $this->originalService = $originalService;
    parent::__construct($utils);
  }

  protected function processMemberships($c, $cid) {
    // My custom code
    // I can call original method as $this->originalService->processMemberships();
  }

}
```


This proposal is based in my Drupal9 / Symfony research, development and testing, but it could be another way to achive this which I'm missing. So in that case, please let me know your thoughts!

Before
----------------------------------------
Some Business Logic methods in `Drupal\webform_civicrm\WebformCivicrmPostProcess->processMemberships($c, $cid)` cannot be decorated by other D9 custom modules

After
----------------------------------------
Methods in `Drupal\webform_civicrm\WebformCivicrmPostProcess->processMemberships($c, $cid)` now can be decorated by other D9 custom modules

Technical Details
----------------------------------------
Some references about this topic:
- [Drupal 8: Service Decorators](https://www.axelerant.com/blog/drupal-8-service-decorators)
- [How to Decorate Services](https://symfony.com/doc/current/service_container/service_decoration.html)

