### PR TITLE
Allow title display of static contact element to be invisible or none

### DIFF
--- a/templates/webform-civicrm-contact.html.twig
+++ b/templates/webform-civicrm-contact.html.twig
@@ -17,8 +17,8 @@
  */
 #}
 <div{{ title_attributes }}>
-{% if attributes['type'] == 'hidden' and attributes['title'] %}
-  <label><b>{{ attributes['title'] }}</b></label>
+{% if attributes['type'] == 'hidden' and attributes['title'] and element['#title_display'] != 'none' %}
+  <label{% if element['#title_display'] == 'invisible' %} hidden{% endif %}><b>{{ attributes['title'] }}</b></label>
 {% endif %}
 
 {% if description_display == 'before' and description.content %}


### PR DESCRIPTION
Overview
----------------------------------------
This twig template change enables the expected behaviour of setting the element Title Display to 'invisible' or 'none'.

Before
----------------------------------------
If you create a webform with a CiviCRM Contact element, set the Form Widget to Static, and set the Title Display for that element to 'invisible' or 'none', the Title is still displayed.

After
----------------------------------------
Setting the Title Display to `'invisible'` will result in the label gaining the `hidden` attribute. Setting the Title Display to `'none'` will omit the label from the output.

Technical Details
----------------------------------------
This changes two lines of the Twig template, adding to one existing conditional so the label will be omitted if the `#title_display` is `'none'`, and then adding a new conditional to decide whether the label should get the `hidden` attribute.
