### PR TITLE
Empty array set in default values causes issue with API4 when rendering the form

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -355,6 +355,7 @@ class ContactComponent implements ContactComponentInterface {
       if ($key === 'relationship') {
         foreach ($filter as $val) {
           $filterVal = $contact_element->getElementProperty($component, "filter_relationship_{$val}");
+          $this->wf_crm_search_filterArray($filterVal);
           if ($filterVal) {
             $params['relationship'][$val] = $filterVal;
           }
@@ -362,6 +363,7 @@ class ContactComponent implements ContactComponentInterface {
       }
       else {
         $filterVal = $contact_element->getElementProperty($component, $filter);
+        $this->wf_crm_search_filterArray($filterVal);
         if ($filterVal) {
           $op = '=';
           if (in_array($filter, ['group', 'tag'])) {
@@ -373,6 +375,15 @@ class ContactComponent implements ContactComponentInterface {
       }
     }
     return $params;
+  }
+
+  /**
+   * Remove blank values in the array.
+   */
+  function wf_crm_search_filterArray(&$filterVal) {
+    if (is_array($filterVal)) {
+      $filterVal = array_filter($filterVal);
+    }
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
````
civicrm_1_contact_1_contact_existing:
    '#type': civicrm_contact
    '#title': 'Existing Contact'
    '#widget': hidden
    '#none_prompt': '+ Create new +'
    '#results_display':
      display_name: display_name
    '#no_autofill':
      '': ''
    '#hide_fields':
      '': ''
    '#default': user
    '#group':
      '': ''
    '#tag':
      '': ''
    '#allow_create': 1
    '#contact_type': individual
    '#form_key': civicrm_1_contact_1_contact_existing
    '#parent': civicrm_1_contact_1_fieldset_fieldset
    '#extra': {  }

````

Error:
CRM_Core_Exception: One of parameters (value: ) is not of the type CommaSeparatedIntegers in CRM_Utils_Type::validate() (line 469 of /var/sites/html/drupal9/vendor/civicrm/civicrm-core/CRM/Utils/Type.php).


Before
----------------------------------------
Fatal error when viewing webform

After
----------------------------------------
No Fatal error