### PR TITLE
Fix bug assigning contribution second contact

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2117,7 +2117,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $paymentProcessor = \Civi\Payment\System::singleton()->getByName($processor_type['name'], TRUE);
     }
     // Add contact details to params (most processors want a first_name and last_name)
-    $contact = $this->utils->wf_civicrm_api('contact', 'getsingle', ['id' => $this->ent['contact'][1]['id']]);
+    $i = $this->getContributionContactIndex();
+    $contact = $this->utils->wf_civicrm_api('contact', 'getsingle', ['id' => $this->ent['contact'][$i]['id']]);
     $params += $contact;
     $params['contributionID'] = $params['id'] = $this->ent['contribution'][1]['id'];
     if (!empty($this->ent['contribution_recur'][1]['id'])) {


### PR DESCRIPTION
Overview
----------------------------------------

If you have two contacts to assign a contribution, and you expose to the user that can choose which contact will be assigned the contribuion, via component `civicrm_1_contribution_1_contribution_contact_id`.

If for any reason the **contact 1** (`civicrm_1_contact_1_contact_*`) don't have filled the info, and isn't created.
*We use conditional for not create always the contact 1*

With the previous conditions a fatal error is produced. The contribution can't be assigned to a contact.

![image](https://user-images.githubusercontent.com/2327763/230045915-cbb447f1-0b59-4d35-844a-55c72fc0d94c.png)


Before
----------------------------------------

The contribution can't be assigned to a contact **1** and a fatal error is triggered.

After
----------------------------------------

The contribution  is assigned correctly to the contact selected and not error is triggered.


Technical Details
----------------------------------------


Comments
----------------------------------------

Ref to PR https://github.com/colemanw/webform_civicrm/pull/821
