### PR TITLE
[wip] - D9/10 - Fix ordering on payment table

### DIFF
--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -62,10 +62,11 @@
     var $lineItem = $('.line-item.' + item, '#wf-crm-billing-items');
     if (!$lineItem.length) {
       var oe = $('#wf-crm-billing-items tbody tr:first').hasClass('odd') ? ' even' : ' odd';
-      $('#wf-crm-billing-items tbody').prepend('<tr class="line-item ' + item + oe + '" data-amount="' + amount + '">' +
+      let newItem = $('<tr class="line-item ' + item + oe + '" data-amount="' + amount + '">' +
         '<td>' + label + '</td>' +
         '<td>' + CRM.formatMoney(amount) + '</td>' +
       '</tr>');
+      newItem.insertBefore('#wf-crm-billing-total');
     }
     else {
       var taxPara = 1;
@@ -98,8 +99,13 @@
   function calculateLineItemAmount() {
     var fieldKey = $(this).data('civicrmFieldKey'),
       amount = getFieldAmount(fieldKey),
+      input = $(this).attr('type'),
       label = $(this).closest('div.form-item').find('label').text() || Drupal.t('Contribution'),
       lineKey = fieldKey.split('_').slice(0, 4).join('_');
+
+    if (input === 'radio' || input === 'checkbox') {
+      label = $(this).closest('fieldset.form-item').find('legend').text() || label;
+    }
     updateLineItem(lineKey, amount, label);
   }
 
@@ -118,7 +124,7 @@
 
       loadBillingBlock();
 
-      $('.civicrm-enabled.contribution-line-item')
+      $('.civicrm-enabled.contribution-line-item:not(fieldset)')
         .each(calculateLineItemAmount)
         .on('change keyup', calculateLineItemAmount)
         .each(function() {

--- a/js/webform_civicrm_payment.js
+++ b/js/webform_civicrm_payment.js
@@ -106,6 +106,9 @@
     if (input === 'radio' || input === 'checkbox') {
       label = $(this).closest('fieldset.form-item').find('legend').text() || label;
     }
+    if (typeof input === 'undefined' && $(this).is('fieldset')) {
+      label = $(this).find('legend').text() || label;
+    }
     updateLineItem(lineKey, amount, label);
   }
 
@@ -124,7 +127,7 @@
 
       loadBillingBlock();
 
-      $('.civicrm-enabled.contribution-line-item:not(fieldset)')
+      $('.civicrm-enabled.contribution-line-item')
         .each(calculateLineItemAmount)
         .on('change keyup', calculateLineItemAmount)
         .each(function() {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1756,11 +1756,14 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
               }
               $fee_amount_id = "civicrm_{$c}_membership_{$n}_membership_fee_amount";
               $membership_label = $this->getMembershipTypeField($type, 'name') . ": " . $member_name;
+              if (isset($this->enabled[$fee_amount_id])) {
+                $membership_label = wf_crm_aval($webform_elements, $this->enabled[$fee_amount_id] . ':#title', $membership_label);
+              }
               $this->line_items[] = [
                 'qty' => $membership_item['num_terms'],
                 'unit_price' => $price,
                 'financial_type_id' => $membership_financialtype,
-                'label' => wf_crm_aval($webform_elements, $this->enabled[$fee_amount_id] . ':#title', $membership_label),
+                'label' => $membership_label,
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
                 'fid' => $fee_amount_id,

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -498,6 +498,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
               'unit_price' => $p['fee_amount'] ?? 0,
               'element' => "civicrm_{$c}_participant_{$n}_participant_{$id_and_type}",
               'contact_label' => $participantName,
+              'fid' => "civicrm_{$c}_participant_{$n}_participant_fee_amount",
             ];
           }
         }
@@ -1687,6 +1688,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    */
   private function tallyLineItems() {
     $submittedFormValues = $this->form_state->getUserInput();
+    $webform_elements = $this->node->getElementsDecodedAndFlattened();
     // Contribution
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (isset($this->enabled[$fid]) || $this->getData($fid) > 0) {
@@ -1694,9 +1696,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         'qty' => 1,
         'unit_price' => $this->getData($fid),
         'financial_type_id' => wf_crm_aval($this->data, 'contribution:1:contribution:1:financial_type_id'),
-        'label' => wf_crm_aval($this->node->getElementsDecodedAndFlattened(), $this->enabled[$fid] . ':#title', t('Contribution')),
+        'label' => wf_crm_aval($webform_elements, $this->enabled[$fid] . ':#title', t('Contribution')),
         'element' => 'civicrm_1_contribution_1',
         'entity_table' => 'civicrm_contribution',
+        'fid' => $fid,
       ];
     }
     // LineItems
@@ -1709,9 +1712,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             'qty' => 1,
             'unit_price' => $lineitem['line_total'],
             'financial_type_id' => $lineitem['financial_type_id'],
-            'label' => wf_crm_aval($this->node->getElementsDecodedAndFlattened(), $this->enabled[$fid] . ':#title', t('Line Item')),
+            'label' => wf_crm_aval($webform_elements, $this->enabled[$fid] . ':#title', t('Line Item')),
             'element' => "civicrm_1_lineitem_{$n}",
             'entity_table' => 'civicrm_contribution',
+            'fid' => $fid,
           ];
         }
       }
@@ -1750,13 +1754,16 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
               if (empty($member_name)) {
                 $member_name = $this->utils->wf_crm_display_name($this->existing_contacts[$c]);
               }
+              $fee_amount_id = "civicrm_{$c}_membership_{$n}_membership_fee_amount";
+              $membership_label = $this->getMembershipTypeField($type, 'name') . ": " . $member_name;
               $this->line_items[] = [
                 'qty' => $membership_item['num_terms'],
                 'unit_price' => $price,
                 'financial_type_id' => $membership_financialtype,
-                'label' => $this->getMembershipTypeField($type, 'name') . ": " . $member_name,
+                'label' => wf_crm_aval($webform_elements, $this->enabled[$fee_amount_id] . ':#title', $membership_label),
                 'element' => "civicrm_{$c}_membership_{$n}",
                 'entity_table' => 'civicrm_membership',
+                'fid' => $fee_amount_id,
               ];
             }
           }

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -663,10 +663,12 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         }
       }
     }
+    // Merge remaining values.
+    $displayLineItems = array_values(array_replace($displayLineItems, $this->line_items));
     $submittedFormValues = $this->form_state->getUserInput();
     foreach ($displayLineItems as $item) {
       // Load the rows for only submitted items. Final page items will be displayed on the payment table using js.
-      if (!empty($submittedFormValues) && isset($item['fid']) && !isset($submittedFormValues[$item['fid']])) {
+      if (!empty($submittedFormValues) && isset($item['fid']) && !isset($submittedFormValues[$item['fid']]) && isset($this->enabled[$item['fid']])) {
         continue;
       }
       $total += $item['line_total'];

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -652,7 +652,23 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     }
 
     $taxRates = \CRM_Core_PseudoConstant::getTaxRates();
-    foreach ($this->line_items as $item) {
+    // Ensure the display of line items respects
+    // the ordering set on the component page.
+    $displayLineItems = [];
+    foreach ($this->enabled as $fid => $v) {
+      foreach ($this->line_items as $k => $item) {
+        if (!empty($item['fid']) && $fid == $item['fid']) {
+          $displayLineItems[$k] = $item;
+          continue 2;
+        }
+      }
+    }
+    $submittedFormValues = $this->form_state->getUserInput();
+    foreach ($displayLineItems as $item) {
+      // Load the rows for only submitted items. Final page items will be displayed on the payment table using js.
+      if (!empty($submittedFormValues) && isset($item['fid']) && !isset($submittedFormValues[$item['fid']])) {
+        continue;
+      }
       $total += $item['line_total'];
       // Sales Tax integration
       if (!empty($item['financial_type_id'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Ensure Payment table lists the amount options according to the order set on the build page.

Before
----------------------------------------
If there are multiple payment options on the webform, there are several display issues with the payment table.

- The list is not in the order of the build page.
- If the line item elements are of type Radio or Checkbox, a default `Contribution` label is displayed instead of the label configured for the element.

Eg, the Element order on the build page for this webform is

- Membership Fee
- First Line Item Amount
- Second Line Item Amount
- Donation Amount.

But the payment table displays some random order with labels incorrect for checkbox and radio inputs.

<img width="1421" alt="Contact Information" src="https://github.com/colemanw/webform_civicrm/assets/5929648/8d1cddbc-c256-41aa-8f46-c865475e7a29">

After
----------------------------------------
Fixed. 

- Sorting is according to the labels set on the build page configuration.
- Label is fixed to ensure its displayed as per the element config.

<img width="1409" alt="First Line Item Amount" src="https://github.com/colemanw/webform_civicrm/assets/5929648/137bb923-4d3a-412e-8d02-f0de0ae2e4e2">


