### PR TITLE
[NFC] Remove unit test line that installs from zip only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,6 @@ jobs:
           composer config extra.compile-mode all
           composer config minimum-stability dev
           composer config prefer-stable true
-          composer config preferred-install dist
           composer config allow-plugins.civicrm/composer-compile-plugin true
           composer config allow-plugins.civicrm/composer-downloads-plugin true
           composer config allow-plugins.civicrm/civicrm-asset-plugin true


### PR DESCRIPTION
Overview
----------------------------------------
I don't think this is needed anymore, and interferes with `git am` lower down.

Before
----------------------------------------
This line makes composer attempt to use the zip download from github first. It means that most of the time the `git am` call will fail. It's not called very often, but is useful.

After
----------------------------------------
Should be no change in terms of what gets tested.

Technical Details
----------------------------------------
Civi used to "guess" at what type of errors and logging to do, and one of the ways it did that was to see if there was a .git folder present. Civi doesn't guess anymore.

Comments
----------------------------------------

