### PR TITLE
D9/10 - Add setting to disable primary participant for Contact 1

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -938,9 +938,15 @@ class AdminForm implements AdminFormInterface {
       '#title' => t('Allow events to be autoloaded from URL'),
       '#default_value' => (bool) wf_crm_aval($this->data, 'reg_options:allow_url_load'),
     ];
+    $this->form['participant']['reg_options']['disable_primary_participant'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Disable Contact 1 to be stored as Primary Participant'),
+      '#default_value' => (bool) wf_crm_aval($this->data, 'reg_options:disable_primary_participant'),
+    ];
     $this->help($this->form['participant']['reg_options']['block_form'], 'reg_options_block_form');
     $this->help($this->form['participant']['reg_options']['disable_unregister'], 'reg_options_disable_unregister');
     $this->help($this->form['participant']['reg_options']['allow_url_load'], 'reg_options_allow_url_load');
+    $this->help($this->form['participant']['reg_options']['disable_primary_participant'], 'reg_options_disable_primary_participant');
     $this->addAjaxItem('participant', 'participant_reg_type', 'participants');
     $this->addAjaxItem('participant', 'event_type', 'participants');
     $this->addAjaxItem('participant', 'show_past_events', 'participants');

--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -269,6 +269,15 @@ class AdminHelp implements AdminHelpInterface {
       '/{node.nid}?c1event1={event1.event_id},{event2.event_id}&amp;c2event1={event3.event_id}</code></p>';
   }
 
+  /**
+   * Help text for disable primary setting.
+   */
+  protected function reg_options_disable_primary_participant() {
+    return '<p>' .
+      t('If enabled, Contact 1 will not be stored as primary participant for multiple registrations.') .
+      '</p>';
+  }
+
   protected function reg_options_show_past_events() {
     return '<p>' .
       t('To also display events that have ended, choose an option for how far in the past to search.') .

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1190,7 +1190,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
                 unset($params['status_id']);
               }
               // Set the currency of the result to the currency type that was submitted.
-              $params['fee_currency'] = $this->data['contribution'][$n]['currency'];
+              if (isset($this->data['contribution'][$n]['currency'])) {
+                $params['fee_currency'] = $this->data['contribution'][$n]['currency'];
+              }
               $result = $this->utils->wf_civicrm_api('participant', 'create', $params);
               $this->ent['participant'][$n]['id'] = $result['id'];
 
@@ -1205,7 +1207,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
                 }
               }
               // When registering contact 1, store id to apply to other contacts
-              if ($c == 1) {
+              if ($c == 1 && empty($this->data['reg_options']['disable_primary_participant'])) {
                 $registered_by_id[$e][$i] = $result['id'];
               }
             }


### PR DESCRIPTION
Overview
----------------------------------------
Add setting to disable storage of registered_by_id on multiple participant registration.

Before
----------------------------------------
If multiple contacts are registered to an event using webform, contact 1 pid is stored as registered_by_id for all other participant records.

After
----------------------------------------
Config introduced to make this optional.

<img width="632" alt="image" src="https://github.com/colemanw/webform_civicrm/assets/5929648/11bd677d-a2cd-49e0-8493-3e5d26bbc1e4">

If enabled, all participants created on webform submission will be stored as normal participant records instead of being secondary records with primary as Contact 1.


Comments
----------------------------------------
@KarinG 