### PR TITLE
Set the currency to match the submission

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1188,6 +1188,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
               if (empty($params['status_id'])) {
                 unset($params['status_id']);
               }
+              // Set the currency of the result to the currency type that was submitted.
+              $params['fee_currency'] = $this->data['contribution'][$n]['currency'];
               $result = $this->utils->wf_civicrm_api('participant', 'create', $params);
               $this->ent['participant'][$n]['id'] = $result['id'];
 


### PR DESCRIPTION
Overview
----------------------------------------
For webforms that use a different currency than the default currency of the site, the data is inconsistently passed to CiviCRM. While viewing the Contribution shows the correct currency of the particular webform (i.e. EUR),  the Event tab on a contact record would show the *Amount* paid in the default currency (i.e. USD)

Before
----------------------------------------
Currently, the Participant record is being created without specifying the currency (i.e. `fee_amount` and so it uses the default currency.

_Replication steps_
1. Create a Webform with CiviCRM processing, in which the Contribution is **not** the default currency
2. Make a submission
3. Within CiviCRM, go to the Event tab of the Contact for the submission
4. Look at the *Amount* listed on that summary page and compare it to the amount listed as the Contribution when **View** is clicked.

After
----------------------------------------
With this patch,  `fee_currency` is added to the `$params` that create the Participant record, and set equal to the currency that is passed in by the webform submission, so that the currencies match across CiviCRM.

