### PR TITLE
Fix for php8

### DIFF
--- a/includes/contact_component.inc
+++ b/includes/contact_component.inc
@@ -498,7 +498,7 @@ function _webform_render_civicrm_contact($component, $value = NULL, $filter = TR
         $js = "$onChange wfCivi.existingInit(field, $c, {$node->nid}, $callback_path, toHide);";
       }
       // Display empty option unless there are no results
-      if (!$component['extra']['allow_create'] || count($element['#options']) > 1) {
+      if (!$component['extra']['allow_create'] || (!empty($element['#options']) && is_array($element['#options']) && count($element['#options']) > 1)) {
         $element['#empty_option'] = $component['extra'][$element['#options'] ? 'search_prompt' : 'none_prompt'];
       }
 


### PR DESCRIPTION

Overview
----------------------------------------
Fix for php8, similar to https://github.com/colemanw/webform_civicrm/pull/795.

Before
----------------------------------------
TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given in _webform_render_civicrm_contact()

After
----------------------------------------
No error

Technical Details
----------------------------------------


Comments
----------------------------------------

