### PR TITLE
D9 - Add Receive Date field to contribution tab

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1128,6 +1128,13 @@ class AdminForm implements AdminFormInterface {
         }
         if (isset($set['fields'])) {
           foreach ($set['fields'] as $fid => $field) {
+            // Display receive date only if processor = 'Pay Later' or '- User Select -'
+            if ($fid == 'contribution_receive_date') {
+              $pp = wf_crm_aval($this->data, "contribution:1:contribution:1:payment_processor_id", 'create_civicrm_webform_element', TRUE);
+              if (!empty($pp) && $pp !== 'create_civicrm_webform_element') {
+                continue;
+              }
+            }
             $fid = "civicrm_1_contribution_1_$fid";
             if (strpos($sid, 'cg') === 0) {
               $this->form['contribution']['sets']['custom'][$sid][$fid] = $this->addItem($fid, $field);
@@ -1140,6 +1147,7 @@ class AdminForm implements AdminFormInterface {
       }
     }
     $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_financial_type_id", "..:custom");
+    $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_payment_processor_id", "..:contribution");
 
     //Add Currency.
     $this->form['contribution']['sets']['contribution']['contribution_1_settings_currency'] = [
@@ -1963,9 +1971,9 @@ class AdminForm implements AdminFormInterface {
                 $created[] = $field['name'];
               }
               // @todo: Update Conditionals as per Drupal 9 standards.
-              // if (isset($field['civicrm_condition'])) {
-              //   $this->addConditionalRule($field, $enabled);
-              // }
+              if (isset($field['civicrm_condition'])) {
+                $this->addConditionalRule($field, $enabled);
+              }
             }
           }
         }
@@ -2176,7 +2184,7 @@ class AdminForm implements AdminFormInterface {
           if (isset($options[$value])) {
             $field['states'] = [
               'visible' => [
-                ":input[name='{$source_id}']" => ['value' => $value],
+                ':input[name="' . $source_key . '"]' => ['value' => $value],
               ],
             ];
             unset($field['civicrm_condition']);

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -741,6 +741,24 @@ class Fields implements FieldsInterface {
           'type' => 'textfield',
           'parent' => 'contribution_pagebreak',
         ];
+        $fields['contribution_receive_date'] = [
+          'name' => t('Contribution Receive Date'),
+          'type' => 'datetime',
+          'parent' => 'contribution_pagebreak',
+          'default_value' => 'now',
+          'date_date_min' => 'today',
+          'date_time_element' => 'timepicker',
+          'civicrm_condition' => [
+            'andor' => 'or',
+            'action' => 'show',
+            'rules' => [
+              'contribution_payment_processor_id' => [
+                'values' => '0',
+                'operator' => 'equal',
+              ],
+            ],
+          ],
+        ];
         $donationFinancialType = current($this->utils->wf_crm_apivalues('FinancialType', 'get', [
           'return' => 'id',
           'name' => 'Donation',

--- a/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
+++ b/tests/src/FunctionalJavascript/ContributionPayLaterTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
 
 use Civi\Api4\Contribution;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\Core\Url;
 
 /**
@@ -52,8 +53,9 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->pressButton('Next >');
     $this->assertPageNoErrorMessages();
     $this->getSession()->getPage()->fillField('Contribution Amount', '30');
-    $futureReceiveDate = date('d-m-Y', strtotime('+3 days'));
-    $this->getSession()->getPage()->fillField('Contribution Receive Date', $futureReceiveDate);
+
+    $futureReceiveDate = new DrupalDateTime('+1 month');
+    $this->getSession()->getPage()->fillField('civicrm_1_contribution_1_contribution_receive_date[date]', $futureReceiveDate->format('m-d-Y'));
     $this->getSession()->getPage()->fillField('civicrm_1_contribution_1_contribution_receive_date[time]', '07:15:00');
 
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
@@ -74,8 +76,9 @@ final class ContributionPayLaterTest extends WebformCivicrmTestBase {
     $this->assertEquals('Pending', $contribution['contribution_status_id:label']);
     $this->assertEquals('Member Dues', $contribution['financial_type_id:label']);
     $this->assertEquals('USD', $contribution['currency']);
-    $verifyDate = date('Y-m-d', strtotime($futureReceiveDate));
-    $this->assertEquals("{$verifyDate} 07:15:00", $contribution['receive_date']);
+    $verifyDate = $futureReceiveDate->format('Y-m-d');
+    $contributionDate = date('Y-m-d', strtotime($contribution['receive_date']));
+    $this->assertEquals("{$verifyDate} 07:15:00", "{$contributionDate} 07:15:00");
 
     $sent_email = $this->getMostRecentEmail();
     $this->assertStringContainsString('From: Admin <admin@example.com>', $sent_email);

--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -178,7 +178,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
     $this->assertEquals($today,  $membership['join_date']);
     $this->assertEquals($today,  $membership['start_date']);
 
-    $this->assertEquals(date('Y-m-d', strtotime($today. ' +365 days')),  $membership['end_date']);
+    $this->assertEquals(date('Y-m-d', strtotime('+1 year -1 day')), $membership['end_date']);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------
Add Date Received field on the Contribution tab

Before
----------------------------------------
No way to allow users to choose receive date for their pay later contributions.

**Use-case**: A member selects pay later and admin is wondering when? Next month, next quarter?
If you do a pay later in webform -> it lands on today:
Letting Admins add Contribution Date (Date Received) to a webform (in general) would allow users to not just say Pay Later, but also say When. 

After
----------------------------------------
Receive Date field added on the contribution tab.


Comments
----------------------------------------
@KarinG 