### PR TITLE
Adjust test for receipt subject line fix in core 5.63

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -90,7 +90,13 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $sent_email = $this->getMostRecentEmail();
     $this->assertStringContainsString('From: Pay Laterers <pay.later@example.org>', $sent_email);
     $this->assertStringContainsString('To: Frederick Pabst <fred@example.com>', $sent_email);
-    $this->assertStringContainsString('Subject: Invoice - Contribution - Frederick Pabst', $sent_email);
+    // Adjust for fix in core - since status is now completed, it shouldn't say invoice.
+    if (version_compare(\CRM_Core_BAO_Domain::version(), '5.63.alpha1', '<')) {
+      $this->assertStringContainsString('Subject: Invoice - Contribution - Frederick Pabst', $sent_email);
+    }
+    else {
+      $this->assertStringContainsString('Subject: Receipt - Contribution - Frederick Pabst', $sent_email);
+    }
   }
 
   public function testSubmitContribution() {


### PR DESCRIPTION
Overview
----------------------------------------
In core 5.63 the subject no longer says Invoice when a pay later is completed and the receipt is sent. That sounds correct, so adjust the test to match.