### PR TITLE
Refresh payment block on selecting Pay later

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -13,7 +13,7 @@
 
   function loadBillingBlock() {
     var type = getPaymentProcessor();
-    if (type && type !== '0') {
+    if (type) {
       $.ajax({
         url: setting.contributionCallback + '&' + setting.processor_id_key + '=' + type,
         success: function(data) {


### PR DESCRIPTION
Overview
----------------------------------------
Refresh payment block on selecting pay later.

Before
----------------------------------------
Payment block is not refreshed if user selects pay later. This causes an issue when Stripe is a default payment option selected on the webform. To replicate:

- Create a webform with Contritbuion section enabled.
- Ensure Payment processor is set to "User Select" with Stripe & pay later as options. Default = Stripe.
- Load the webform, and notice stripe is selected by default.
- Select pay later and submit.
- The webform redirects to front page and no submission is recorded.

After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Js seems to avoid refreshing the payment block if pay later is selected. This PR removes that condition.

