### PR TITLE
Set empty value for N/A.

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -345,7 +345,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
       };
     }
     else {
-      $el.append('<option value="">'+Drupal.t('- N/A -')+'</option>');
+      $el.append('<option value="-">'+Drupal.t('- N/A -')+'</option>');
     }
     $el.removeAttr('disabled').trigger('change', 'webform_civicrm:chainselect');
   }

--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -345,7 +345,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
       };
     }
     else {
-      $el.append('<option value="-">'+Drupal.t('- N/A -')+'</option>');
+      $el.append('<option value="">'+Drupal.t('- N/A -')+'</option>');
     }
     $el.removeAttr('disabled').trigger('change', 'webform_civicrm:chainselect');
   }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -835,6 +835,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           if (isset($params['county_id']) && $params['county_id'] === '-') {
             $params['county_id'] = '';
           }
+          // Substitute state stub ('-' is a hack to get around required field when there are no available states)
+          if (isset($params['state_province_id']) && $params['state_province_id'] === '-') {
+            $params['state_province_id'] = '';
+          }
           // Check if anything was changed, else skip the update
           if (!empty($existing[$i])) {
             $same = TRUE;


### PR DESCRIPTION
Overview
----------------------------------------
When "Address" is enabled for a contact with _Country and State/Province_ element enabled, if user selects a country that has no state, this error is thrown upon form submission:

```
Drupal\Core\Entity\EntityStorageException: state_province_id is not a valid integer in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 817 of /app/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).
```

I think CiviCRM is expecting an integer although got "-" instead.

Before
----------------------------------------
Throws error when selecting "N/A" as the option for "State/Province" element.

After
----------------------------------------
No more error.