### PR TITLE
D9  - Fix js validation on required checkbox fields

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -31,7 +31,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
         }
         names.organization = names.household = names.first + (names.last ? ' ' : '') + names.last;
         for (i in names) {
-          $(':input[name$="civicrm_'+num+'_contact_1_contact_'+i+'_name"]', formClass).val(names[i]);
+          $(':input[name$="civicrm_' + num + '_contact_1_contact_' + i + '_name"]', formClass).val(names[i]);
         }
       }
       return;
@@ -232,7 +232,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
         pub.initFileField(fid, this);
         return;
       }
-      var $wrapper = $(formClass +' div.form-item[class*="-'+(fid.replace(/_/g, '-'))+'"]');
+      var $wrapper = $(formClass + ' div.form-item[class*="-' + (fid.replace(/_/g, '-')) + '"]');
       if (this.data_type === 'Date') {
         var vals = val.split(' ');
         var $date_el = $('input[name="' + fid + '[date]"]', $wrapper);
@@ -271,8 +271,9 @@ var wfCivi = (function (D, $, drupalSettings, once) {
       // Next go after the wrapper - for radios & checkboxes
       else {
         $.each($.makeArray(val), function(k, v) {
-          $('input[value="'+v+'"]', $wrapper).prop('checked', true).trigger('change', 'webform_civicrm:autofill');
+          $('input[value="' + v + '"]', $wrapper).prop('checked', true).trigger('change', 'webform_civicrm:autofill');
         });
+        $('input[type="checkbox"]:first-child', $wrapper).removeAttr('required');
       }
     });
   }


### PR DESCRIPTION
Overview
----------------------------------------
Incorrect validation submitting webform with mandatory checkboxes

Before
----------------------------------------
If a checkbox field is populated after selecting a contact in the autocomplete field, the required attribute still complains of being required even if an option is checked using ajax.

![image](https://user-images.githubusercontent.com/5929648/236622808-7e93c005-7add-4638-971b-b0a78b6efad0.png)


After
----------------------------------------
Form submits without any validation error.

Technical Details
----------------------------------------
Looks like webform assigns required=required attribute to the first checkbox element. Triggering a change event on the 3rd checkbox does not toggle the required attribute from the first option. Hence removing it separately.

Comments
----------------------------------------
Related drupal ticket - https://www.drupal.org/project/webform_civicrm/issues/3355974