### PR TITLE
D9 - Replace group usage with crmgroup to avoid inconsistency with drupal #group

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\webform_civicrm;
 
-
 use Drupal\Core\Session\AnonymousUserSession;
 use Drupal\webform\Entity\Webform;
 use Drupal\Component\Render\FormattableMarkup;
@@ -1573,7 +1572,7 @@ class AdminForm implements AdminFormInterface {
       if ($field['type'] != 'hidden') {
         $options += ['create_civicrm_webform_element' => t('- User Select -')];
       }
-      if ($name == 'group') {
+      if ($name == 'crmgroup') {
         $options += ['public_groups' => t('- User Select - (public groups)')];
       }
       $options += $this->utils->wf_crm_field_options($field, 'config_form', $this->data);
@@ -1948,7 +1947,7 @@ class AdminForm implements AdminFormInterface {
           $val = (array) $val;
           if (in_array('create_civicrm_webform_element', $val, TRUE)
           || (!empty($val[0]) && $field['type'] == 'hidden')
-          || (preg_match('/_group$/', $key) && in_array('public_groups', $val, TRUE))) {
+          || (preg_match('/_crmgroup$/', $key) && in_array('public_groups', $val, TRUE))) {
             // Restore disabled component
             if (isset($disabled[$key])) {
               webform_component_update($disabled[$key]);

--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -339,7 +339,7 @@ class ContactComponent implements ContactComponentInterface {
       'contact_type',
       'contact_sub_type',
       'tag',
-      'group',
+      'crmgroup',
       'relationship' => [
         'contact',
         'types',
@@ -365,9 +365,13 @@ class ContactComponent implements ContactComponentInterface {
         $this->wf_crm_search_filterArray($filterVal);
         if ($filterVal) {
           switch ($filter) {
-            case 'group':
+            case 'crmgroup':
+              $filter = 'groups';
+              $op = 'IN';
+              break;
+
             case 'tag':
-              $filter .= 's';
+              $filter = 'tags';
               $op = 'IN';
               break;
 

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -68,7 +68,7 @@ class FieldOptions implements FieldOptionsInterface {
       }
       elseif (isset($field['table']) && $field['table'] === 'group') {
         $params = ['is_hidden' => 0];
-        $options = wf_crm_aval($data, "contact:$c:other:1:group");
+        $options = wf_crm_aval($data, "contact:$c:other:1:crmgroup");
         if (!empty($options) && !empty($options['public_groups'])) {
           $params['visibility'] = "Public Pages";
         }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -450,7 +450,7 @@ class Fields implements FieldsInterface {
         'type' => 'select',
         'expose_list' => TRUE,
       ];
-      $fields['other_group'] = [
+      $fields['other_crmgroup'] = [
         'name' => t('Group(s)'),
         'type' => 'select',
         'civicrm_live_options' => 1,

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -62,7 +62,7 @@ class CivicrmContact extends WebformElementBase {
         'filter_relationship_types' => [],
         'filter_relationship_contact' => [],
         'contact_sub_type' => '',
-        'group' => [],
+        'crmgroup' => [],
         'tag' => [],
         'check_permissions' => 1,
         // Set for custom fields.
@@ -81,15 +81,6 @@ class CivicrmContact extends WebformElementBase {
     \Drupal::service('civicrm')->initialize();
     $element['#form_key'] = $element['#form_key'] ?? $element['#webform_key'];
 
-    // Avoid call to Drupal\Core\Render\Element\RenderElement::processGroup() as this module uses the
-    // 'group' property key to filter the contacts loaded in the autocomplete field.
-    if ($element['#widget'] === 'autocomplete') {
-      $element['#process'] = [
-        ['Drupal\Core\Render\Element\Textfield', 'processAutocomplete'],
-        ['Drupal\Core\Render\Element\Textfield', 'processAjaxForm'],
-        ['Drupal\Core\Render\Element\Textfield', 'processPattern'],
-      ];
-    }
     // Webform removes values which equal their defaults but does not populate
     // they keys.
     $ensure_keys_have_values = [
@@ -391,12 +382,12 @@ class CivicrmContact extends WebformElementBase {
         '#default_value' => $element_properties['contact_sub_type'],
       ];
     }
-    $form['filters']['group'] = [
+    $form['filters']['crmgroup'] = [
       '#type' => 'select',
       '#multiple' => TRUE,
       '#title' => $this->t('Groups'),
       '#options' => ['' => '- ' . $this->t('None') . ' -'] + $utils->wf_crm_apivalues('group_contact', 'getoptions', ['field' => 'group_id']),
-      '#default_value' => $element_properties['group'],
+      '#default_value' => $element_properties['crmgroup'],
       '#description' => $this->t('Listed contacts must be members of at least one of the selected groups (leave blank to not filter by group).'),
     ];
     $form['filters']['tag'] = [
@@ -649,10 +640,7 @@ class CivicrmContact extends WebformElementBase {
       $args = [
         '%name' => empty($element['#title']) ? $element['#parents'][0] : $element['#title'],
       ];
-      // Avoid error while calling form_state which expects '#group' as a string value :(.
-      $static_element = $element;
-      unset($static_element['#group']);
-      $form_state->setError($static_element, t('%name field is required.', $args));
+      $form_state->setError($element, t('%name field is required.', $args));
     }
   }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -214,6 +214,7 @@ abstract class WebformCivicrmBase {
         if (strpos($fid, $prefix . 'other') !== FALSE) {
           [, , , , , $ent] = explode('_', $fid);
           [, , , , , $field] = explode('_', $fid, 6);
+          $ent = ($ent === 'crmgroup') ? 'group' : $ent;
           // Cheap way to avoid fetching the same data twice from the api
           if (!is_array($api[$ent])) {
             $api[$ent] = $this->utils->wf_civicrm_api($api[$ent], 'get', ['contact_id' => $cid]);

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2528,9 +2528,9 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           if (!empty($this->data[$ent][$c][$table][$n][$name]) && is_array($this->data[$ent][$c][$table][$n][$name])) {
             $val = array_unique(array_merge($val, $this->data[$ent][$c][$table][$n][$name]));
           }
-          if (substr($name, 0, 6) === 'custom' || ($table == 'other' && in_array($name, ['group', 'tag']))) {
+          if (substr($name, 0, 6) === 'custom' || ($table == 'other' && in_array($name, ['crmgroup', 'tag']))) {
             $val = array_filter($val);
-            if ($name === 'group') {
+            if ($name === 'crmgroup') {
               unset($val['public_groups']);
             }
           }

--- a/tests/src/FunctionalJavascript/ContactSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/ContactSubmissionTest.php
@@ -80,7 +80,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Autocomplete',
       'filter' => [
-        'group' => $this->group['id'],
+        'crmgroup' => $this->group['id'],
       ],
     ];
     $this->editContactElement($editContact);
@@ -123,7 +123,7 @@ final class ContactSubmissionTest extends WebformCivicrmTestBase {
       'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
       'widget' => 'Select List',
       'filter' => [
-        'group' => $this->group['id'],
+        'crmgroup' => $this->group['id'],
       ],
     ];
     $this->editContactElement($editContact);

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -49,7 +49,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     // Enable Groups Field and then set it to -User Select (Public Group)-
     $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_other', 'Yes');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption("civicrm_1_contact_1_other_group[]", 'public_groups');
+    $this->getSession()->getPage()->selectFieldOption("civicrm_1_contact_1_other_crmgroup[]", 'public_groups');
     $this->htmlOutput();
     $this->saveCiviCRMSettings();
 
@@ -85,7 +85,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     // Enable Tags and Groups Fields and then set Tag(s) to -User Select-
     $this->getSession()->getPage()->selectFieldOption('contact_1_number_of_other', 'Yes');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->selectFieldOption("civicrm_1_contact_1_other_group[]", 'create_civicrm_webform_element');
+    $this->getSession()->getPage()->selectFieldOption("civicrm_1_contact_1_other_crmgroup[]", 'create_civicrm_webform_element');
     $this->getSession()->getPage()->selectFieldOption("civicrm_1_contact_1_other_tag[]", 'create_civicrm_webform_element');
     $this->htmlOutput();
     $this->saveCiviCRMSettings();
@@ -94,7 +94,7 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
 
     // Change type of group field to checkbox.
-    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-other-group-operations', FALSE, FALSE, NULL, 'checkboxes');
+    $this->editCivicrmOptionElement('edit-webform-ui-elements-civicrm-1-contact-1-other-crmgroup-operations', FALSE, FALSE, NULL, 'checkboxes');
 
     $majorDonorTagID = $this->utils->wf_civicrm_api('Tag', 'get', [
       'name' => (version_compare(\CRM_Core_BAO_Domain::version(), '5.68.alpha1', '<') ? "Major Donor" : "Major_Donor"),

--- a/tests/src/FunctionalJavascript/LocationTypeTest.php
+++ b/tests/src/FunctionalJavascript/LocationTypeTest.php
@@ -127,7 +127,7 @@ final class LocationTypeTest extends WebformCivicrmTestBase {
       'widget' => 'Autocomplete',
       'hide_fields' => 'address',
       'filter' => [
-        'group' => '- None -',
+        'crmgroup' => '- None -',
       ],
     ];
     $this->editContactElement($editContact);

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -511,7 +511,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    *     'widget' => 'Static',
    *     'default' => 'relationship',
    *     'filter' => [
-   *        'group' => group_id,
+   *        'crmgroup' => group_id,
    *      ],
    *     'default_relationship' => [
    *       'default_relationship_to' => 'Contact 3',
@@ -591,8 +591,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     // Apply contact filter.
     if (!empty($params['filter'])) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-filters"]')->click();
-      if (!empty($params['filter']['group'])) {
-        $this->getSession()->getPage()->selectFieldOption('Groups', $params['filter']['group']);
+      if (!empty($params['filter']['crmgroup'])) {
+        $this->getSession()->getPage()->selectFieldOption('Groups', $params['filter']['crmgroup']);
       }
       if (!empty($params['filter']['filter_relationship_types'])) {
         $this->getSession()->getPage()->selectFieldOption('properties[filter_relationship_types][]', $params['filter']['filter_relationship_types']);

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -443,3 +443,79 @@ function webform_civicrm_update_8007() {
     }
   }
 }
+
+/**
+ * Replace element with a new element key.
+ */
+function _recursiveKeyReplace(array &$elements, $searchKey, $replacementKey) {
+  foreach ($elements as $key => &$value) {
+    if ($key === $searchKey) {
+      $keys = array_keys($elements);
+      $index = array_search($key, $keys, true);
+      if ($index !== false) {
+        array_splice($keys, $index, 1, $replacementKey);
+        $elements = array_combine($keys, array_values($elements));
+      }
+    }
+    elseif (is_array($value)) {
+      _recursiveKeyReplace($value, $searchKey, $replacementKey);
+    }
+  }
+}
+
+/**
+ * Update usage of group to crmgroup
+ */
+function webform_civicrm_update_8008() {
+  $webforms = Webform::loadMultiple();
+
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    $elements = $webform->getElementsDecodedAndFlattened();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $settings = &$config['webform_civicrm']['settings'];
+    foreach ($elements as $key => $value) {
+      [$civifield] = explode('_', $key);
+      if ($civifield != 'civicrm') {
+        continue;
+      }
+      if (preg_match('/_contact_existing$/', $key)) {
+        $element = $webform->getElement($key);
+        if (isset($element['#group'])) {
+          $element['#crmgroup'] = $element['#group'];
+          unset($element['#group']);
+          $webform->setElementProperties($key, $element);
+        }
+      }
+      if (preg_match('/_other_group$/', $key)) {
+        $element = $webform->getElement($key);
+        $new_key = str_replace('_other_group', '_other_crmgroup', $key);
+        $element['#form_key'] = $element['#webform_key'] = $new_key;
+        if (isset($element['#webform_id'])) {
+          $element['#webform_id'] = str_replace('_other_group', '_other_crmgroup', $element['#webform_id']);
+        }
+        if (isset($element['#webform_parents']) && is_array($element['#webform_parents'])) {
+          foreach ($element['#webform_parents'] as $k => $v) {
+            $element['#webform_parents'][$k] = str_replace('_other_group', '_other_crmgroup', $v);
+          }
+        }
+        if (isset($settings[$key])) {
+          $settings[$new_key] = $settings[$key];
+          unset($settings[$key]);
+        }
+
+        // Place element at the correct position.
+        $elements = $webform->getElementsDecoded();
+        _recursiveKeyReplace($elements, $key, $new_key);
+        $webform->setElements($elements);
+
+        $webform->setElementProperties($new_key, $element);
+      }
+    }
+    $handler->setConfiguration($config);
+    $webform->save();
+  }
+}


### PR DESCRIPTION
Overview
----------------------------------------
Existing Contact can have validation error when filtered by group

Before
----------------------------------------
Existing Contact can have validation error when filtered by group

After
----------------------------------------
No error.

Technical Details
----------------------------------------
Implements the longer approach from https://github.com/colemanw/webform_civicrm/pull/619#issue-1013204079

Replace `group` usage with `crmgroup` to avoid inconsistency with drupal `#group`

Comments
----------------------------------------
Drupal Ticket: https://www.drupal.org/project/webform_civicrm/issues/3254254