### PR TITLE
Improve speed of getting Civi version

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -68,7 +68,8 @@ class Fields implements FieldsInterface {
         'activity' => ['entity_type' => 'activity', 'label' => t('Activity'), 'max_instances' => 99,  'attachments' => TRUE],
         'relationship' => ['entity_type' => 'contact', 'label' => t('Relationship'), 'help_text' => TRUE, 'custom_fields' => 'combined'],
       ];
-      $civicrm_version = $this->utils->wf_crm_apivalues('System', 'get')[0]['version'];
+      
+      $civicrm_version = \CRM_Utils_System::version();
       // Grant is moved to extension after > 5.47.0.
       if (version_compare($civicrm_version, '5.47') >= 0) {
         $components = array_diff($components, ['CiviGrant']);


### PR DESCRIPTION
Overview
----------------------------------------
A speed boost that loads pages anywhere from 280ms to 700ms faster.

Before
----------------------------------------
Slower page load.

After
----------------------------------------
Faster page load.

Technical Details
----------------------------------------
The `System.get` API does a lot more than just calculate the version - enough so that when I ran XDebug profiling on a page submission, the API call stood out as the lowest-hanging fruit.

You can test this by running these on your command line and observing the time on the last line:
```shell
time cv api System.get 
time cv ev '$t = CRM_Utils_System::version(); var_dump($t)'
```

Comments
----------------------------------------
On a pretty bare site, the speed difference is 280-300ms.  On a heavy site, I've sped this up by as much as 700ms.  This function runs on every webform page load and submission.
