### PR TITLE
D9 - Load current employer relationship on the existing contact field

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -281,13 +281,13 @@ class ContactComponent implements ContactComponentInterface {
         // Put current employer first in the list
         if ($type == $employer_type && $current) {
           $search_key = $a == 'b' ? 'id' : 'employer_id';
-          // Note: inconsistency in api3 - search key is "employer_id" but return key is "current_employer_id"
-          $employer = $this->utils->wf_crm_apivalues('contact', 'get', [
-            $search_key => $cid,
-            'sequential' => 1,
-          ], $a == 'b' ? 'current_employer_id' : 'id');
+          $employer = $this->utils->wf_civicrm_api4('Contact', 'get', [
+            'where' => [
+              [$search_key, '=', $cid],
+            ],
+          ])->first()[$a == 'b' ? 'employer_id' : 'id'] ?? NULL;
           if ($employer) {
-            $found[$employer[0]] = $employer[0];
+            $found[$employer] = $employer;
           }
         }
         $type_ids[] = $type;


### PR DESCRIPTION
Overview
----------------------------------------
Load current employer relationship if more than 1 employee of relationship exist on the individual contact.

Before
----------------------------------------
To replicate:

- Create a civicrm contact with current employer = OrgA.
- Add a new relationship for employee of and select Org B with current employer = 1.
- Individual now has 2 employee of relationship with OrgB as the latest and current.

- Create a webform with 2 contacts - Individual & organization. Enable `existing contact` field on both.
- Edit the existing contact field for second contact organization and default it to relationship => employer of Contact 1.
- Load the contact with cid1 = individual contact id.
- The org contact is loaded with OrgA contact value (instead of the latest OrgB).

After
----------------------------------------
Api3 is replaced by api4 call to prioritise current employer to list on the top.
