### PR TITLE
fix check for billing email when contributor isn't contact 1

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1846,9 +1846,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $valid = FALSE;
     }
     // Email
-    for ($i = 1; $i <= $this->data['contact'][1]['number_of_email']; ++$i) {
-      if (!empty($this->crmValues["civicrm_1_contact_{$i}_email_email"])) {
-        $c = $this->getContributionContactIndex();
+    $c = $this->getContributionContactIndex();
+    for ($i = 1; $i <= $this->data['contact'][$c]['number_of_email']; ++$i) {
+      if (!empty($this->crmValues["civicrm_{$c}_contact_{$i}_email_email"])) {
         $params['email'] = $this->crmValues["civicrm_{$c}_contact_{$i}_email_email"];
         break;
       }


### PR DESCRIPTION
Overview
----------------------------------------
The check for billing address email still assumes contact 1 is always the contributor.

Steps to replicate:
* Create a webform with two contacts and a contribution.
* Contributor should be contact 2.
* Set "Number of Emails" for contact 1 to 0, and "Number of Emails" for contact 2 to 1 or more.
* Try to submit the payment.

Before
----------------------------------------
Error: `An email address is required to complete this transaction.`

After
----------------------------------------
No error.

Technical Details
----------------------------------------
Not all of the references to contact 1 were replaced by a reference to the contributor contact.