### PR TITLE
Fix default activity on webform if filed on case

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -781,8 +781,15 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
                 'is_deleted' => '0',
                 'is_current_revision' => '1',
                 'options' => ['limit' => 1],
+                'activity_type_id' => $this->data['activity'][$n]['activity'][1]['activity_type_id'],
               ];
-              $params['activity_type_id'] = $this->data['activity'][$n]['activity'][1]['activity_type_id'];
+              $caseType = $this->data['activity'][$n]['case_type_id'] ?? NULL;
+              if (!empty($caseType) && $caseType[0] === '#') {
+                $case_num = substr($caseType, 1);
+                if (!empty($this->ent['case'][$case_num]['id'])) {
+                  $params['case_id'] = $this->ent['case'][$case_num]['id'];
+                }
+              }
               $items = $this->utils->wf_crm_apivalues('activity', 'get', $params);
               if (isset($items[0]['id'])) {
                 $this->ent['activity'][$n] = ['id' => $items[0]['id']];


### PR DESCRIPTION
Overview
----------------------------------------
Fix default activity on webform if filed on case

Before
----------------------------------------
Incorrect activity is loaded on the webform, if file on case is enabled in webform config.

To replicate:

- Create a webform with Activity & Case.
- **Case Tab**: Update Existing Case: Ongoing; Case Type: Housing Support; Enable Case Subject
- **Activity Tab**: Update Existing Activity: Scheduled; Activity Type: Followup; File on Case: Case 1; Enable Activity Subject.
- **In CiviCRM**: Create 2 cases on your logged in contact with case status: Resolved & set the second case status as Ongoing.
- Ensure both the cases have followup activity with a value in subject field.
- Load the webform with c1 as the logged in contact. 
- **Current Outcome**: The webform loads the activity subject from the Resolved case.
- **Expected Outcome**: The webform must load the Ongoing Case followup activity subject into the subject field as per our activity config settings.


After
----------------------------------------
Correct Activity subject is loaded.

Technical Details
----------------------------------------
When the activity is loaded in preprocess, ensure it takes case_id into consideration if configured in settings.

