### PR TITLE
D9 - Add upgrade code to fix lowercase contact subtype stored in settings

### DIFF
--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -360,3 +360,60 @@ function webform_civicrm_update_8005() {
     }
   }
 }
+
+/**
+ * Fix contact subtype case in existing webforms.
+ */
+function webform_civicrm_update_8006() {
+  \Drupal::service('civicrm')->initialize();
+  $utils = \Drupal::service('webform_civicrm.utils');
+  $subTypes = $utils->wf_crm_apivalues('Contact', 'getoptions', [
+    'field' => "contact_sub_type",
+  ]);
+  if (empty($subTypes)) {
+    return;
+  }
+  // change keys to lowercase
+  $subTypes = array_change_key_case($subTypes, CASE_LOWER);
+
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $settings = &$config['webform_civicrm']['settings'];
+
+    $settings_updated = FALSE;
+    foreach ($settings as $key => &$value) {
+      if (preg_match('/contact_contact_sub_type$/', $key)) {
+        foreach ($value as $k => $v) {
+          if (strtolower($k) == $k && !empty($subTypes[$k])) {
+            $value[$subTypes[$k]] = $subTypes[$k];
+            unset($value[$k]);
+            $settings_updated = TRUE;
+          }
+        }
+      }
+    }
+    // Update data key in settings to have the correct case for subtype. 
+    $data = &$settings['data'];
+    foreach ($data['contact'] as $key => &$contact) {
+      if (!empty($contact['contact'][1]['contact_sub_type'])) {
+        foreach ($contact['contact'][1]['contact_sub_type'] as $k => $v) {
+          if (strtolower($k) == $k && !empty($subTypes[$k])) {
+            $contact['contact'][1]['contact_sub_type'][$subTypes[$k]] = $subTypes[$k];
+            unset($contact['contact'][1]['contact_sub_type'][$k]);
+            $settings_updated = TRUE;
+          }
+        }
+      }
+    }
+
+    if ($settings_updated) {
+      $handler->setConfiguration($config);
+      $webform->save();
+    }
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Fix contact subtype case in existing webforms

Before
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3346854

Update from 6.2.1 loses contact subtype settings from all webforms


After
----------------------------------------
Updates the value of contact subtype in existing webforms to actual value hence fixing the loading of subtype default on the webform settings page.


