### PR TITLE
(Regression) - Fix contact sub type custom field load

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -305,7 +305,7 @@ class AdminForm implements AdminFormInterface {
         continue;
       }
       if (!empty($set['sub_types'])) {
-        if (!$subTypeIsUserSelect && !array_intersect($c['contact'][1]['contact_sub_type'], array_map('strtolower', $set['sub_types']))) {
+        if (!$subTypeIsUserSelect && !array_intersect($c['contact'][1]['contact_sub_type'], $set['sub_types'])) {
           continue;
         }
         $pos = &$this->form['contact_' . $n]['contact_subtype_wrapper']['contact_custom_wrapper'];


### PR DESCRIPTION
Overview
----------------------------------------
https://civicrm.stackexchange.com/questions/43366/contact-subtype-custom-sets-not-loaded-on-webform

Regression from: https://github.com/colemanw/webform_civicrm/pull/766

Before
----------------------------------------
Custom field option not loaded

After
----------------------------------------
Custom field option loaded