### PR TITLE
D9 - Modify Submission page to include civicrm links

### DIFF
--- a/src/Controller/WebformCivicrmSubmissionViewController.php
+++ b/src/Controller/WebformCivicrmSubmissionViewController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\webform_civicrm\Controller;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\webform\Controller\WebformSubmissionViewController;
+use Drupal\Core\Link;
+
+class WebformCivicrmSubmissionViewController extends WebformSubmissionViewController {
+
+  /**
+   * @inheritdoc
+   */
+  public function title(EntityInterface $webform_submission, $duplicate = FALSE) {
+    $title = parent::title($webform_submission, $duplicate);
+    if (!empty($webform_submission->getData()['civicrm'])) {
+      $data = $webform_submission->getData()['civicrm'];
+      if (!empty($data['contact'][1]['display_name'])) {
+        return $this->t('@title by @name', ['@title' => $title, '@name' => $data['contact'][1]['display_name']]);
+      }
+    }
+    return $title;
+  }
+
+}

--- a/src/WebformCivicrmRouteSubscriber.php
+++ b/src/WebformCivicrmRouteSubscriber.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\webform_civicrm;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\webform\Controller\WebformSubmissionViewController;
+use Symfony\Component\Routing\RouteCollection;
+
+class WebformCivicrmRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * Override title on webform submission page.
+   *
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    if ($route = $collection->get('entity.webform_submission.canonical')) {
+      $route->setDefault('_title_callback', '\Drupal\webform_civicrm\Controller\WebformCivicrmSubmissionViewController::title');
+    }
+  }
+
+}

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -140,9 +140,11 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     for ($i = 1; $i <= $num; $i++) {
       // In this test: contact_id 1 = Default Organization; contact_id 2 = Drupal User; contact_id 3 = Frederick
       $contact = $this->utils->wf_civicrm_api('Contact', 'get', [
+        'sequential' => 1,
         'first_name' => $this->_contacts[$i]['first_name'],
         'last_name' => $this->_contacts[$i]['last_name'],
       ]);
+      $this->_contacts[$i]['display_name'] = $contact['values'][0]['display_name'];
       $this->assertEquals(1, $contact['count']);
       $this->assertTrue(in_array($contact['id'], $activityContacts));
     }
@@ -170,6 +172,21 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals('Awesome Activity', $activity['subject']);
     $this->assertEquals('1', $activity['activity_type_id']);
     $this->assertTrue(strtotime($today) -  strtotime($activity['activity_date_time']) < 120);
+
+    $sid = $this->getLastSubmissionId($this->webform);
+    $this->drupalGet(Url::fromRoute('entity.webform_submission.canonical', [
+      'webform' => $this->webform->id(),
+      'webform_submission' => $sid,
+    ]));
+    $this->htmlOutput();
+
+    $title = $this->webform->label();
+    $displayName = $this->_contacts[1]['display_name'];
+    $this->assertSession()->pageTextContains("{$title}: Submission #{$sid} by {$displayName}");
+    $this->assertLink("View {$displayName}");
+    $this->assertLink("View Activity");
+    $this->assertNoLink('View Contribution');
+    $this->assertNoLink('View Participant');
   }
 
 }

--- a/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ActivitySubmissionTest.php
@@ -170,10 +170,10 @@ final class ActivitySubmissionTest extends WebformCivicrmTestBase {
 
     $title = $this->webform->label();
     $this->assertSession()->pageTextContains("{$title}: Submission #{$sid} by Frederick Pabst");
-    $this->assertLink("View Frederick Pabst");
-    $this->assertLink("View Activity");
-    $this->assertNoLink('View Contribution');
-    $this->assertNoLink('View Participant');
+    $this->assertSession()->linkExists("View Frederick Pabst");
+    $this->assertSession()->linkExists("View Activity");
+    $this->assertSession()-> linkNotExists('View Contribution');
+    $this->assertSession()-> linkNotExists('View Participant');
 
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contact['id'], 'aid' => $activity['id']]]));
     $this->assertPageNoErrorMessages();

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -79,10 +79,10 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $displayName = $contact['values'][0]['display_name'];
 
     $this->assertSession()->pageTextContains("{$title}: Submission #{$sid} by {$displayName}");
-    $this->assertLink("View {$displayName}");
-    $this->assertNoLink("View Activity");
-    $this->assertLink('View Contribution');
-    $this->assertNoLink('View Participant');
+    $this->assertSession()->linkExists("View {$displayName}");
+    $this->assertSession()-> linkNotExists("View Activity");
+    $this->assertSession()->linkExists('View Contribution');
+    $this->assertSession()-> linkNotExists('View Participant');
   }
 
   public function testSubmitContribution() {

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -64,6 +64,25 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertEquals('10.00', $contribution['total_amount']);
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
+
+    $sid = $this->getLastSubmissionId($this->webform);
+    $this->drupalGet(Url::fromRoute('entity.webform_submission.canonical', [
+      'webform' => $this->webform->id(),
+      'webform_submission' => $sid,
+    ]));
+    $this->htmlOutput();
+    $title = $this->webform->label();
+    $contact = $this->utils->wf_civicrm_api('contact', 'get', [
+      'sequential' => 1,
+      'first_name' => 'Frederick',
+    ]);
+    $displayName = $contact['values'][0]['display_name'];
+
+    $this->assertSession()->pageTextContains("{$title}: Submission #{$sid} by {$displayName}");
+    $this->assertLink("View {$displayName}");
+    $this->assertNoLink("View Activity");
+    $this->assertLink('View Contribution');
+    $this->assertNoLink('View Participant');
   }
 
   public function testSubmitContribution() {

--- a/tests/src/FunctionalJavascript/SubmissionEditTest.php
+++ b/tests/src/FunctionalJavascript/SubmissionEditTest.php
@@ -33,17 +33,9 @@ final class SubmissionEditTest extends WebformCivicrmTestBase {
     // Should have created one contact
     $newMax = $this->getMaxId();
     $this->assertEquals($oldMax + 1, $newMax);
-
     $this->assertEquals('Dummy', civicrm_api3('Contact', 'get', ['id' => $newMax])['values'][$newMax]['first_name']);
 
-    // Get submission id
-    $database = \Drupal::database();
-    $query = $database->query("SELECT MAX(sid) AS maxsid FROM {webform_submission} WHERE webform_id = :wfid", [
-      ':wfid' => $this->webform->id(),
-    ]);
-    $sid = $query->fetchAll()[0]->maxsid;
-    $submission = WebformSubmission::load($sid);
-
+    $submission = WebformSubmission::load($this->getLastSubmissionId($this->webform));
     // Edit submission and save
     $this->drupalGet($submission->toUrl('edit-form'));
     $this->getSession()->getPage()->fillField('First Name', 'Smarty');

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -759,6 +759,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    */
   protected function getLastSubmissionId(WebformInterface $webform) {
     $submission_ids = \Drupal::entityQuery('webform_submission')
+      ->accessCheck(TRUE)
       ->condition('webform_id', $webform->id())
       ->sort('created', 'DESC')
       ->range(0, 1)

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -7,6 +7,7 @@ use Drupal\Tests\webform\Traits\WebformBrowserTestTrait;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Exception\ExpectationException;
 use Drupal\Core\Url;
+use Drupal\webform\WebformInterface;
 
 abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
@@ -744,6 +745,25 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->fillCKEditor('settings[body_custom_html][value]', $params['body']);
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
+  }
+
+  /**
+   * Returns the ID of the last submission on a given webform.
+   *
+   * @param \Drupal\webform\WebformInterface $webform
+   *   The webform entity object.
+   *
+   * @return int|null
+   *   The ID of the last submission on the webform, or null if there are no
+   *   submissions.
+   */
+  protected function getLastSubmissionId(WebformInterface $webform) {
+    $submission_ids = \Drupal::entityQuery('webform_submission')
+      ->condition('webform_id', $webform->id())
+      ->sort('created', 'DESC')
+      ->range(0, 1)
+      ->execute();
+    return reset($submission_ids);
   }
 
 }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -13,6 +13,7 @@ use Drupal\webform\Entity\WebformSubmission;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * The versions of CiviCRM and WebForm. Min is >=.  Max is <. FALSE = no MAX
@@ -261,56 +262,45 @@ function _fillCiviCRMData($data, $webformSubmission) {
 }
 
 /**
- * Implements hook_webform_submission_render_alter().
+ * Implements hook_webform_submission_view_alter().
+ *
  * Add display name to title while viewing a submission.
  */
-function webform_civicrm_webform_submission_render_alter(&$sub) {
-  if (!empty($sub['#submission']->civicrm['contact'][1]['display_name']) && empty($sub['#email']) && $sub['#format'] == 'html') {
-    drupal_set_title(t('Submission #@num by @name', ['@num' => $sub['#submission']->sid, '@name' => $sub['#submission']->civicrm['contact'][1]['display_name']]));
-  }
-}
-
-/**
- * Implements hook_webform_submission_actions().
- * Add links to view contact & activity.
- */
-function webform_civicrm_webform_submission_actions($node, $submission) {
-  $actions = [];
-  if (!empty($node->webform_civicrm)
-    && !empty($submission->civicrm)
-    && webform_results_access($node)
-    && user_access('access CiviCRM')) {
-    $data = $submission->civicrm;
-    if (!empty($data['contact'][1]['display_name'])) {
-      $actions['civicrm_action contact_view'] = [
-        'title' => t('View @name', ['@name' => $data['contact'][1]['display_name']]),
-        'href' => 'civicrm/contact/view',
-        'query' => ['reset' => 1, 'cid' => $data['contact'][1]['id']],
-      ];
-      if (!empty($data['activity'][1]['id'])) {
-        $actions['civicrm_action activity_view'] = [
-          'title' => t('View Activity'),
-          'href' => 'civicrm/activity',
-          'query' => ['action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data['activity'][1]['id']],
-        ];
-      }
-      if (!empty($data['contribution'][1]['id'])) {
-        $actions['civicrm_action contribution_view'] = [
-          'title' => t('View Contribution'),
-          'href' => 'civicrm/contact/view/contribution',
-          'query' => ['action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data['contribution'][1]['id']],
-        ];
-      }
-      if (!empty($data['participant'][1]['id'])) {
-        $actions['civicrm_action participant_view'] = [
-          'title' => t('View Participant'),
-          'href' => 'civicrm/contact/view/participant',
-          'query' => ['action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data['participant'][1]['id']],
-        ];
+function webform_civicrm_webform_submission_view_alter(array &$build, WebformSubmission $submission) {
+  $webform = $submission->getWebform();
+  $config = $webform->getHandlers('webform_civicrm')->getConfiguration();
+  if (!empty($config['webform_civicrm']) && !empty($submission->getData()['civicrm']) && \Drupal::currentUser()->hasPermission('access CiviCRM')) {
+    $data = $submission->getData()['civicrm'];
+    $links = [];
+    $entity_links = [
+      'contact' => 'contact/view',
+      'activity' => 'activity',
+      'contribution' => 'contact/view/contribution',
+      'participant' => 'contact/view/participant'
+    ];
+    foreach ($entity_links as $entity => $link) {
+      if (!empty($data[$entity][1]['id'])) {
+        $query = ['action' => 'view', 'reset' => 1, 'cid' => $data['contact'][1]['id'], 'id' => $data[$entity][1]['id']];
+        $name = ucfirst($entity);
+        if ($entity == 'contact') {
+          $query = ['reset' => 1, 'cid' => $data['contact'][1]['id']];
+          $name = $data['contact'][1]['display_name'];
+        }
+        $url = Url::fromUri('internal:/civicrm/' . $link, ['query' => $query, 'absolute' => TRUE]);
+        $links[$entity] = Link::fromTextAndUrl(t('View @entity', ['@entity' => $name]), $url)->toRenderable();
       }
     }
+    if (!empty($links)) {
+      $links_markup = '';
+      foreach ($links as $link) {
+        $links_markup .= '<li>' . \Drupal::service('renderer')->renderPlain($link) . '</li>';
+      }
+      $build['civicrm_actions'] = [
+        '#markup' => '<ul class="inline">' . $links_markup . '</ul>',
+        '#weight' => -10,
+      ];
+    }
   }
-  return $actions;
 }
 
 /**

--- a/webform_civicrm.services.yml
+++ b/webform_civicrm.services.yml
@@ -28,3 +28,7 @@ services:
   webform_civicrm.confirmform:
       class: Drupal\webform_civicrm\WebformCivicrmConfirmForm
       arguments: ['@webform_civicrm.utils']
+  webform_civicrm.route_subscriber:
+    class: Drupal\webform_civicrm\WebformCivicrmRouteSubscriber
+    tags:
+      - { name: event_subscriber }


### PR DESCRIPTION
Overview
----------------------------------------
Remove deprecated code and replace it to include civicrm urls (contact, activity, participant, contribution) on submission view page.

Before
----------------------------------------
- View Submission page does not include links to civicrm contact, activity, etc. D7 had those links displayed.
- The module has deprecated D7 code to provide this but it does not work anymore.

After
----------------------------------------
- Contact 1 display name is included at the top.
- Activity, Contribution, etc created during the webform submission is linked on the page.

![• CONTACT INFORMATION](https://user-images.githubusercontent.com/5929648/232310550-f7d3f110-900e-498b-b48c-ba17c0bbf5d3.jpg)


Comments
----------------------------------------
Related Drupal Issue: https://www.drupal.org/project/webform_civicrm/issues/3353059