### PR TITLE
Update info.yml to support drupal 10

### DIFF
--- a/tests/modules/webform_civicrm_test/webform_civicrm_test.info.yml
+++ b/tests/modules/webform_civicrm_test/webform_civicrm_test.info.yml
@@ -2,6 +2,6 @@ name: 'Webform CiviCRM test'
 type: module
 description: 'Support module for webform civicrm testing.'
 package: 'Webform CiviCRM Testing'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^9.4 || ^10
 dependencies:
   - 'webform_civicrm:webform_civicrm'

--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -1,7 +1,7 @@
 name: 'Webform CiviCRM'
 type: module
 description: 'Webform CiviCRM Integration'
-core_version_requirement: ^8.8 || ^9
+core_version_requirement: ^9.4 || ^10
 package: 'CiviCRM'
 dependencies:
   - drupal:webform


### PR DESCRIPTION
Overview
----------------------------------------
Some things to note:
* If you install it on drupal 10, you'll need the 6.2.x-dev version of the parent webform, but there isn't a compelling reason to up the version required in composer.json to `^6.2` since you don't need that for drupal 9. But composer should figure it out based on the parent webform's branch's composer.jsons you just might need to put `"minimum-stability": "dev"` in your root composer.json.
* Stripe and firewall would need to be master versions from git if using those.
* Iats needs to be patched if using that.