### PR TITLE
D9 - Set default currency on the contribution tab

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1138,7 +1138,7 @@ class AdminForm implements AdminFormInterface {
     $this->form['contribution']['sets']['contribution']['contribution_1_settings_currency'] = [
       '#type' => 'select',
       '#title' => t('Currency'),
-      '#default_value' => wf_crm_aval($this->data, "contribution:1:currency"),
+      '#default_value' => wf_crm_aval($this->data, "contribution:1:currency", $this->utils->wf_crm_get_civi_setting('defaultCurrency')),
       '#options' => \CRM_Core_OptionGroup::values('currencies_enabled'),
       '#required' => TRUE,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Save button does nothing is currency is not set to any value.

Before
----------------------------------------
Currency field is required. If user fails to set it and navigates to another tab (eg Membership) & saves the webform => nothing happens and console returns the following error:

<img width="805" alt="image" src="https://github.com/colemanw/webform_civicrm/assets/5929648/1ed9641d-a02d-4415-82f2-ed36ab28880f">

This is because the Contribution tab is not active on the browser. Saving the form now has required validation error on the invisible field. 

After
----------------------------------------
Default currency is pre-selected.

<img width="371" alt="image" src="https://github.com/colemanw/webform_civicrm/assets/5929648/da16c9d1-806b-4672-abbf-fbcde13f427d">



Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3375985