### PR TITLE
D9 - Fix js break on admin screen

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -458,7 +458,7 @@ var wfCiviAdmin = (function (D, $, once) {
               var icon_name = cl[2];
               if (cl[0] === 'contact') {
                 name = 'name="' + (i + 1) + '_contact_type"';
-                var type = $('select[name="' + (i + 1) + '_contact_type"', '#webform-civicrm-settings-form').val();
+                var type = $('select[name="' + (i + 1) + '_contact_type"]', '#webform-civicrm-settings-form').val();
                 icon_name = getContactIcon(type);
               }
               $('#webform-civicrm-settings-form .vertical-tabs__menu-item').eq(i).find('a strong').first().before('<i class="crm-i ' + icon_name + '" ' + name + '> </i> ');


### PR DESCRIPTION
Overview
----------------------------------------
Fix test failures caused by js break on admin screen.

Before
----------------------------------------
Replicates on Drupal > 9.5.

Admin Screen has console errors 

![image](https://user-images.githubusercontent.com/5929648/232210201-de75635c-b060-4e6d-9eb8-be84ece1efc9.png)

After
----------------------------------------
Fixed.


Comments
----------------------------------------
@KarinG 