### PR TITLE
Deprecated settings

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -59,8 +59,7 @@ abstract class WebformCivicrmBase {
         return $this->_payment_processor;
 
       case 'tax_rate':
-        $taxSettings = $this->utils->wf_crm_get_civi_setting('contribution_invoice_settings');
-        if (is_array($taxSettings) && !empty($taxSettings['invoicing'])) {
+        if (\Civi::settings()->get('invoicing')) {
           $contribution_enabled = wf_crm_aval($this->data, 'contribution:1:contribution:1:enable_contribution');
           if ($contribution_enabled) {
             // tax integration

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -660,10 +660,8 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
 
       if ($itemTaxRate !== NULL) {
         // Change the line item label to display the tax rate it contains
-        $taxSettings = $this->utils->wf_crm_get_civi_setting('contribution_invoice_settings');
-
-        if (($itemTaxRate !== 0) && ($taxSettings['tax_display_settings'] !== 'Do_not_show')) {
-          $item['label'] .= ' (' . t('includes @rate @tax', ['@rate' => (float) $itemTaxRate . '%', '@tax' => $taxSettings['tax_term']]) . ')';
+        if (($itemTaxRate !== 0) && (\Civi::settings()->get('tax_display_settings') !== 'Do_not_show')) {
+          $item['label'] .= ' (' . t('includes @rate @tax', ['@rate' => (float) $itemTaxRate . '%', '@tax' => \Civi::settings()->get('tax_term')]) . ')';
         }
 
         // Add calculation for financial type that contains tax


### PR DESCRIPTION
Overview
----------------------------------------
This should fix the test fail at https://github.com/colemanw/webform_civicrm/actions/runs/7447529454/job/20260015089

Before
----------------------------------------
`User deprecated function: contribution_invoice_settings is not a valid setting. Request the actual setting Caller: Civi\API\Provider\MagicFunctionProvider::invoke in CRM_Core_Error::deprecatedWarning() (line 1129 of /home/runner/drupal/vendor/civicrm/civicrm-core/CRM/Core/Error.php)`

After
----------------------------------------


Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/20970

Comments
----------------------------------------

