### PR TITLE
Fix submitting state/province with IDs over 10,000

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -684,10 +684,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           }
         }
       }
-      // Translate state abbr to id (skip if using $masters address which would have returned id not abbr from the api)
-      if (empty($masters) && !empty($contact['address'][1]['state_province_id'])) {
-        $contact['address'][1]['state_province_id'] = $this->utils->wf_crm_state_abbr($contact['address'][1]['state_province_id'], 'id', $contact['address'][1]['country_id'] ?? NULL);
-      }
       foreach ($contact as $table => $fields) {
         if (is_array($fields) && !empty($fields[1])) {
           $params['match'] += $fields[1];


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3340681.

Before
----------------------------------------
Crash when submitting an address with a state/province with id >= 10,000.

After
----------------------------------------
No crash

Technical Details
----------------------------------------
#813 replaced the state abbreviation on this field with an ID.  The code I'm removing is trying to convert it from abbreviation to ID.

Comments
----------------------------------------
This is the only use of `wf_crm_state_abbr` in the codebase.  Is there any reason not to delete the entire function and associated tests?  If not, I'll do so in a follow-up PR.
