### PR TITLE
fix address sharing with user select

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -348,7 +348,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
 
   function sharedAddress(item, action, speed) {
     var name = parseName($(item).attr('name'));
-    var fields = $(item).parents('form.webform-submission-form').find('[name*="'+(name.replace(/master_id.*$/, ''))+'"').not('[name*=location_type_id]').not('[name*=master_id]').not('[type="hidden"]');
+    var fields = $(item).parents('form.webform-submission-form').find('[name*="'+(name.replace(/master_id.*$/, ''))+'"]').not('[name*=location_type_id]').not('[name*=master_id]').not('[type="hidden"]');
     if (action === 'hide') {
       fields.parent().hide(speed, function() {$(this).css('display', 'none');});
       fields.prop('disabled', true);


### PR DESCRIPTION
Overview
----------------------------------------
PR #753 introduced a syntax error by unintentionally deleting a close square bracket.

To trigger this, you must enable address sharing with user select.  When you select a user, you'll get a syntax error in your JS console.

Before
----------------------------------------
JS broken after selecting address sharing.

After
----------------------------------------
Fixed.

Comments
----------------------------------------
Just a one byte change!
