### PR TITLE
[test only] Switch to downloading extensions in the yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,10 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require drupal/token:^1.9
+      - name: Download some test helpers
+        run: |
+          cd ~/drupal
+          COMPOSER_MEMORY_LIMIT=-1 composer require semperit/minkcivicrmhelpers
       - name: Set identity
         # Needed for `git am` but otherwise irrelevant
         run: |
@@ -117,6 +121,29 @@ jobs:
           cd  ~/drupal/vendor/civicrm/civicrm-core
           curl -L -o prpatch.patch ${{ github.event.inputs.coreprurl }}.patch
           git am prpatch.patch
+      - name: Do a fake temp install
+        # so that we can use civi api to get extensions with a version appropriate to the installed civi version
+        run: |
+          cd ~/drupal
+          composer require drush/drush
+          mkdir -p /home/runner/civicrm-cv
+          curl -L https://download.civicrm.org/cv/cv.phar -o /home/runner/civicrm-cv/cv
+          chmod +x /home/runner/civicrm-cv/cv
+          ./vendor/drush/drush/drush -y -l http://civi.localhost site-install standard --db-url='mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/fakedb' --site-name=FakeCivi
+          chmod +w web/sites/default
+          /home/runner/civicrm-cv/cv core:install --cms-base-url=http://civi.localhost -m loadGenerated=1
+      - name: Download Civi extensions
+        run: |
+          mkdir -p ~/drupal/web/sites/default/files/civicrm/ext
+          cd ~/drupal/web/sites/default/files/civicrm/ext
+          # We could add an `if` here that depends on the matrix if we wanted e.g. to use git to download a dev version for a given run.
+          # But normally we'll just let civi decide which version to download.
+          # Apparently we have to install it, otherwise stripe gives a dependency error even with install=0. I think that's a bug, but let's just do it. This is a fake install anyway.
+          /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=mjwshared
+          /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=firewall
+          /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.drastikbydesign.stripe
+          /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.iatspayments.civicrm
+          /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.aghstrategies.uscounties
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &
@@ -133,6 +160,8 @@ jobs:
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080
           MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'
           BROWSERTEST_OUTPUT_DIRECTORY: '${{ runner.temp }}/browser_output'
+          DEV_EXTENSION_DIR: /home/runner/drupal/web/sites/default/files/civicrm/ext
+          DEV_EXTENSION_URL: http://127.0.0.1:8080/sites/default/files/civicrm/ext
       - uses: actions/upload-artifact@v3
         if: ${{ failure() || success() }}
         with:

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -16,10 +16,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    $this->utils->wf_civicrm_api('Extension', 'download', [
-      'key' => "com.aghstrategies.uscounties",
-    ]);
-    drupal_flush_all_caches();
+    $this->setUpExtension('com.aghstrategies.uscounties');
   }
 
   /**

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -19,10 +19,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    // Download installs and enables!
-    $result = civicrm_api3('Extension', 'download', [
-      'key' => "com.iatspayments.civicrm",
-    ]);
+    $this->setUpExtension('com.iatspayments.civicrm');
 
     // Legacy CC
     $params = [

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -16,16 +16,8 @@ final class StripeTest extends WebformCivicrmTestBase {
    */
   protected function setUp(): void {
     parent::setUp();
-    // Download installs and enables!
-    $this->utils->wf_civicrm_api('Extension', 'download', [
-      'key' => "mjwshared",
-    ]);
-    $this->utils->wf_civicrm_api('Extension', 'download', [
-      'key' => "firewall",
-    ]);
-    $this->utils->wf_civicrm_api('Extension', 'download', [
-      'key' => "com.drastikbydesign.stripe",
-    ]);
+
+    $this->setUpExtension('mjwshared,firewall,com.drastikbydesign.stripe');
 
     $params = [];
     $result = $this->utils->wf_civicrm_api('Stripe', 'setuptest', $params);

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -11,6 +11,7 @@ use Drupal\Core\Url;
 abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
   use WebformBrowserTestTrait;
+  use \Drupal\Tests\mink_civicrm_helpers\Traits\Utils;
 
   /**
    * {@inheritdoc}
@@ -21,6 +22,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     'webform_civicrm',
     'token',
     'ckeditor5',
+    'mink_civicrm_helpers',
   ];
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Each individual test for iats and stripe downloads the extensions in its setUp function, so besides lab.civicrm.org being hit about 4x4x4 times, it's difficult to do things like run against a specific version of an extension or patch it.

After
----------------------------------------
Download the extensions once in the yml. Can apply patches easily in the yml.

Technical Details
----------------------------------------
The install still happens in setUp() the same as before, just instead of the extension being in the temporary simpletest subfolder that gets created for each test, it's in a central more permanent location.

Comments
----------------------------------------

