### PR TITLE
When searching for a contact subtype we have to use the 'CONTAINS' op…

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -367,10 +367,19 @@ class ContactComponent implements ContactComponentInterface {
         $filterVal = $contact_element->getElementProperty($component, $filter);
         $this->wf_crm_search_filterArray($filterVal);
         if ($filterVal) {
-          $op = '=';
-          if (in_array($filter, ['group', 'tag'])) {
-            $filter .= 's';
-            $op = 'IN';
+          switch ($filter) {
+            case 'group':
+            case 'tag':
+              $filter .= 's';
+              $op = 'IN';
+              break;
+
+            case 'contact_sub_type':
+              $op = 'CONTAINS';
+              break;
+
+            default:
+              $op = '=';
           }
           $params['where'][] = [$filter, $op, $filterVal];
         }


### PR DESCRIPTION
…erator or it will not find contacts with multiple subtypes

Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/25931

Before
----------------------------------------
Using "existing contact" filter with a contact subtype filter does not find contacts with multiple subtypes.

After
----------------------------------------
Using "existing contact" filter with a contact subtype filter does find contacts with multiple subtypes.

Technical Details
----------------------------------------


Comments
----------------------------------------
