### PR TITLE
always load utils.inc on submission_render_alter

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -331,6 +331,7 @@ function webform_civicrm_webform_submission_render_alter(&$renderable) {
     return;
   }
   civicrm_initialize();
+  module_load_include('inc', 'webform_civicrm', 'includes/utils');
 
   // Add display name to title while viewing a submission.
   if (!empty($renderable['#submission']->civicrm['contact'][1]['display_name']) && empty($renderable['#email']) && $renderable['#format'] == 'html') {


### PR DESCRIPTION
Overview
----------------------------------------
Drupal crashes when trying to render hidden select fields in webform submissions.

I'm not sure when this regressed - I started seeing the issue about a week ago, and see that Webform got an update, but I can't see anything in that update to cause this.

To replicate, have a hidden select field (in my case, an event picker), submit the form, then try to view it.

Before
----------------------------------------
WSOD:
```
Error: Call to undefined function wf_crm_field_options() in webform_civicrm_webform_submission_render_alter() (line 343 of /home/jon/local/mysite/web/sites/all/modules/webform_civicrm/webform_civicrm.module).
```

After
----------------------------------------
Displays.

Technical Details
----------------------------------------
I assume that this line was previously called by an earlier function in the call stack. 