### PR TITLE
Fix state display on preview

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -334,7 +334,7 @@ class CivicrmOptions extends OptionsBase {
       $state_id = $value;
     }
     else {
-      $state_id = $value['#plain_text'] ?? NULL;
+      $state_id = $value['#plain_text'] ?? $value['#markup'] ?? NULL;
     }
     if ($format === 'raw' || empty($state_id) || !is_numeric($state_id)) {
       return $value;

--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -321,4 +321,33 @@ class CivicrmOptions extends OptionsBase {
     }
   }
 
+  /**
+   * @inheritDoc
+   */
+  protected function format($type, array &$element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    $value = parent::format($type, $element, $webform_submission, $options);
+    $format = $this->getItemFormat($element);
+    if (!str_ends_with($element['#form_key'], '_address_state_province_id')) {
+      return $value;
+    }
+    if ($type === 'Text') {
+      $state_id = $value;
+    }
+    else {
+      $state_id = $value['#plain_text'] ?? NULL;
+    }
+    if ($format === 'raw' || empty($state_id) || !is_numeric($state_id)) {
+      return $value;
+    }
+    $utils = \Drupal::service('webform_civicrm.utils');
+    $state = $utils->wf_crm_apivalues('state_province', 'get', ['id' => $state_id], 'name');
+    if (!empty($state[$state_id])) {
+      if ($type === 'Text') {
+        return $state[$state_id];
+      }
+      $value['#plain_text'] = $state[$state_id];
+    }
+    return $value;
+  }
+
 }

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -76,6 +76,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
 
     $this->node = $webform_submission->getWebform();
+    // $this->node->applyVariants($webform_submission);
 
     $handler_collection = $this->node->getHandlers('webform_civicrm');
     $instance_ids = $handler_collection->getInstanceIds();

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -76,7 +76,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
 
     $this->node = $webform_submission->getWebform();
-    // $this->node->applyVariants($webform_submission);
 
     $handler_collection = $this->node->getHandlers('webform_civicrm');
     $instance_ids = $handler_collection->getInstanceIds();


### PR DESCRIPTION
Overview
----------------------------------------
Fix state display on preview

Before
----------------------------------------
![Existing Contact](https://github.com/colemanw/webform_civicrm/assets/5929648/31757dd8-5db8-4843-9276-ed5c81c3e3f8)

After
----------------------------------------
![Contact 1](https://github.com/colemanw/webform_civicrm/assets/5929648/0878c076-c5a8-4367-a5d8-9b73ae362daf)

Technical Details
----------------------------------------
The state has numerous options that we do not define as `#options` in the YAML configuration due to its daisy-chaining load based on country selection.

This PR adds a format function for label displays. I believe it should also fix the tokens @MegaphoneJon.

Comments
----------------------------------------
Drupal Ticket: https://www.drupal.org/project/webform_civicrm/issues/3410313