### PR TITLE
D9 - Fix autocomplete search if contact id plus display fields are selected

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -142,6 +142,9 @@ class ContactComponent implements ContactComponentInterface {
     if ($str) {
       $searchFields = [];
       foreach ($display_fields as $fld) {
+        if ($fld == 'id' && !is_numeric($str)) {
+          continue;
+        }
         $searchFields[] = [$fld, 'CONTAINS', $str];
       }
       $params['where'][] = ['OR', $searchFields];


### PR DESCRIPTION
Overview
----------------------------------------
Autocomplete search broken if Contact ID plus other Contact Display Fields are selected

Before
----------------------------------------
See drupal ticket - https://www.drupal.org/project/webform_civicrm/issues/3396214

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Ignore contact id while searching for string values.

