### PR TITLE
remove WFC 4.x-era test mode workaround

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2245,27 +2245,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         $params[$key] = $value;
       }
     }
-
-    // Fix bug for testing.
-    // @todo Pay Later causes issues as it returns `0`.
-    if ($params['is_test'] == 1 && $params['payment_processor_id'] !== '0') {
-      $liveProcessorName = $this->utils->wf_civicrm_api('payment_processor', 'getvalue', [
-        'id' => $params['payment_processor_id'],
-        'return' => 'name',
-      ]);
-      // Lookup current domain for multisite support
-      static $domain = 0;
-      if (!$domain) {
-        $domain = $this->utils->wf_civicrm_api('domain', 'get', ['current_domain' => 1, 'return' => 'id']);
-        $domain = wf_crm_aval($domain, 'id', 1);
-      }
-      $params['payment_processor_id'] = $this->utils->wf_civicrm_api('payment_processor', 'getvalue', [
-        'return' => 'id',
-        'name' => $liveProcessorName,
-        'is_test' => 1,
-        'domain_id' => $domain,
-      ]);
-    }
     if (empty($params['payment_instrument_id']) && !empty($params['payment_processor_id'])) {
       $params['payment_instrument_id'] = $this->getPaymentInstrument($params['payment_processor_id']);
     }


### PR DESCRIPTION
Overview
----------------------------------------
This code dates to when WFC forms required a matching Civi-native contribution page.

Given a payment processor with ID 1 and the corresponding test processor with ID 2:
* `civicrm_contribution_page` always stores the ID of 1, because test mode is set in the URL.
* WFC stores the *actual* payment processor ID.

But in the old days, we inherited the ID from the native page, so WFC would get a 1, even in test mode.

This code looked up the test processor ID - but that's no longer necessary.  We now store the correct ID.

Before
----------------------------------------
Code to look up the correct ID, which we already have.

After
----------------------------------------
We use the correct ID.

Comments
----------------------------------------
If it makes the reviewer feel better, all this code is wrapped in an `if` so it only fires in test mode.  This can't affect live mode.