### PR TITLE
Modify fillOptions to alphabetize dropdown list

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -328,20 +328,21 @@ var wfCivi = (function (D, $, drupalSettings, once) {
   }
 
   function fillOptions(element, data) {
+    var sortedData = Object.entries(data).sort(([,a],[,b]) => a > b);
     var $el = $(element),
       value = $el.attr('data-val') ? $el.attr('data-val') : $el.val();
     $el.find('option').remove();
-    if (!$.isEmptyObject(data || [])) {
+    if (!sortedData.length == 0) {
       if (!data['']) {
         var text = $el.hasClass('required') ? Drupal.t('- Select -') : Drupal.t('- None -');
         $el.append('<option value="">'+text+'</option>');
       }
-      $.each(data, function(key, val) {
-        $el.append('<option value="'+key+'">'+val+'</option>');
-      });
-      if (value in data) {
-        $el.val(value);
-      }
+      for (let i = 0; i < sortedData.length; i++) {
+        $el.append('<option value="'+sortedData[i][0]+'">'+sortedData[i][1]+'</option>');
+        if (sortedData[i][0] == value) {
+          $el.val(value);
+        }
+      };
     }
     else {
       $el.append('<option value="-">'+Drupal.t('- N/A -')+'</option>');


### PR DESCRIPTION
Overview
----------------------------------------
This PR resolves the [issue](https://www.drupal.org/project/webform_civicrm/issues/3340709) of states not shown in alphabetical order.

Before
----------------------------------------
The browser re-sorts the JSON by id, so the options are not necessarily in alphabetical order. This is most apparent when the Country is set to United States, United Kingdom, India, or Bermuda.

To replicate:
*   Create a webform with CiviCRM processing enabled
*  Include a set of address fields on Contact 1
*  Add Country and State to the form
*  Save and View
* Note that when either United States, United Kingdom, India, or Bermuda are selected as the Country, the State drop down list is not in alphabetical order.

After
----------------------------------------
States/provinces are sorted alphabetically.

Technical Details
----------------------------------------
`fillOptions()` has been modified so that the data is an array instead of an object, which allows for sorting by the elements' values.

Comments
----------------------------------------
This is the fixed version of #925, which should be closed.  #925 doesn't keep a selected value when the function is called multiple times.
