### PR TITLE
D9 - Update value to default_value to avoid fixed value submission

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -253,7 +253,7 @@ class Fields implements FieldsInterface {
       $fields['contact_preferred_language'] = [
         'name' => t('Preferred Language'),
         'type' => 'select',
-        'value' => $this->utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
+        'default_value' => $this->utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
       ];
       $default_communication_style = $this->utils->wf_crm_apivalues('OptionValue', 'get', [
         'sequential' => 1,
@@ -423,13 +423,13 @@ class Fields implements FieldsInterface {
             'name' => $label,
             'type' => 'select',
             'expose_list' => TRUE,
-            'value' => '1',
+            'default_value' => '1',
           ];
           $fields[$key . '_is_primary'] = [
             'name' => 'Is Primary',
             'type' => 'select',
             'expose_list' => TRUE,
-            'value' => '1',
+            'default_value' => '1',
           ];
         }
       }
@@ -531,7 +531,7 @@ class Fields implements FieldsInterface {
           'extra' => ['required' => 1, 'multiple' => $this->utils->wf_crm_get_civi_setting('civicaseAllowMultipleClients', 0)],
           'data_type' => 'ContactReference',
           'set' => 'caseRoles',
-          'value' => 1,
+          'default_value' => 1,
         ];
         $fields['case_status_id'] = [
           'name' => t('Case # Status'),
@@ -774,7 +774,7 @@ class Fields implements FieldsInterface {
           'name' => t('Frequency of Installments'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 0,
+          'default_value' => 0,
           'exposed_empty_option' => '- ' . t('No Installments') . ' -',
           'set' => 'contributionRecur',
         ];
@@ -850,14 +850,14 @@ class Fields implements FieldsInterface {
           'name' => t('Participant Role'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => '1',
+          'default_value' => '1',
           'extra' => ['multiple' => 1, 'required' => 1],
         ];
         $fields['participant_status_id'] = [
           'name' => t('Registration Status'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 0,
+          'default_value' => 0,
           'exposed_empty_option' => '- ' . t('Automatic') . ' -',
         ];
         $fields['participant_note'] = [
@@ -887,7 +887,7 @@ class Fields implements FieldsInterface {
           'name' => t('Override Status'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 0,
+          'default_value' => 0,
           'exposed_empty_option' => '- ' . t('No') . ' -',
         ];
         $fields['membership_status_override_end_date'] = [
@@ -908,7 +908,7 @@ class Fields implements FieldsInterface {
           'name' => t('Number of Terms'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 1,
+          'default_value' => 1,
           'empty_option' => t('Enter Dates Manually'),
         ];
         if (isset($sets['contribution'])) {
@@ -972,7 +972,7 @@ class Fields implements FieldsInterface {
           'name' => t('Grant Status'),
           'type' => 'select',
           'expose_list' => TRUE,
-          'value' => 0,
+          'default_value' => 0,
           'exposed_empty_option' => '- ' . t('Automatic') . ' -',
         ];
         $fields['grant_application_received_date'] = [

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -374,10 +374,10 @@ abstract class WebformCivicrmBase {
     // Put placeholder 'user-select' where location_type_id is empty for second pass
     foreach ($settingsArray[$ent] as $setting) {
       $valueFound = false;
-      foreach($values as $key => $value){
+      foreach($values as $key => $value) {
         if ((in_array($ent, ['address', 'email']) && $value['location_type_id'] == $setting['location_type_id'])
             || (
-              $value['location_type_id'] == $setting['location_type_id'] &&
+              isset($setting['location_type_id']) && $value['location_type_id'] == $setting['location_type_id'] &&
               (
                 !isset($setting[$ent.'_type_id']) ||
                 (isset($value[$ent.'_type_id'])) && $value[$ent.'_type_id'] == $setting[$ent.'_type_id']


### PR DESCRIPTION
Overview
----------------------------------------
Fix submission of fixed values on webform submission.

Before
----------------------------------------
Some fields submits fixed values on webform submission if `-User Select-` is enabled on them. Eg:

- Preferred Language
- Address, Email, Phone, IM Location Type & Is Primary.
- Case Client is always set to first contact if `-User Select-` is enabled.
- Number of Terms field for membership.
- Grant Status
- Participant Role
- Participant Status

After
----------------------------------------
The expectation here is to load default value on them, not submit the fixed values. Updating 'value' to `default_value` fixe the usecase.

Comments
----------------------------------------
@KarinG This is a followup for https://github.com/colemanw/webform_civicrm/pull/862