### PR TITLE
D8/9 - Enable HTML on autocomplete field

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -14,7 +14,8 @@
             hintText: field.data('search-prompt'),
             noResultsText: field.data('none-prompt'),
             resultsFormatter: formatChoices,
-            searchingText: "Searching..."
+            searchingText: "Searching...",
+            enableHTML: true
           };
           wfCivi.existingInit(
             field,


### PR DESCRIPTION
Overview
----------------------------------------
Apostrophe displays as `&#039` on the autocomplete field - https://www.drupal.org/project/webform_civicrm/issues/3300150

Before
----------------------------------------
<img width="518" alt="image" src="https://github.com/colemanw/webform_civicrm/assets/5929648/1f3a2d6a-d2c1-44f9-af33-bb957a178a5c">

After
----------------------------------------
<img width="518" alt="image" src="https://github.com/colemanw/webform_civicrm/assets/5929648/d4c997e4-9b23-47c3-b778-3818f0412688">

Technical Details
----------------------------------------
Enable HTML on tokeninput.

Comments
----------------------------------------
Drupal ticket - https://www.drupal.org/project/webform_civicrm/issues/3300150