### PR TITLE
Remove drupal 10 hack in unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,18 +99,10 @@ jobs:
         run: |
           cd ~/drupal
           COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} -W
-      - name: Ensure Webform ^6.2
-        if: ${{ matrix.drupal == '10.0.*' }}
+      - name: Download Webform
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.2@beta'
-      - name: Ensure Webform ^6.0
-        if: ${{ matrix.drupal != '10.0.*' }}
-        run: |
-          cd ~/drupal
-          #COMPOSER_MEMORY_LIMIT=-1 composer require cweagans/composer-patches
-          #jq '.extra.patches = {"drupal/webform": {"Regression": "https://www.drupal.org/files/issues/2021-12-13/3254028-2.patch"}}' composer.json > temp.json && mv temp.json composer.json
-          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:6.x-dev@dev'
+          COMPOSER_MEMORY_LIMIT=-1 composer require 'drupal/webform:^6.2'
       - name: Install webform_civicrm
         run: |
           cd ~/drupal

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,26 +152,17 @@ jobs:
           ./vendor/drush/drush/drush -y -l http://civi.localhost site-install standard --db-url='mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/fakedb' --site-name=FakeCivi
           chmod +w web/sites/default
           /home/runner/civicrm-cv/cv core:install --cms-base-url=http://civi.localhost
-      - name: Download Civi extensions from git
-        if: ${{ matrix.drupal == '10.0.*' }}
+      - name: Download Civi extensions
         run: |
           mkdir -p ~/drupal/web/sites/default/files/civicrm/ext
           cd ~/drupal/web/sites/default/files/civicrm/ext
-          /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.aghstrategies.uscounties
-          # Let's get latest git versions of these
-          git clone https://lab.civicrm.org/extensions/mjwshared.git
-          git clone https://lab.civicrm.org/extensions/firewall.git
-          git clone https://lab.civicrm.org/extensions/stripe.git
-          git clone https://github.com/iATSPayments/com.iatspayments.civicrm.git
-      - name: Download Civi extensions normal
-        if: ${{ matrix.drupal != '10.0.*' }}
-        run: |
-          mkdir -p ~/drupal/web/sites/default/files/civicrm/ext
-          cd ~/drupal/web/sites/default/files/civicrm/ext
-          # Normally we'll just let civi decide which version to download.
+          # Allow "unapproved" extensions
+          /home/runner/civicrm-cv/cv ev '\Civi::settings()->set("ext_repo_url", "https://civicrm.org/extdir/ver={ver}|cms={uf}|ready=");'
+          /home/runner/civicrm-cv/cv ev '\Civi::settings()->set("http_timeout", 60);'
           # Apparently we have to install it, otherwise stripe gives a dependency error even with install=0. I think that's a bug, but let's just do it. This is a fake install anyway.
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=mjwshared
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=firewall
+          /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=mjwpaymentapi
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.drastikbydesign.stripe
           /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.iatspayments.civicrm
           /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.aghstrategies.uscounties

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -356,8 +356,7 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     $this->assertStringContainsString('frederick@pabst.io', $sent_email[0]['to']);
 
     // Verify tokens are rendered correctly.
-    if (version_compare(\Drupal::VERSION, '10', '>=')) {
-      $this->assertEquals("Submitted Values Are -
+    $this->assertEquals("Submitted Values Are -
 
 -------- Contact 1 
 -----------------------------------------------------------
@@ -376,28 +375,6 @@ Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Li
 
 [1] mailto:frederick@pabst.io
 ", $sent_email[0]['body']);
-    }
-    else {
-      // Verify tokens are rendered correctly.
-      $this->assertEquals("Submitted Values Are -
--------- Contact 1 
------------------------------------------------------------
-
-*Existing Contact*
-Frederick Pabst
-*First Name*
-Frederick
-*Last Name*
-Pabst
-*Email*
-frederick@pabst.io [1]
-Existing Contact - Frederick Pabst. Activity 1 ID - {$actID1}. Activity 2 ID - {$actID2}.
-Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Links -
-{$cidURL}.
-
-[1] mailto:frederick@pabst.io
-", $sent_email[0]['body']);
-    }
   }
 
 }

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -17,7 +17,7 @@ final class StripeTest extends WebformCivicrmTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->setUpExtension('mjwshared,firewall,com.drastikbydesign.stripe');
+    $this->setUpExtension('mjwshared,firewall,mjwpaymentapi,com.drastikbydesign.stripe');
 
     $params = [];
     $result = $this->utils->wf_civicrm_api('Stripe', 'setuptest', $params);

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -752,18 +752,13 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     }
 
     // Fill value on the wysiwyg editor.
-    if (version_compare(\Drupal::VERSION, '10', '>=')) {
-      $this->getSession()->executeScript("
-        const element = document.getElementById(\"$fieldId\");
-        const editor = Drupal.CKEditor5Instances.get(
-          element.getAttribute('data-ckeditor5-id'),
-        );
-        editor.setData(\"$value\");
-      ");
-    }
-    else {
-      $this->getSession()->executeScript("CKEDITOR.instances[\"$fieldId\"].setData(\"$value\");");
-    }
+    $this->getSession()->executeScript("
+      const element = document.getElementById(\"$fieldId\");
+      const editor = Drupal.CKEditor5Instances.get(
+        element.getAttribute('data-ckeditor5-id'),
+      );
+      editor.setData(\"$value\");
+    ");
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Hack

Before
----------------------------------------
Hack

After
----------------------------------------
Still a little hack because being new mjwpaymentapi isn't in the "approved" list.

Technical Details
----------------------------------------
When initially trying to get running on drupal 10, various extensions needed the master version, not released. That's not true anymore, and, as of a few hours ago, the new stripe mjwpaymentapi doesn't need special version handling either.

Comments
----------------------------------------
Also remove the other hack for the parent webform which was from even earlier in the drupal 10 readiness attempts.
