### PR TITLE
Fix problem with setting do_not_notify_assignees_for

### DIFF
--- a/includes/wf_crm_webform_postprocess.inc
+++ b/includes/wf_crm_webform_postprocess.inc
@@ -1450,7 +1450,7 @@ class wf_crm_webform_postprocess extends wf_crm_webform_base {
             $this->processAttachments('activity', $n, $activity['id'], empty($params['id']));
           }
           if (!empty($params['assignee_contact_id'])) {
-            if (wf_crm_get_civi_setting('activity_assignee_notification')) {
+            if (wf_crm_get_civi_setting('activity_assignee_notification') && !in_array($params['activity_type_id'], wf_crm_get_civi_setting('do_not_notify_assignees_for'))) {
               // Send email to assignees. TODO: Move to CiviCRM API?
               $assignees = wf_crm_apivalues('contact', 'get', [
                 'id' => ['IN' => (array) $params['assignee_contact_id']],


### PR DESCRIPTION
Overview
----------------------------------------
Module does not respect setting from CiviCRM Admin "Do not notify assignees for"

Before
----------------------------------------
If You select any type of activity in CiviCRM Admin Setting -> Display Setting -> Do not notify assignees for it will won't respect it.

![Screenshot from 2023-11-24 22-01-01](https://github.com/colemanw/webform_civicrm/assets/5382898/d6bb1a48-42cc-471f-a819-8c585f6e1432)

After
----------------------------------------
Excludes selected activities from sending notify

Technical Details
----------------------------------------
Simple missing if on settings

