### PR TITLE
Don't overwrite existing soft credits

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2317,13 +2317,12 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       }
     }
     // Save honoree
-    // FIXME: these api params were deprecated in 4.5, should be switched to use soft-credits when we drop support for 4.4
     if (!empty($contribution['honor_contact_id']) && !empty($contribution['honor_type_id'])) {
-      $this->utils->wf_civicrm_api('contribution', 'create', [
-        'id' => $id,
-        'total_amount' => $contribution['total_amount'],
-        'honor_contact_id' => $contribution['honor_contact_id'],
-        'honor_type_id' => $contribution['honor_type_id'],
+      $this->utils->wf_civicrm_api('contribution_soft', 'create', [
+        'contribution_id' => $id,
+        'amount' => $contribution['total_amount'],
+        'contact_id' => $contribution['honor_contact_id'],
+        'soft_credit_type_id' => $contribution['honor_type_id'],
       ]);
     }
 


### PR DESCRIPTION
Overview
----------------------------------------
If you have an extension that adds a soft credit to contributions on the contribution's `post` hook (e.g. [Automatic Soft Credits](https://civicrm.org/extensions/automatic-soft-credits), and you have "in honor/memory" enabled on your webform, your existing soft credit will be overwritten.

Before
----------------------------------------
One soft credit (from the webform)

After
----------------------------------------
Both soft credits.

Comments
----------------------------------------
I'm implementing the comment that says "switch this to soft credits when we drop support for 4.4" :slightly_smiling_face: .  In doing so, we fix a bug - the original code was written before you could have multiple soft credits.