### PR TITLE
[NFC] Unit tests - allow installing from git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
           composer config extra.compile-mode all
           composer config minimum-stability dev
           composer config prefer-stable true
+          composer config preferred-install auto
           composer config allow-plugins.civicrm/composer-compile-plugin true
           composer config allow-plugins.civicrm/composer-downloads-plugin true
           composer config allow-plugins.civicrm/civicrm-asset-plugin true
@@ -96,7 +97,7 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} --prefer-dist -W
+          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} -W
       - name: Ensure Webform ^6.2
         if: ${{ matrix.drupal == '10.0.*' }}
         run: |


### PR DESCRIPTION
Overview
----------------------------------------
Followup to https://github.com/colemanw/webform_civicrm/pull/887

Before
----------------------------------------
Always installs from zip file from github

After
----------------------------------------
Installs from zip when the package is a numbered release, from git clone when it's a `.x-dev` or `dev-master` branch.

Technical Details
----------------------------------------
PR 887 was correct about the part about .git folders, however there are two further pieces of information:
1. There's a specific override in the github workflow line that downloads civi, which I didn't notice.
2. In composer 2.1 they changed the default so that using zips is the default, so in PR 887 removing the line that set it to "dist" actually did nothing since that line has done nothing since composer 2.1.

Setting it to "auto" sets it to "dist" for numbered releases, and "source" for dev installs. This is a good compromise. (Dist is slightly faster, which is why it's the default, but source is needed since otherwise sometimes patches won't apply.)

Comments
----------------------------------------

