### PR TITLE
Add  option to enable public groups on the webform

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1548,6 +1548,9 @@ class AdminForm implements AdminFormInterface {
       if ($field['type'] != 'hidden') {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
+      if ($name == 'group') {
+        $options += ['public_groups' => t('- User Select - (public groups)')];
+      }
       $options += $this->utils->wf_crm_field_options($field, 'config_form', $this->data);
       $item += [
         '#type' => 'select',
@@ -1918,7 +1921,9 @@ class AdminForm implements AdminFormInterface {
         }
         elseif (!isset($enabled[$key])) {
           $val = (array) $val;
-          if (in_array('create_civicrm_webform_element', $val, TRUE) || (!empty($val[0]) && $field['type'] == 'hidden')) {
+          if (in_array('create_civicrm_webform_element', $val, TRUE)
+          || (!empty($val[0]) && $field['type'] == 'hidden')
+          || (preg_match('/_group$/', $key) && in_array('public_groups', $val, TRUE))) {
             // Restore disabled component
             if (isset($disabled[$key])) {
               webform_component_update($disabled[$key]);
@@ -2194,7 +2199,7 @@ class AdminForm implements AdminFormInterface {
     // Find fields to delete
     foreach ($fields as $key => $val) {
       $val = (array) wf_crm_aval($this->settings, $key);
-      if (((in_array('create_civicrm_webform_element', $val, TRUE)) && $this->settings['nid'])
+      if (((in_array('create_civicrm_webform_element', $val, TRUE) || in_array('public_groups', $val, TRUE)) && $this->settings['nid'])
         || strpos($key, 'fieldset') !== FALSE) {
         unset($fields[$key]);
       }

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -67,7 +67,12 @@ class FieldOptions implements FieldOptionsInterface {
         $ret = $utils->wf_crm_get_tags($ent, wf_crm_aval($split, 1));
       }
       elseif (isset($field['table']) && $field['table'] === 'group') {
-        $ret = $utils->wf_crm_apivalues('group', 'get', ['is_hidden' => 0], 'title');
+        $params = ['is_hidden' => 0];
+        $options = wf_crm_aval($data, "contact:$c:other:1:group");
+        if (!empty($options) && !empty($options['public_groups'])) {
+          $params['visibility'] = "Public Pages";
+        }
+        $ret = $utils->wf_crm_apivalues('group', 'get',  $params, 'title');
       }
       elseif ($name === 'survey_id') {
         $ret = $utils->wf_crm_get_surveys(wf_crm_aval($data, "activity:$c:activity:1", []));

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2514,6 +2514,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           }
           if (substr($name, 0, 6) === 'custom' || ($table == 'other' && in_array($name, ['group', 'tag']))) {
             $val = array_filter($val);
+            if ($name === 'group') {
+              unset($val['public_groups']);
+            }
           }
 
           // We need to handle items being de-selected too and provide an array to pass to Entity.create API


### PR DESCRIPTION
Overview
----------------------------------------
Resubmission of https://github.com/colemanw/webform_civicrm/pull/640 with test.

Before
----------------------------------------
https://chat.civicrm.org/civicrm/pl/u9pouzzjcidmbmf3dnmmcuwfsw

>iirc for Webform - currently we have the Groups field we can set to 'user select' but that then puts all groups on show, and one has to manually untick all non-public ones if the goal is to have this field function as a newsletter sign up group - correct? if so, do others see the benefit in having an option in the setting dropdown for eg
user selects (all groups)
user selects (public groups only)
and then hopefully that list would change on the form dynamically as Public Groups were added/removed. thoughts?

After
----------------------------------------
Group field has a new option 

If chosen - only public groups (visibility = public pages) will be loaded on the webform element.

Comments
----------------------------------------
Drupal Ticket = https://www.drupal.org/project/webform_civicrm/issues/3303795