### PR TITLE
PHP8: Add NULL coalescing operator for relationship types

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -363,8 +363,8 @@ class Utils implements UtilsInterface {
     static $types = [];
     if (!$types) {
       foreach ($this->wf_crm_apivalues('relationship_type', 'get', ['is_active' => 1]) as $r) {
-        $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a'));
-        $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b'));
+        $r['type_a'] = strtolower(wf_crm_aval($r, 'contact_type_a') ?? '');
+        $r['type_b'] = strtolower(wf_crm_aval($r, 'contact_type_b') ?? '');
         $r['sub_type_a'] = wf_crm_aval($r, 'contact_sub_type_a');
         if (!is_null($r['sub_type_a'])) {
           $r['sub_type_a'] = $r['sub_type_a'];


### PR DESCRIPTION
Overview
----------------------------------------
In PHP8, passing NULL to `strtolower()` results in an error. This PR adds a null coalescing operator so that if the relationship  retrieved does not have a contact type set, the value will be set to an empty string to avoid the error.

Before
----------------------------------------
```
Deprecated function: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in Drupal\webform_civicrm\Utils->wf_crm_get_relationship_types() (line 368 of webform_civicrm/src/Utils.php) 
```
After
----------------------------------------
No longer receive a depreciated function alert.
