### PR TITLE
change .removeAttr('checked') to .prop('checked', false) in resetFields

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -174,7 +174,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
             });
             $('.civicrm-remove-file', this).click();
             $('input:checkbox, input:radio', this).each(function() {
-              $(this).removeAttr('checked').trigger('change', 'webform_civicrm:reset');
+              $(this).prop('checked', false).trigger('change', 'webform_civicrm:reset');
             });
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
Addressing this issue:

https://www.drupal.org/project/webform_civicrm/issues/3381559#comment-15198961

Before
----------------------------------------
If you search for an Existing Contact, causing checkboxes to be autofilled, those checkboxes are not unchecked when clicking the 'x' to search for a different contact (full issue description and reproduction steps in the link above).

After
----------------------------------------
Checkboxes are unchecked as appropriate.

Technical Details
----------------------------------------
I haven't understood the second part of the line, I've just assumed that it should be retained:

`.trigger('change', 'webform_civicrm:reset')`

Comments
----------------------------------------
There are other uses of `.removeAttr` in the same file and elsewhere, which may or may not be correct. I haven't looked into changing them because I'm not aware of any specific bug which they might be causing.
