### PR TITLE
Allow manually running unit tests against a drupal 8 civi PR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ on:
       coreprurl:
         description: (optional) Core PR URL
         required: false
+      drupal8prurl:
+        description: (optional) Drupal 8 PR URL
+        required: false
 
 jobs:
   phpunit:
@@ -134,6 +137,12 @@ jobs:
         run: |
           cd  ~/drupal/vendor/civicrm/civicrm-core
           curl -L -o prpatch.patch ${{ github.event.inputs.coreprurl }}.patch
+          git am prpatch.patch
+      - name: Optionally Apply Drupal 8 PR
+        if: ${{ github.event.inputs.drupal8prurl != 0 }}
+        run: |
+          cd  ~/drupal/web/modules/contrib/civicrm
+          curl -L -o prpatch.patch ${{ github.event.inputs.drupal8prurl }}.patch
           git am prpatch.patch
       - name: Do a fake temp install
         # so that we can use civi api to get extensions with a version appropriate to the installed civi version


### PR DESCRIPTION
Overview
----------------------------------------
There's already the ability to do this for a core PR. This extends it to allow doing it on a PR from the https://github.com/civicrm/civicrm-drupal-8 repo.

Before
----------------------------------------
can't (easily)

After
----------------------------------------
can (easily)

Technical Details
----------------------------------------


Comments
----------------------------------------
I've already run this on one in my own fork, which is always another way to do this kind of thing, but it's convenient to have it in the workflow dropdown here.