### PR TITLE
(alternate to 913) Temp unit test update for IATS to handle differences in versions

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -381,7 +381,12 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     // Wait for the ACHEFT form to load in.
     $this->assertSession()->waitForField('account_holder');
     $this->getSession()->getPage()->fillField('Account Holder', 'CiviCRM user');
-    $this->getSession()->getPage()->fillField('Bank Account Number', '12345678');
+    // remove this if block and use the first version after next IATS release
+    if (version_compare(\Drupal::VERSION, '10', '>=')) {
+      $this->getSession()->getPage()->fillField('Account No.', '12345678');
+    } else {
+      $this->getSession()->getPage()->fillField('Bank Account Number', '12345678');
+    }
     $this->getSession()->getPage()->fillField('Bank Identification Number', '111111111');
     $this->getSession()->getPage()->fillField('Bank Name', 'Bank of CiviCRM');
     $this->getSession()->getPage()->selectFieldOption('bank_account_type', 'Savings');


### PR DESCRIPTION
Overview
----------------------------------------
Alternate to #913 

The field label is different in the git version of IATS, which is installed during drupal 10 runs but not during drupal 9 runs.

Before
----------------------------------------
Bank Account Number

After
----------------------------------------
Account No.

Technical Details
----------------------------------------
The drupal 10 run installs git versions of extensions, whereas drupal 9 installs released versions, and this label changed recently in iats master.

Comments
----------------------------------------
The reason that drupal 10 and 9 do different things is because when drupal 10 was first added to the test matrix, the various extensions didn't support drupal 10 in their released versions, so an alternate would be to take another look at whether the extensions used in tests are all now supporting drupal 10 in their released versions, and then remove that difference. Although it's kind of nice testing with the additional variation to get advance warning of extension issues. 🤷 

Another alternate specifically for this label issue would be a more sophisticated `if` block which looks at which version of iats got installed but it's not straightforward, and would still be temporary.