### PR TITLE
Add option for tokenised view link in activity details

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -525,6 +525,7 @@ class AdminForm implements AdminFormInterface {
           'entire_result' => t('Include <em>entire</em> webform submission in activity details'),
           'view_link' => t('Include link to <em>view</em> webform submission in activity details'),
           'edit_link' => t('Include link to <em>edit</em> webform submission in activity details'),
+          'view_link_secure' => t('Include secure (tokenised) link to <em>view</em> webform submission in activity details'),
           'update_existing' => t('Update the details when an existing activity is updated'),
         ],
         '#default_value' => wf_crm_aval($this->data, "activity:$n:details", ['view_link'], TRUE),

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1613,7 +1613,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if (!empty($this->data['activity'][$activity_number]['details']['view_link'])) {
       $params['details'] .= '<p>' . $this->submission->toLink(t('View Webform Submission'), 'canonical', [
         'absolute' => TRUE,
-      ])->toString() . '</p>';
+      ])->toString() . '</p>' . \Drupal\Core\Link::fromTextAndUrl('View Webform Submission', $this->submission->getTokenUrl('view'))->toString();
+    }
+    if (!empty($this->data['activity'][$activity_number]['details']['view_link_secure'])) {
+      $params['details'] .= '<p>' . \Drupal\Core\Link::fromTextAndUrl('View Webform Submission', $this->submission->getTokenUrl('view'))->toString() . '</p>';
     }
     if (!empty($this->data['activity'][$activity_number]['details']['edit_link'])) {
       $params['details'] .= '<p>' . $this->submission->toLink(t('Edit Submission'), 'edit-form', [


### PR DESCRIPTION
Overview
----------------------------------------
Individual webform submissions can optionally be accessed via a unique/tokenised link. This adds that option to the activity details - so you can make that link available without having to provide access to all webform submissions.

This allows you to do things like - if you have permission to view the civicrm activity you can click the link to view the webform submission but you can't see other submissions.

Before
----------------------------------------
No tokenised view link

After
----------------------------------------
Tokenised view link is an option

Technical Details
----------------------------------------


Comments
----------------------------------------

