### PR TITLE
Multi-page webform invalid data with image

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -103,6 +103,14 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     $this->form['#attributes']['data-form-defaults'] = Json::encode($this->getWebformDefaults());
     // Early return if the form (or page) was already submitted
     $triggering_element = $this->form_state->getTriggeringElement();
+
+    // When user uploads a file using a managed_file element, avoid making any change to $this->form.
+    if ($this->form_state->hasFileElement()
+      && is_array($triggering_element['#submit'])
+      && in_array('file_managed_file_submit', $triggering_element['#submit'], TRUE)) {
+      return;
+    }
+
     if ($triggering_element && $triggering_element['#id'] == 'edit-wizard-prev'
       || (empty($this->form_state->isRebuilding()) && !empty($this->form_state->getValues()) && empty($this->form['#submission']->is_draft))
       // When resuming from a draft


### PR DESCRIPTION
Overview
----------------------------------------
Data not submitted when upload image element is present in the multi-page webform setup.

Before
----------------------------------------
When having a multi-step form (with or without preview) and on one of the steps/pages we got a contact image field (file upload field), the submitted data do not keep the other changes but just the contact's image.

See drupal ticket for details - https://www.drupal.org/project/webform_civicrm/issues/3372150

After
----------------------------------------
Data submitted without any issues.

Technical Details
----------------------------------------
When you upload a file using a managed_file element, it involves AJAX requests behind the scenes, which trigger the form alteration hooks.

This patch prevents alterForm method from being called when you upload a file.
 
Comments
----------------------------------------
Drupal Ticket - https://www.drupal.org/project/webform_civicrm/issues/3372150