### PR TITLE
D9 - Fix fatal error when relationship filter is added on contact field

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -208,6 +208,8 @@ class ContactComponent implements ContactComponentInterface {
     if (!is_numeric($cid)) {
       return FALSE;
     }
+    // Remove unnecessary param as api v4 does not accept them.
+    unset($filters['relationship']);
     $filters['where'][] = ['id', '=', $cid];
     $filters['where'][] = ['is_deleted', '=', 0];
     // A contact always has permission to view self

--- a/tests/src/FunctionalJavascript/ContactRelationshipTest.php
+++ b/tests/src/FunctionalJavascript/ContactRelationshipTest.php
@@ -362,6 +362,9 @@ final class ContactRelationshipTest extends WebformCivicrmTestBase {
         'default_relationship_to' => 'Contact 1',
         'default_relationship' => 'Test Relationship Contact 1',
       ],
+      'filter' => [
+        'filter_relationship_types' => 'Test Relationship Contact 1'
+      ],
     ];
     $this->editContactElement($editContact);
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -520,6 +520,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       if (!empty($params['filter']['group'])) {
         $this->getSession()->getPage()->selectFieldOption('Groups', $params['filter']['group']);
       }
+      if (!empty($params['filter']['filter_relationship_types'])) {
+        $this->getSession()->getPage()->selectFieldOption('properties[filter_relationship_types][]', $params['filter']['filter_relationship_types']);
+      }
       if (isset($params['filter']['check_permissions']) && empty($params['filter']['check_permissions'])) {
         $this->getSession()->getPage()->uncheckField('properties[check_permissions]');
       }


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error when relationship filter is added on contact field

Before
----------------------------------------
From https://www.drupal.org/project/webform_civicrm/issues/3336269

After updating the webform_civicrm module to 6.2.2 we began getting errors for forms with CiviCRM relationships. I am not sure whether this is unique to our installation or if it is a common issue. It did not exist with 6.2.1, and rolling back to 6.2.1 resolves our immediate problem.

The specific error we're seeing in the log is:
>API_Exception: Unknown api parameter: setRelationship in Civi\Api4\Generic\AbstractAction->__call() (line 218 of /var/www/html/vendor/civicrm/civicrm-core/Civi/Api4/Generic/AbstractAction.php).

The form page is a wsod, but removing this line from the yaml '#default': relationship allows the page to load - not really sure why - but when submitting the form the same API_Exception occurs.


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
v4 does not accept irrelevant params and throws an error if passed in. Since `wf_crm_contact_access()` checks for the access to the contact, `relationship` param isn't required and can be ignored.

Comments
----------------------------------------
@KarinG 