### PR TITLE
flatten $eventFTId from array to string

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -528,14 +528,14 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         'return' => ["id"],
         'name' => "Event Fee",
         'is_active' => 1,
-      ])[0];
+      ])[0]['id'] ?? NULL;
       if (empty($eventFTId)) {
         $eventFTId = $this->utils->wf_crm_apivalues('FinancialType', 'get', [
           'sequential' => 1,
           'return' => ["id"],
           'is_active' => 1,
           'options' => ['limit' => 1],
-        ])[0];
+        ])[0]['id'];
       }
     }
     foreach ($this->line_items as &$item) {


### PR DESCRIPTION
Overview
----------------------------------------
 A previous PR of mine, #810, introduced a bug for the "Sales Tax integration" section of the `tallyLineItems()` function.

Before
----------------------------------------
If a Webform tallies line items on one page, the user is prevented from moving to a second -i.e. payment-  page because 
a TypeError would be thrown:

```
TypeError: Illegal offset type in isset or empty in Drupal\webform_civicrm\WebformCivicrmPostProcess->tallyLineItems() (line 1763 of /code/modules/contrib/webform_civicrm/src/WebformCivicrmPostProcess.php) 
```
After
----------------------------------------
In flattening `$eventFTId` so it is no longer an array, but a string, the TypeError is avoided and the user can move on to the next page of the Webform.
 
Technical Details
----------------------------------------
* The previous PR dynamically retrieved the Event's financial type id (`$eventFTId`), however, it returned it as an array with a key of `id`.
* `$eventFTId` is then passed as an argument in setting `$item['financial_type_id']`, so  `$item['financial_type_id']` becomes a nested array: `$item['financial_type_id'][0]['id' => 1]`
*  So that when `isset()` is called on `$taxRates[$line_item['financial_type_id']]`, it is trying to evaluate `$taxRates[['id' => 1]]`

