### PR TITLE
Don't pass FALSE as a string value

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2583,6 +2583,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $options = $this->utils->wf_crm_field_options($component, '', $this->data);
           $val = array_search($val, $options);
         }
+        // Don't pass FALSE as a string value.
+        if ($val === FALSE && $field['data_type'] === 'String') {
+          $val = '';
+        }
 
         // Only known contacts are allowed to empty a field
         if (($val !== '' && $val !== NULL && $val !== []) || !empty($this->existing_contacts[$c])) {


### PR DESCRIPTION
Overview
----------------------------------------
Given:
* Custom fields of type "checkbox" added to the webform
* A webform submission that doesn't check any of the boxes

We end up passing either an empty array or `FALSE` to `Contact.create`.  Both of these cause a WSOD.

The empty array is a valid submission, and is fixed by civicrm/civicrm-core#23305.
However, `FALSE` is not a valid value and should be fixed in `webform_civicrm`.

You can replicate this by creating a custom field of type "Alphanumeric"/"Checkbox", adding it to a webform, then setting it to "static options".  When you submit the form without checking a box, the value will be set to FALSE ("live options" submits an empty array).

Before
----------------------------------------
WSOD.

After
----------------------------------------
Submits as an empty string.