### PR TITLE
PHP8 clean up: initialize $urlParam as emtpy string

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -396,6 +396,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     $n = $this->data['participant_reg_type'] == 'separate' ? $c : 1;
     $p = wf_crm_aval($this->data, "participant:$n:participant");
     if ($p) {
+      $urlParam = '';
       foreach ($p as $e => $value) {
         $event_ids = [];
         // Get the available event list from the component
@@ -412,7 +413,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           $urlParam = "c{$c}event{$e}";
         }
         foreach (explode(',', wf_crm_aval($_GET, $urlParam)) as $url_param_value) {
-          if (isset($eids[$url_param_value])){
+          if (isset($eids[$url_param_value])) {
             $event_ids[] = $eids[$url_param_value];
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
In PHP8,  passing NULL as the second parameter to the `explore()` function results in an error. Currently, this is happening when a user goes to a url that has parameters passed into it, i.e. example.com/form/registration?c5event1=100. 

Before
----------------------------------------
```
Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated in Drupal\webform_civicrm\WebformCivicrmPreProcess->loadURLEvents() (line 414 of webform_civicrm/src/WebformCivicrmPreProcess.php) 
```

After
----------------------------------------
By initializing `$urlParam` as an empty string, the deprecation error is avoided in the case that the variable is not otherwise set.

Technical Details
----------------------------------------
Because  `explode(',', wf_crm_aval($_GET, $urlParam)` is part of a loop, sometimes `$urlParam` has a value, but it can also be NULL for different iterations through the code.

Comments
----------------------------------------
This PR also includes a non functional change of adjusting the spacing between an ending parenthesis and a starting curly brace on the line below the `explode()` function.