### PR TITLE
contact 1 email isn't always the billing email

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Webform CiviCRM
 ===============
 
-Webform CiviCRM is a powerful, flexible, user-friendly form builder for CiviCRM!
+Webform CiviCRM is a powerful, flexible, user-friendly form builder for CiviCRM
 
 Installation & Getting Started
 ------------------------------

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1875,7 +1875,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * Return index value of contribution contact.
    */
   private function getContributionContactIndex() {
-    return wf_crm_aval($this->settings, "data:contribution:1:contribution:1:contact_id") ?? wf_crm_aval($this->submissionValue("civicrm_1_contribution_1_contribution_contact_id"), 0) ?? 1;
+    return wf_crm_aval($this->settings, "data:contribution:1:contribution:1:contact_id") ?? $this->crmValues["civicrm_1_contribution_1_contribution_contact_id"] ?? 1;
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3410941.

Before
----------------------------------------
Error when submitting a contribution and contact 1's email is blank.

After
----------------------------------------
Error when submitting a contribution when the contribution owner's email is blank.