### PR TITLE
[NFC] Deprecated call to FinancialAccount::add

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -173,7 +173,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       'tax_rate' => $tax_rate,
       'is_active' => 1,
     ], $accountParams);
-    $account = \CRM_Financial_BAO_FinancialAccount::add($params);
+    $account = \CRM_Financial_BAO_FinancialAccount::writeRecord($params);
     $entityParams = [
       'entity_table' => 'civicrm_financial_type',
       'entity_id' => $financialTypeId,


### PR DESCRIPTION
Overview
----------------------------------------
See https://github.com/civicrm/civicrm-core/blob/61472fd6c819d2fe3d6b3311085fec0883119ef1/CRM/Financial/BAO/FinancialAccount.php#L55

It comes up at the bottom of every test run.