### PR TITLE
remove wf_crm_state_abbr, now used only in tests

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -105,34 +105,6 @@ class Utils implements UtilsInterface {
   }
 
   /**
-   * Match a state/province id to its abbr. and vice-versa
-   *
-   * @param $input
-   *   User input (state province id or abbr)
-   * @param $ret
-   *   String: 'id'
-   * @param $country_id
-   *   Int: (optional) must be supplied if fetching id from abbr
-   *
-   * @return string or integer
-   */
-  function wf_crm_state_abbr($input, $ret = 'abbreviation', $country_id = NULL) {
-    $params = ['sequential' => 1];
-    if ($ret == 'id') {
-      $params['abbreviation'] = $input;
-      if (!$country_id || $country_id === 'default') {
-        $country_id = (int) $this->wf_crm_get_civi_setting('defaultContactCountry', 1228);
-      }
-    }
-    else {
-      $params['id'] = $input;
-    }
-    $params['country_id'] = $country_id;
-    $result = $this->wf_crm_apivalues('StateProvince', 'get', $params, $ret);
-    return wf_crm_aval($result, 0);
-  }
-
-  /**
    * Get list of events.
    *
    * @param array $reg_options

--- a/src/UtilsInterface.php
+++ b/src/UtilsInterface.php
@@ -51,20 +51,6 @@ interface UtilsInterface {
   public function wf_crm_get_states($param = NULL);
 
   /**
-   * Match a state/province id to its abbr. and vice-versa
-   *
-   * @param $input
-   *   User input (state province id or abbr)
-   * @param $ret
-   *   String: 'abbreviation' or 'id'
-   * @param $country_id
-   *   Int: (optional) must be supplied if fetching id from abbr
-   *
-   * @return string or integer
-   */
-  function wf_crm_state_abbr($input, $ret = 'abbreviation', $country_id = NULL);
-
-  /**
    * Get list of events.
    *
    * @param array $reg_options

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -69,7 +69,10 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'return' => "id",
       'name' => "United States",
     ]);
-    $stateID = $this->utils->wf_crm_state_abbr('NJ', 'id');
+    $stateID = $this->utils->wf_civicrm_api('StateProvince', 'getvalue', [
+      'return' => "id",
+      'name' => "New Jersey",
+    ]);
     $edit = [
       'First Name' => 'Frederick',
       'Last Name' => 'Pabst',
@@ -77,7 +80,7 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'City' => 'Newark',
       'Postal Code' => '12345',
       'Country' => $countryID,
-      'State/Province' => $stateID, // New Jersey
+      'State/Province' => $stateID,
     ];
     $this->postSubmission($this->webform, $edit);
 
@@ -191,7 +194,10 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'return' => "id",
       'name' => "Canada",
     ]);
-    $state_id = $this->utils->wf_crm_state_abbr('AB', 'id', $canada_id);
+    $state_id = $this->utils->wf_civicrm_api('StateProvince', 'getvalue', [
+      'return' => "id",
+      'name' => "Alberta",
+    ]);
     // Check if address fields are pre populated with existing values.
     $this->assertSession()->fieldValueEquals('Street Address', '123 Defence Colony');
     $this->assertSession()->fieldValueEquals('City', 'Edmonton');

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -327,14 +327,18 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
       $expected_tax_amount = 13;
     }
 
+    $provinceId = $this->utils->wf_civicrm_api('StateProvince', 'getvalue', [
+      'return' => "id",
+      'name' => "Alberta",
+    ]);
     $this->assertSession()->waitForField('First Name');
 
-    $this->getSession()->getPage()->fillField('First Name', $province .'_first');
+    $this->getSession()->getPage()->fillField('First Name', $province . '_first');
     $this->getSession()->getPage()->fillField('Last Name', $province . '_last');
     $this->getSession()->getPage()->fillField('Street Address', '39 Street');
     $this->getSession()->getPage()->fillField('City', 'City');
     $this->getSession()->getPage()->fillField('Postal Code', 'A0B 1C2');
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_address_state_province_id', $this->utils->wf_crm_state_abbr('AB', 'id', 1039));
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_address_state_province_id', $provinceId);
     $this->getSession()->getPage()->fillField('Email', $province . '@example.com');
 
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_membership_1_membership_financial_type_id', $financial_type_id);


### PR DESCRIPTION
Per discussion in #841 - `wf_crm_state_abbr()` isn't called from anywhere except tests, so removing it.