### PR TITLE
Initialize CiviCRM in _fillCiviCRMData()

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -190,6 +190,7 @@ function _fillCiviCRMData($data, $webformSubmission) {
     return $data;
   }
 
+  \Drupal::service('civicrm')->initialize();
   $utils = \Drupal::service('webform_civicrm.utils');
   $webform = $webformSubmission->getWebform();
   foreach ($data as $key => $val) {


### PR DESCRIPTION
drupal.org issue: [#3355339](https://www.drupal.org/node/3355339)

Overview
----------------------------------------
In some cases viewing results of a CiviCRM webform leads to a `Call to undefined function Drupal\webform_civicrm\civicrm_api3() in Drupal\webform_civicrm\Utils->wf_civicrm_api()` error due to CiviCRM not being initialized yet.

Steps to reproduce
----------------------------------------
Create a Webform with CiviCRM processing enabled, submit it and try to view results. I'm not sure about the specific scenario and don't have the time to investigate as the Webform this appears on is quite large.

Proposed resolution
----------------------------------------
In `_fillCiviCRMData()` there should be a `\Drupal::service('civicrm')->initialize();`, which makes sure we have our global functions available. Re-initializing does not hurt as it early-returns in that case.