### PR TITLE
D9 - Fix the submission of default custom field value

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -1099,7 +1099,7 @@ class Fields implements FieldsInterface {
         $fields[$id]['name'] = $custom_field['label'];
         $fields[$id]['required'] = (int) !empty($custom_field['is_required']);
         if (!empty($custom_field['default_value'])) {
-          $fields[$id]['value'] = implode(',', $this->utils->wf_crm_explode_multivalue_str($custom_field['default_value']));
+          $fields[$id]['default_value'] = implode(',', $this->utils->wf_crm_explode_multivalue_str($custom_field['default_value']));
         }
         $fields[$id]['data_type'] = $custom_field['data_type'];
         if (!empty($custom_field['help_pre']) || !empty($custom_field['help_post'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix the submission of default custom field value

Before
----------------------------------------
When submitting a webform which updates a custom field, the value is always set to the default value (if there is one) when "Option type" is set to "Reuse an existing set".

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Update the `#value` with `#default_value` property.

Comments
----------------------------------------
Drupal Ticket: https://www.drupal.org/project/webform_civicrm/issues/3326150
