### PR TITLE
D9 - Add test to verify subtype custom field submission

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1950,9 +1950,10 @@ class AdminForm implements AdminFormInterface {
               if ($name != 'enable_contribution') {
                 $created[] = $field['name'];
               }
-              if (isset($field['civicrm_condition'])) {
-                $this->addConditionalRule($field, $enabled);
-              }
+              // @todo: Update Conditionals as per Drupal 9 standards.
+              // if (isset($field['civicrm_condition'])) {
+              //   $this->addConditionalRule($field, $enabled);
+              // }
             }
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Add test to verify subtype custom field submission. Fix done in https://github.com/colemanw/webform_civicrm/pull/831

Before
----------------------------------------
No test to verify submission of subtype custom fields.

After
----------------------------------------
Test Added.

Technical Details
----------------------------------------
`addConditionalRule()` is still using the old D7 code to add webform conditionals. I've added a todo for now. An upgrade to this function is required but is not in the scope of this PR.
 
Comments
----------------------------------------
@KarinG @pradpnayak 