### PR TITLE
Do not display "Existing contact" fields as autocomplete when not configured as such

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -9,19 +9,21 @@
         }
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));
         var isSelect = field.data('is-select');
-        var isAutocomplete = field.data('is-autocomplete');
-        if (isAutocomplete) {
+        if (!isSelect) {
+          var tokenValues = field.data('is-contactid') ? false : {
+            hintText: field.data('search-prompt'),
+            noResultsText: field.data('none-prompt'),
+            resultsFormatter: formatChoices,
+            searchingText: "Searching..."
+          };
           wfCivi.existingInit(
             field,
             field.data('civicrm-contact'),
             field.data('form-id'),
             autocompleteUrl,
-            toHide, {
-            hintText: field.data('search-prompt'),
-            noResultsText: field.data('none-prompt'),
-            resultsFormatter: formatChoices,
-            searchingText: "Searching..."
-          });
+            toHide,
+            tokenValues
+          );
         }
 
         field.change(function () {

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -9,7 +9,8 @@
         }
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));
         var isSelect = field.data('is-select');
-        if (!isSelect) {
+        var isAutocomplete = field.data('is-autocomplete');
+        if (isAutocomplete) {
           wfCivi.existingInit(
             field,
             field.data('civicrm-contact'),

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -130,6 +130,9 @@ class CivicrmContact extends WebformElementBase {
       $element['#options'] = [];
       $element['#attributes']['data-is-select'] = 1;
     }
+    elseif ($element['#widget'] === 'autocomplete') {
+      $element['#attributes']['data-is-autocomplete'] = 1;
+    }
     // get translated properties used for autocomplete widget
     $element['#attributes']['data-search-prompt'] = $this->getTranslatedElementProperty($element, 'search_prompt') ?? t('- Choose existing -');
     $element['#attributes']['data-none-prompt'] = $this->getTranslatedElementProperty($element, 'none_prompt') ?? t('+ Create new +');

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -130,8 +130,10 @@ class CivicrmContact extends WebformElementBase {
       $element['#options'] = [];
       $element['#attributes']['data-is-select'] = 1;
     }
-    elseif ($element['#widget'] === 'autocomplete') {
-      $element['#attributes']['data-is-autocomplete'] = 1;
+    elseif ($element['#widget'] === 'textfield') {
+      $element['#attributes']['data-is-contactid'] = 1;
+      $element['#description'] = 'Lookup by Contact ID.';
+      $element['#size'] = 8;
     }
     // get translated properties used for autocomplete widget
     $element['#attributes']['data-search-prompt'] = $this->getTranslatedElementProperty($element, 'search_prompt') ?? t('- Choose existing -');


### PR DESCRIPTION
drupal.org issue: [#3353716](https://www.drupal.org/project/webform_civicrm/issues/3353716)

Overview
----------------------------------------
Existing Contact fields can be configured to display as either an autocomplete, or a select field, or a textfield ("Enter Contact ID"), or be hidden. When selecting the textfield ("Enter Contact ID") option, the field will nevertheless be displayed as an autocomplete field. That is due to JS code only checking for whether the field ist "not a select field".

Steps to reproduce
----------------------------------------
1. Create a Webform with CiviCRM processing enabled
2. Enable a contact and add the "Existing Contact" field
3. Go to the "Build" tab and edit the "Existing Contact" field to display as "Enter Contact ID" for form display and disable prepopulation from URL or current contact
4. View the Webform, the "Existing Contact" field is being displayed as if it were an autocomplete field, while it should be just a simple textfield. It's basically just as if it were configured to be an "autocomplete" field, which is a separate form display option.

Proposed resolution
----------------------------------------
Add an `is-autocomplete` attribute for the webform field and let the JS code depend on that rather than the field not being a select field for initializing autcomplete behavior.