### PR TITLE
apply variants on postProcess

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -76,7 +76,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
 
     $this->node = $webform_submission->getWebform();
-
+    $this->node->applyVariants($webform_submission);
     $handler_collection = $this->node->getHandlers('webform_civicrm');
     $instance_ids = $handler_collection->getInstanceIds();
     $handler = $handler_collection->get(reset($instance_ids));


### PR DESCRIPTION
Don't merge yet - this is to see if it passes tests.

Overview
----------------------------------------
Webform-CiviCRM doesn't account for variants in the postProcess.

Before
----------------------------------------
Variants ignored

After
----------------------------------------
Variants applied.