### PR TITLE
D9 - Ensure new events are loaded as default on the event field

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -554,9 +554,13 @@ abstract class WebformCivicrmBase {
   protected function getExposedOptions($field_key, $exclude = []) {
     $field = $this->getComponent($field_key);
 
-    if ($field && $field['#type'] == 'hidden') {
+    if ($field && ($field['#type'] == 'hidden' || !empty($field['#civicrm_live_options']))) {
       // Fetch live options
-      $exposed = $this->utils->wf_crm_field_options($field, 'civicrm_live_options', $this->data);
+      $params = [
+        'extra' => wf_crm_aval($field, 'extra', []) + wf_crm_aval($field, '#extra', []),
+        'form_key' => $field['#form_key'],
+      ];
+      $exposed = $this->utils->wf_crm_field_options($params, 'civicrm_live_options', $this->data);
       foreach ($exclude as $i) {
         unset($exposed[$i]);
       }

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -435,7 +435,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         else {
           $urlParam = "c{$c}event{$e}";
         }
-        foreach (explode(',', wf_crm_aval($_GET, $urlParam)) as $url_param_value) {
+        foreach (explode(',', wf_crm_aval($_GET, $urlParam, '')) as $url_param_value) {
           if (isset($eids[$url_param_value])) {
             $event_ids[] = $eids[$url_param_value];
           }

--- a/tests/src/FunctionalJavascript/EventTest.php
+++ b/tests/src/FunctionalJavascript/EventTest.php
@@ -305,9 +305,10 @@ final class EventTest extends WebformCivicrmTestBase {
   }
 
   /**
-   * Test the working of 'Show Full Events'.
+   * Test the working of 'Show Full Events'
+   * and default URL load of events.
    */
-  function testMaxParticipant() {
+  function testMaxParticipantAndEventUrlDefault() {
     $event = $this->utils->wf_civicrm_api('Event', 'create', [
       'event_type_id' => "Conference",
       'title' => "Test Event 2",
@@ -374,6 +375,7 @@ final class EventTest extends WebformCivicrmTestBase {
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
     $this->getSession()->getPage()->selectFieldOption('reg_options[show_remaining]', 'always');
+    $this->getSession()->getPage()->checkField('reg_options[allow_url_load]');
     $this->getSession()->getPage()->selectFieldOption('participant_1_number_of_participant', 1);
     $this->assertSession()->assertWaitOnAjaxRequest();
     $this->htmlOutput();
@@ -405,6 +407,25 @@ final class EventTest extends WebformCivicrmTestBase {
     $this->assertSession()->pageTextNotContains('Test Event 1');
     $this->assertSession()->pageTextContains('Test Event 2');
     $this->assertSession()->pageTextContains('Test Event 3');
+
+    // Ensure URL events are set as default on the event field.
+    $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['event1' => $this->_event2['id']]]));
+    $this->assertSession()->checkboxChecked('Test Event 2');
+
+    // Create new event and load it from the URL.
+    $event = $this->utils->wf_civicrm_api('Event', 'create', [
+      'event_type_id' => "Conference",
+      'title' => "Test Event 4",
+      'start_date' => date('Y-m-d'),
+      'financial_type_id' => $this->ft['id'],
+    ]);
+    $this->assertEquals(0, $event['is_error']);
+    $this->assertEquals(1, $event['count']);
+    $this->_event4 = reset($event['values']);
+
+    $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['event1' => $this->_event4['id']]]));
+    $this->assertSession()->pageTextContains('Test Event 4');
+    $this->assertSession()->checkboxChecked('Test Event 4');
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
URL Event is not loaded if event is added after configuring the webform.

Before
----------------------------------------
To replicate:

- Create a webform with events = `User Select`.
- Enable `Allow events to be autoloaded from URL` config from Events tab.
- Load the webform with query string `event1=<id>`. Works fine.
- Create a new event in civicrm.
- Load the webform with query string `event1=<id>` where <id> is the event id of the newly created event. The event is not loaded as default on the webform.

After
----------------------------------------
Event is loaded as default.

Technical Details
----------------------------------------
Ensure we have the latest options if we have  `civicrm_live_options` enabled for the webform element.

