### PR TITLE
D9 - Set verified checksum contact in the session

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -603,19 +603,7 @@ class Utils implements UtilsInterface {
   }
 
   /**
-   * Wrapper for all CiviCRM APIv4 calls
-   *
-   * @param string $entity
-   *   API entity
-   * @param string $operation
-   *   API operation
-   * @param array $params
-   *   API params
-   * @param string|int|array $index
-   *   Controls the Result array format.
-   *
-   * @return array
-   *   Result of API call
+   * @inheritDoc
    */
   function wf_civicrm_api4($entity, $operation, $params, $index = NULL) {
     if (!$entity) {
@@ -1050,9 +1038,7 @@ class Utils implements UtilsInterface {
         if ($c == 1) {
           $session->set('userID', $cid);
         }
-        else {
-          return TRUE;
-        }
+        return TRUE;
       }
     }
     // If no checksum is passed and user is anonymous, reset prev checksum session values if any.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1102,7 +1102,8 @@ class Utils implements UtilsInterface {
       }
     }
     return FALSE;
-
+  }
+  
   /**
    * @return string Which field is the tag display field in this version of civi?
    */
@@ -1111,7 +1112,6 @@ class Utils implements UtilsInterface {
       return 'label';
     }
     return 'name';
-
   }
 
 }

--- a/src/UtilsInterface.php
+++ b/src/UtilsInterface.php
@@ -347,4 +347,15 @@ interface UtilsInterface {
    */
   function wf_civicrm_api4($entity, $operation, $params, $index = NULL);
 
+  /**
+   * Check if logged in user or the checksum user
+   * is allowed to view a contact.
+   *
+   * @param int $cid
+   *
+   * @return boolean
+   *   TRUE if checksum user is allowed to view $cid.
+   */
+  function isContactAccessible($cid);
+
 }

--- a/src/UtilsInterface.php
+++ b/src/UtilsInterface.php
@@ -318,4 +318,15 @@ interface UtilsInterface {
    */
   function wf_crm_get_civi_setting($setting_name, $default_value = NULL);
 
+  /**
+   * Set checksum user in the session.
+   *
+   * @param int $c
+   * @param int $cid
+   *
+   * @return boolean
+   *   TRUE if checksum is valid.
+   */
+  function checksumUserAccess($c, $cid);
+
 }

--- a/src/UtilsInterface.php
+++ b/src/UtilsInterface.php
@@ -319,6 +319,7 @@ interface UtilsInterface {
   function wf_crm_get_civi_setting($setting_name, $default_value = NULL);
 
   /**
+   * Check if user checksum is available in the URL.
    * Set checksum user in the session.
    *
    * @param int $c
@@ -328,5 +329,22 @@ interface UtilsInterface {
    *   TRUE if checksum is valid.
    */
   function checksumUserAccess($c, $cid);
+
+  /**
+   * Wrapper for all CiviCRM APIv4 calls
+   *
+   * @param string $entity
+   *   API entity
+   * @param string $operation
+   *   API operation
+   * @param array $params
+   *   API params
+   * @param string|int|array $index
+   *   Controls the Result array format.
+   *
+   * @return array|\Civi\Api4\Generic\Result
+   *   Result of API call
+   */
+  function wf_civicrm_api4($entity, $operation, $params, $index = NULL);
 
 }

--- a/tests/modules/webform_civicrm_test/config/install/webform.webform.update_contact_details.yml
+++ b/tests/modules/webform_civicrm_test/config/install/webform.webform.update_contact_details.yml
@@ -66,6 +66,40 @@ elements: |-
           width: 20
         '#parent': civicrm_1_contact_1_fieldset_fieldset
         '#title': Email
+  civicrm_2_contact_1_fieldset_fieldset:
+    '#type': fieldset
+    '#title': 'Contact 2'
+    '#form_key': civicrm_2_contact_1_fieldset_fieldset
+    civicrm_2_contact_1_contact_existing:
+      '#type': civicrm_contact
+      '#title': 'Existing Contact'
+      '#widget': hidden
+      '#none_prompt': '+ Create new +'
+      '#results_display':
+        display_name: display_name
+      '#default': relationship
+      '#default_relationship_to': '1'
+      '#default_relationship':
+        8_b: 8_b
+      '#filter_relationship_contact': '1'
+      '#filter_relationship_types':
+        8_b: 8_b
+      '#allow_create': 1
+      '#contact_type': household
+      '#form_key': civicrm_2_contact_1_contact_existing
+      '#parent': civicrm_2_contact_1_fieldset_fieldset
+      '#extra': {  }
+    civicrm_2_contact_1_contact_household_name:
+      '#type': textfield
+      '#counter_type': character
+      '#counter_maximum': 128
+      '#counter_maximum_message': ' '
+      '#contact_type': household
+      '#form_key': civicrm_2_contact_1_contact_household_name
+      '#extra':
+        width: 20
+      '#parent': civicrm_2_contact_1_fieldset_fieldset
+      '#title': 'Household Name'
   address_information:
     '#type': webform_wizard_page
     '#title': 'Address Information'
@@ -828,9 +862,8 @@ handlers:
     conditions: {  }
     weight: null
     settings:
-      disable: 'Leave Fields and Save Settings'
       nid: 1
-      number_of_contacts: '1'
+      number_of_contacts: '2'
       1_contact_type: individual
       1_webform_label: 'Contact 1'
       civicrm_1_contact_1_contact_contact_sub_type: {  }
@@ -874,6 +907,7 @@ handlers:
       civicrm_1_contact_1_address_country_id: create_civicrm_webform_element
       civicrm_1_contact_1_address_state_province_id: create_civicrm_webform_element
       civicrm_1_contact_1_address_county_id: 0
+      civicrm_1_contact_1_address_master_id: 0
       civicrm_1_contact_1_address_location_type_id: '1'
       civicrm_1_contact_1_address_is_primary: '1'
       contact_1_number_of_phone: '0'
@@ -883,6 +917,30 @@ handlers:
       civicrm_1_contact_1_email_is_primary: '1'
       contact_1_number_of_website: '0'
       contact_1_number_of_im: '0'
+      2_contact_type: household
+      2_webform_label: 'Contact 2'
+      civicrm_2_contact_1_contact_contact_sub_type: {  }
+      civicrm_2_contact_1_contact_existing: create_civicrm_webform_element
+      civicrm_2_contact_1_contact_household_name: create_civicrm_webform_element
+      civicrm_2_contact_1_contact_nick_name: 0
+      civicrm_2_contact_1_contact_preferred_communication_method: 0
+      civicrm_2_contact_1_contact_privacy: 0
+      civicrm_2_contact_1_contact_preferred_language: 0
+      civicrm_2_contact_1_contact_communication_style_id: 0
+      civicrm_2_contact_1_contact_image_url: 0
+      civicrm_2_contact_1_contact_contact_id: 0
+      civicrm_2_contact_1_contact_user_id: 0
+      civicrm_2_contact_1_contact_external_identifier: 0
+      civicrm_2_contact_1_contact_source: 0
+      civicrm_2_contact_1_contact_cs: 0
+      contact_2_settings_matching_rule: Unsupervised
+      contact_2_number_of_other: '0'
+      contact_2_number_of_address: '0'
+      contact_2_number_of_phone: '0'
+      contact_2_number_of_email: '0'
+      contact_2_number_of_website: '0'
+      contact_2_number_of_im: '0'
+      contact_2_number_of_relationship: '0'
       prefix_known: ''
       prefix_unknown: ''
       toggle_message: 0
@@ -904,6 +962,7 @@ handlers:
         disable_unregister: 0
         allow_url_load: 0
       membership_1_number_of_membership: '0'
+      membership_2_number_of_membership: '0'
       civicrm_1_contribution_1_contribution_enable_contribution: '0'
       checksum_text: ''
       create_fieldsets: 1
@@ -935,10 +994,26 @@ handlers:
               1:
                 location_type_id: '1'
                 is_primary: '1'
+          2:
+            contact:
+              1:
+                contact_type: household
+                contact_sub_type: {  }
+                webform_label: 'Contact 2'
+            matching_rule: Unsupervised
+            number_of_other: '0'
+            number_of_address: '0'
+            number_of_phone: '0'
+            number_of_email: '0'
+            number_of_website: '0'
+            number_of_im: '0'
+            number_of_relationship: '0'
         activity:
           number_of_activity: '0'
         membership:
           1:
+            number_of_membership: '0'
+          2:
             number_of_membership: '0'
         participant_reg_type: '0'
         reg_options:

--- a/tests/modules/webform_civicrm_test/config/install/webform.webform.update_contact_details.yml
+++ b/tests/modules/webform_civicrm_test/config/install/webform.webform.update_contact_details.yml
@@ -2,11 +2,11 @@ uuid: null
 langcode: en
 status: open
 dependencies:
+  module:
+    - webform_civicrm
   enforced:
     module:
       - webform_civicrm_test
-  module:
-    - webform_civicrm_test
 weight: 0
 open: null
 close: null
@@ -16,7 +16,7 @@ archive: false
 id: update_contact_details
 title: 'Update Contact Details'
 description: ''
-category: ''
+categories: {  }
 elements: |-
   basic_information:
     '#type': webform_wizard_page
@@ -59,6 +59,13 @@ elements: |-
           width: 20
         '#parent': civicrm_1_contact_1_fieldset_fieldset
         '#title': 'Last Name'
+      civicrm_1_contact_1_email_email:
+        '#type': email
+        '#form_key': civicrm_1_contact_1_email_email
+        '#extra':
+          width: 20
+        '#parent': civicrm_1_contact_1_fieldset_fieldset
+        '#title': Email
   address_information:
     '#type': webform_wizard_page
     '#title': 'Address Information'
@@ -469,12 +476,12 @@ elements: |-
         1111: Kazakhstan
         1112: Kenya
         1113: Kiribati
-        1114: 'Korea, Democratic People''s Republic of'
+        1114: "Korea, Democratic People's Republic of"
         1115: 'Korea, Republic of'
         1251: Kosovo
         1116: Kuwait
         1117: Kyrgyzstan
-        1118: 'Lao People''s Democratic Republic'
+        1118: "Lao People's Democratic Republic"
         1119: Latvia
         1120: Lebanon
         1121: Lesotho
@@ -821,12 +828,12 @@ handlers:
     conditions: {  }
     weight: null
     settings:
+      disable: 'Leave Fields and Save Settings'
       nid: 1
       number_of_contacts: '1'
       1_contact_type: individual
       1_webform_label: 'Contact 1'
-      civicrm_1_contact_1_contact_contact_sub_type:
-        '': ''
+      civicrm_1_contact_1_contact_contact_sub_type: {  }
       civicrm_1_contact_1_contact_existing: create_civicrm_webform_element
       civicrm_1_contact_1_contact_prefix_id: 0
       civicrm_1_contact_1_contact_first_name: create_civicrm_webform_element
@@ -870,17 +877,17 @@ handlers:
       civicrm_1_contact_1_address_location_type_id: '1'
       civicrm_1_contact_1_address_is_primary: '1'
       contact_1_number_of_phone: '0'
-      contact_1_number_of_email: '0'
+      contact_1_number_of_email: '1'
+      civicrm_1_contact_1_email_email: create_civicrm_webform_element
+      civicrm_1_contact_1_email_location_type_id: '1'
+      civicrm_1_contact_1_email_is_primary: '1'
       contact_1_number_of_website: '0'
       contact_1_number_of_im: '0'
-      contact_1_number_of_cg1: '0'
-      contact_1_number_of_cg2: '0'
       prefix_known: ''
       prefix_unknown: ''
       toggle_message: 0
       message: ''
       activity_number_of_activity: '0'
-      case_number_of_case: '0'
       participant_reg_type: '0'
       reg_options:
         event_type:
@@ -898,7 +905,6 @@ handlers:
         allow_url_load: 0
       membership_1_number_of_membership: '0'
       civicrm_1_contribution_1_contribution_enable_contribution: '0'
-      grant_number_of_grant: '0'
       checksum_text: ''
       create_fieldsets: 1
       confirm_subscription: 1
@@ -918,24 +924,22 @@ handlers:
             number_of_other: '0'
             number_of_address: '1'
             number_of_phone: '0'
-            number_of_email: '0'
+            number_of_email: '1'
             number_of_website: '0'
             number_of_im: '0'
-            number_of_cg1: '0'
-            number_of_cg2: '0'
             address:
+              1:
+                location_type_id: '1'
+                is_primary: '1'
+            email:
               1:
                 location_type_id: '1'
                 is_primary: '1'
         activity:
           number_of_activity: '0'
-        case:
-          number_of_case: '0'
         membership:
           1:
             number_of_membership: '0'
-        grant:
-          number_of_grant: '0'
         participant_reg_type: '0'
         reg_options:
           event_type:

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -170,7 +170,11 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'first_name' => 'Pabst',
       'last_name' => 'Anthony',
     ]);
-    $address = $this->utils->wf_civicrm_api('Address', 'create', [
+    $this->utils->wf_civicrm_api('Email', 'create', [
+      'contact_id' => $contact['id'],
+      'email' => "anthony.pabst@example.com",
+    ]);
+    $this->utils->wf_civicrm_api('Address', 'create', [
       'contact_id' => $contact['id'],
       'location_type_id' => "Home",
       'is_primary' => 1,
@@ -180,7 +184,9 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'state_province_id' => "Alberta",
       'postal_code' => 11111,
     ]);
-    $contact_cs = \CRM_Contact_BAO_Contact_Utils::generateChecksum($contact['id']);
+    $contact_cs = $this->utils->wf_civicrm_api4('Contact', 'getChecksum', [
+      'contactId' => $contact['id']
+    ], 0)['checksum'];
 
     $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['cid1' => $contact['id'], 'cs' => $contact_cs]]));
     $this->assertPageNoErrorMessages();
@@ -188,9 +194,11 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     // Check if name fields are pre populated with existing values.
     $this->assertSession()->fieldValueEquals('First Name', $contact['first_name']);
     $this->assertSession()->fieldValueEquals('Last Name', $contact['last_name']);
+    $this->assertSession()->fieldValueEquals('Email', 'anthony.pabst@example.com');
 
-    // Update the last name
+    // Update last name & email
     $this->getSession()->getPage()->fillField('Last Name', 'Morissette');
+    $this->getSession()->getPage()->fillField('Email', 'anthony.pabst1@example.com');
     $this->getSession()->getPage()->pressButton('Next >');
     $this->assertPageNoErrorMessages();
     $canada_id = $this->utils->wf_civicrm_api('Country', 'getvalue', [
@@ -210,10 +218,6 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $this->assertSession()->fieldValueEquals('Postal Code', 11111);
 
     // Change the street & city value in the address fields.
-    $address = [
-      'Street Address' => '123 Defence Colony Updated',
-      'City' => 'Calgary',
-    ];
     $this->getSession()->getPage()->fillField('Street Address', '123 Defence Colony Updated');
     $this->getSession()->getPage()->fillField('City', 'Calgary');
 
@@ -232,6 +236,7 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $expected_values = [
       'first_name' => 'Pabst',
       'last_name' => 'Morissette',
+      'email' => 'anthony.pabst1@example.com',
       'street_address' => "123 Defence Colony Updated",
       'city' => "Calgary",
       'country_id' => $canada_id,

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -184,6 +184,20 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'state_province_id' => "Alberta",
       'postal_code' => 11111,
     ]);
+    $household = $this->createHousehold([
+      'household_name' => 'Anthony Family',
+    ]);
+    // Add relationship b/w the above 2 contacts and ensure
+    // contact has ability to view the household.
+    $this->utils->wf_civicrm_api4('Relationship', 'create', [
+      'values' => [
+        'contact_id_a' => $contact['id'],
+        'relationship_type_id:name' => 'Household Member of',
+        'contact_id_b' => $household['id'],
+        'is_permission_a_b' => 2,
+      ],
+    ]);
+
     $contact_cs = $this->utils->wf_civicrm_api4('Contact', 'getChecksum', [
       'contactId' => $contact['id']
     ], 0)['checksum'];
@@ -195,6 +209,9 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
     $this->assertSession()->fieldValueEquals('First Name', $contact['first_name']);
     $this->assertSession()->fieldValueEquals('Last Name', $contact['last_name']);
     $this->assertSession()->fieldValueEquals('Email', 'anthony.pabst@example.com');
+
+    // Verify if relationship contact is loaded on the form.
+    $this->assertSession()->fieldValueEquals('Household Name', 'Anthony Family');
 
     // Update last name & email
     $this->getSession()->getPage()->fillField('Last Name', 'Morissette');

--- a/tests/src/Unit/UtilsTest.php
+++ b/tests/src/Unit/UtilsTest.php
@@ -5,6 +5,7 @@ namespace Drupal\Tests\webform_civicrm\Unit;
 use Drupal\Tests\UnitTestCase;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
 use Drupal\webform_civicrm\Utils;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * @group webform_civicrm
@@ -12,8 +13,11 @@ use Drupal\webform_civicrm\Utils;
 class UtilsTest extends UnitTestCase {
 
   public function testWfCrmExplodeKey() {
-    $utils = new Utils();
+    $requestStack = new RequestStack();
     $container = new ContainerBuilder();
+    $container->set('request_stack', $requestStack);
+    $utils = new Utils($requestStack);
+    // Set the container for Drupal::service to work correctly.
     \Drupal::setContainer($container);
     $container->set('webform_civicrm.utils', $utils);
 

--- a/webform_civicrm.services.yml
+++ b/webform_civicrm.services.yml
@@ -1,6 +1,7 @@
 services:
   webform_civicrm.utils:
     class: Drupal\webform_civicrm\Utils
+    arguments: ['@request_stack']
   webform_civicrm.fields:
     class: Drupal\webform_civicrm\Fields
     arguments: ['@webform_civicrm.utils']


### PR DESCRIPTION
Overview
----------------------------------------
Grant CiviCRM permissions to the verified checksum contact

Before
----------------------------------------
Webform loaded with checksum contact is not able to view related contacts, etc. 

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Set verified checksum contact in the session and ensure its removed when loaded anonymously without cs.

Comments
----------------------------------------
@KarinG 