### PR TITLE
use form's currency, not system default, for displaying line items/total

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -54,8 +54,33 @@
   function tally() {
     var total = 0;
     total = getTotalAmount();
-    $('#wf-crm-billing-total').find('td+td').html(CRM.formatMoney(total));
+    // Match the existing format for the total.
+    var moneyFormat = getCurrencyFormat($('#wf-crm-billing-total').find('td+td').html());
+    $('#wf-crm-billing-total').find('td+td').html(CRM.formatMoney(total, false, moneyFormat));
     $('#billing-payment-block').toggle(total > 0);
+  }
+
+  // Given an existing amount, generate a valid format for CRM.formatMoney.
+  function getCurrencyFormat(currentAmount) {
+    if (!currentAmount) {
+      return null;
+    }
+    var moneyFormat = null;
+    var noSymbolsFormat = null;
+    // comma or decimal point followed by exactly two digits optionally followed by non-digits.
+    var decimalSeparator = (currentAmount.match(/([\.|,])\d{2}\D*$/) ?? [])[1] ?? '';
+    // comma, period, space, apostrophe or underscore followed by 3 digits.
+    var thousandsSeparator = (currentAmount.match(/([\., \'_])\d{3}/) ?? [])[1] ?? '';
+    // a single digit optionally followed by any number of digits and/or decimal/thousands separators.
+    var noSymbolsAmount = (currentAmount.match(/([0-9][\., \'_0-9]*)/) ?? [])[1].trim() ?? '';
+
+    if (decimalSeparator) {
+      noSymbolsFormat = '1' + thousandsSeparator + '234' + decimalSeparator + '56';
+    } else {
+      noSymbolsFormat = '1' + thousandsSeparator + '235';
+    }
+    moneyFormat = currentAmount.replace(noSymbolsAmount, noSymbolsFormat);
+    return moneyFormat;
   }
 
   function updateLineItem(item, amount, label) {

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -594,6 +594,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
    */
   private function displayLineItems() {
     $rows = [];
+    $currency = wf_crm_aval($this->data, "contribution:1:currency");
     $total = 0;
     // Support hidden contribution field
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
@@ -634,7 +635,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $total += $item['tax_amount'];
         $label = $item['label'] . ($item['qty'] > 1 ? " ({$item['qty']})" : '');
         $rows[] = [
-          'data' => [$label, \CRM_Utils_Money::format($item['line_total'] + $item['tax_amount'])],
+          'data' => [$label, \CRM_Utils_Money::format($item['line_total'] + $item['tax_amount'], $currency)],
           'class' => [$item['element'], 'line-item'],
           'data-amount' => $item['line_total'] + $item['tax_amount'],
           'data-tax' => (float) $itemTaxRate,
@@ -643,14 +644,14 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       else {
         $label = $item['label'] . ($item['qty'] > 1 ? " ({$item['qty']})" : '');
         $rows[] = [
-          'data' => [$label, \CRM_Utils_Money::format($item['line_total'])],
+          'data' => [$label, \CRM_Utils_Money::format($item['line_total'], $currency)],
           'class' => [$item['element'], 'line-item'],
           'data-amount' => $item['line_total'],
         ];
       }
     }
     $rows[] = [
-      'data' => [t('Total'), \CRM_Utils_Money::format($total)],
+      'data' => [t('Total'), \CRM_Utils_Money::format($total, $currency)],
       'id' => 'wf-crm-billing-total',
       'data-amount' => $total,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3340955.

Before
----------------------------------------
The line items and total on the payment page display in the system default currency.

After
----------------------------------------
The line items and total on the payment page display in the webform's currency.

Comments
----------------------------------------
The PHP fix is the primary fix.  The JS fix works because the PHP fix is providing the correct format.