### PR TITLE
D9 - Add Test for PR#837

### DIFF
--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -126,6 +126,9 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Autocomplete',
       'hide_fields' => 'address',
+      'filter' => [
+        'group' => '- None -',
+      ],
     ];
     $this->editContactElement($editContact);
 


### PR DESCRIPTION
Overview
----------------------------------------
Test for PR #837

Before
----------------------------------------
group value set to `-None-` result into fatal error on the webform.

After
----------------------------------------
Test to ensure this does not regress again.


Comments
----------------------------------------
Related PR - https://github.com/colemanw/webform_civicrm/pull/837