### PR TITLE
D9 - WSOD when editing results and pseudoconstant labels don't match Civi

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2708,6 +2708,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $data = $webform_submission->getData();
     }
     else {
+      $webform_submission = $this->submission;
       $data = $this->submission->getData();
     }
 

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -170,6 +170,19 @@ function webform_civicrm_theme() {
 }
 
 /**
+ * Implements hook_entity_load()
+ * Display entity links on submission page.
+ *
+ * @param array $entities
+ */
+function webform_civicrm_webform_submission_load($entities) {
+  foreach ($entities as $entity) {
+    $data = _fillCiviCRMData($entity->getData(), $entity);
+    $entity->setData($data);
+  }
+}
+
+/**
  * Fill civicrm data to the submission object.
  *
  * @param array $data

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -170,17 +170,6 @@ function webform_civicrm_theme() {
 }
 
 /**
- * Implements hook_entity_load()
- * Display labels for civicrm option element.
- */
-function webform_civicrm_webform_submission_load($entities) {
-  foreach ($entities as $entity) {
-    $data = _fillCiviCRMData($entity->getData(), $entity);
-    $entity->setData($data);
-  }
-}
-
-/**
  * Fill civicrm data to the submission object.
  *
  * @param array $data


### PR DESCRIPTION
Overview
----------------------------------------
WSOD when editing results and pseudoconstant labels don't match Civi

Before
----------------------------------------
Detailed steps to reproduce (embed screenshots)

* Create a form that contains a contact prefix field (Mr., Mrs., etc.).
* On the Build tab, change the prefix field to static options. Also modify the labels. I think it needs to be a Listbox.
* Enter a sample submission.
* Go to Results and edit the submission.
* Go to Edit. Note that the prefix you selected appears twice in the select box.
* Go to Notes and attempt to submit. Get a WSOD.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3363414

FYI - @MegaphoneJon 
