### PR TITLE
fix 500 error when viewing existing contact element

### DIFF
--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -340,7 +340,7 @@ class CivicrmContact extends WebformElementBase {
     ];
     $cid = $element_properties['default_contact_id'];
     $contactComponent = \Drupal::service('webform_civicrm.contact_component');
-    if ($cid && $name = $contactComponent->wf_crm_contact_access($element_properties, ['check_permissions' => 1], $cid)) {
+    if ($cid && $name = $contactComponent->wf_crm_contact_access($element_properties, ['checkPermissions' => 1], $cid)) {
       $form['contact_defaults']['default_contact_id']['#default_value'] = $cid;
       $form['contact_defaults']['default_contact_id']['#attributes'] = [
         'data-civicrm-name' => $name,


### PR DESCRIPTION
Overview
----------------------------------------
There is a regression introduced by #785 that causes a 500 error when you attempt to edit an "Existing Contact" element on the Build tab.

To replicate:
* Create a new webform with Civi integration enabled.
* Add only the "Existing Contact" field.
* Edit the element on the Build tab - *Set default contact from* = **Specified Contact** and any (existing) contact ID.
* Save the form, then attempt to edit the element again.
![Selection_1815](https://user-images.githubusercontent.com/1796012/225987930-9b9d6a65-e589-45fc-8499-36781851c7ae.png)

Here is the source for such a form:
```yaml
civicrm_1_contact_1_fieldset_fieldset:
  '#type': fieldset
  '#title': 'Contact 1'
  '#form_key': civicrm_1_contact_1_fieldset_fieldset
  civicrm_1_contact_1_contact_existing:
    '#type': civicrm_contact
    '#title': 'Existing Contact'
    '#widget': hidden
    '#none_prompt': '- None Found -'
    '#results_display':
      display_name: display_name
    '#default': contact_id
    '#default_contact_id': '2'
    '#contact_type': individual
    '#unique_field_values': 0
    '#unique_field_values_ignore_blank': 0
    '#unique_field_value_components': {  }
    '#form_key': civicrm_1_contact_1_contact_existing
    '#parent': civicrm_1_contact_1_fieldset_fieldset
    '#extra': {  }
```

Before
----------------------------------------
500 error.

After
----------------------------------------
Can successfully edit the element.

Technical Details
----------------------------------------
APIv3 uses `check_permissions` and APIv4 uses `checkPermissions`.  There appears to be [code to address this](https://github.com/colemanw/webform_civicrm/blob/254ee95083b07fba2aa619d08f1df8f07d94129a/src/ContactComponent.php#L350) when it's part of the element's properties, but not when the value is hard-coded (as it is where this PR changes it).