### PR TITLE
D9 - Fix fatal error on single static option submission for Activity Type …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Webform CiviCRM
 ===============
 
-Webform CiviCRM is a powerful, flexible, user-friendly form builder for CiviCRM.
+Webform CiviCRM is a powerful, flexible, user-friendly form builder for CiviCRM!
 
 Installation & Getting Started
 ------------------------------

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1039,7 +1039,10 @@ class Utils implements UtilsInterface {
    */
   public function hasMultipleValues($element) {
     if (!empty($element['#extra']['multiple']) ||
-      (empty($element['#civicrm_live_options']) && !empty($element['#options']) && is_array($element['#options']) && count($element['#options']) === 1)) {
+      (empty($element['#civicrm_live_options'])
+      && empty($element['#extra']['aslist'])
+      && !empty($element['#options']) && is_array($element['#options'])
+      && count($element['#options']) === 1)) {
       return TRUE;
     }
     return FALSE;

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -26,6 +26,24 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
   }
 
   /**
+   * Test Activity with single option for Activity Type.
+   */
+  public function testSingleActivityTypeOption() {
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->addActivityFields(1, TRUE);
+    // Alter activity type field to use static options with only 1 option enabled.
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    $this->htmlOutput();
+    $this->editCivicrmOptionElement("edit-webform-ui-elements-civicrm-1-activity-1-activity-activity-type-id-operations", FALSE, TRUE, NULL, NULL, TRUE, TRUE);
+
+    $this->submitWebform();
+    $this->verifyActivityValues();
+  }
+
+  /**
    * Test activity on multiple assignees
    */
   public function testMultipleAssignees() {
@@ -43,7 +61,7 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
    *
    * @param int $num
    */
-  private function addActivityFields($num = 1) {
+  private function addActivityFields($num = 1, $select_activity = FALSE) {
     $this->enableCivicrmOnWebform();
 
     $this->getSession()->getPage()->selectFieldOption('number_of_contacts', $num);
@@ -54,6 +72,12 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('activity_number_of_activity', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
+
+    if ($select_activity) {
+      $this->getSession()->getPage()->selectFieldOption('civicrm_1_activity_1_activity_activity_type_id', '- User Select -');
+      $this->assertSession()->assertWaitOnAjaxRequest();
+      $this->htmlOutput();
+    }
 
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_subject");
     $this->getSession()->getPage()->checkField("civicrm_1_activity_1_activity_details");

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -326,8 +326,12 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    * @param bool $default
    * @param string $type
    *  possible values - checkboxes, radios, select, civicrm-options
+   * @param string $singleOption
+   *  TRUE if only one option is enabled on the element.
+   * @param string $asList
+   *  TRUE if element need to be rendered as select element.
    */
-  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL) {
+  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL, $singleOption = FALSE, $asList = FALSE) {
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
     $checkbox_edit_button->click();
     $this->assertSession()->waitForField('drupal-off-canvas');
@@ -342,14 +346,32 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if ($enableStatic) {
       $this->getSession()->getPage()->selectFieldOption("properties[civicrm_live_options]", 0);
       $this->assertSession()->waitForField('properties[options][options][civicrm_option_1][enabled]', 5000);
+
+      if ($singleOption) {
+        $select_all_checkbox = $this->assertSession()->elementExists('css', '.select-all input.form-checkbox');
+        $select_all_checkbox->click();
+        $this->getSession()->wait(1000);
+        $select_all_checkbox->click();
+        $this->getSession()->wait(1000);
+
+        $this->getSession()->getPage()->checkField('properties[options][options][civicrm_option_1][enabled]');
+        $this->assertSession()->checkboxChecked('properties[options][options][civicrm_option_1][enabled]');
+      }
     }
     if ($default) {
       $this->getSession()->getPage()->selectFieldOption("properties[options][default]", $default);
     }
     if (!$type || $type == 'civicrm-options') {
-      $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
-      $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
-      $this->htmlOutput();
+      if ($asList) {
+        $this->getSession()->getPage()->checkField('properties[extra][aslist]');
+        $this->assertSession()->checkboxChecked('properties[extra][aslist]');
+        $this->htmlOutput();
+      }
+      else {
+        $this->getSession()->getPage()->uncheckField('properties[extra][aslist]');
+        $this->assertSession()->checkboxNotChecked('properties[extra][aslist]');
+        $this->htmlOutput();
+      }
       if (!$multiple) {
         $this->getSession()->getPage()->uncheckField('properties[extra][multiple]');
         $this->assertSession()->checkboxNotChecked('properties[extra][multiple]');


### PR DESCRIPTION
…field

Overview
----------------------------------------
Fix fatal error on single static option submission for Activity Type field.

Before
----------------------------------------
Fatal Error if Activity Type field has a single option enabled. To replicate -

- Create a webform with Activity Type = User select
- Edit this element and enable single static option 
- Submit the webform. Error

![image](https://user-images.githubusercontent.com/5929648/216761368-272f82b5-da0c-48bf-83e0-1b751687772e.png)


After
----------------------------------------
Fixed.


Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3336056