### PR TITLE
Return access denied if user is blocked from accessing the webform

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -21,7 +21,7 @@ use Drupal\webform_civicrm\WebformCivicrmBase;
 use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\webform\Utility\WebformHtmlHelper;
 use Drupal\webform\Utility\WebformXss;
-
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 
 class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivicrmPreProcessInterface {
 
@@ -162,8 +162,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       }
       if ($this->settings['block_unknown_users']) {
         $this->form['submitted']['#access'] = $this->form['actions']['#access'] = FALSE;
-        $this->setMessage(t('Sorry, you do not have permission to access this form.'), 'warning');
-        return;
+        throw new AccessDeniedHttpException();
       }
     }
     if (!empty($this->data['participant_reg_type'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Access Denied if user is blocked from accessing the webform.

Before
----------------------------------------
A hardcoded message is displayed if user is blocked on the webform. To test

- Create a webform.
- Enable `Block unknown user` from additional setting on civicrm tab.
- Access the webform as anonymous.
- A message is displayed on the top with few fields displayed too.

![image](https://github.com/colemanw/webform_civicrm/assets/5929648/b56e1f55-699a-4f3a-b71d-16a879c23ff0)

After
----------------------------------------
403 access denied is returned.

This also respects the access denied configuration on the webform. 

![image](https://github.com/colemanw/webform_civicrm/assets/5929648/a4047496-302a-4fe8-986b-b7fc39bc48ab)

So admins can enter their custom message, etc for the blocked users.

