### PR TITLE
Fix php8.2 warnings

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -31,6 +31,11 @@ class AdminForm implements AdminFormInterface {
   private $data;
 
   /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
+  /**
    * The shim allowing us to slowly port this code.
    *
    * @var \Drupal\webform\WebformInterface

--- a/src/AdminHelp.php
+++ b/src/AdminHelp.php
@@ -15,6 +15,11 @@ use Drupal\Core\Url;
  */
 class AdminHelp implements AdminHelpInterface {
 
+  /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
   public function __construct(UtilsInterface $utils) {
     $this->utils = $utils;
   }

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -11,6 +11,11 @@ class Fields implements FieldsInterface {
    */
   protected $fieldMetadata = [];
 
+  /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
   public function __construct(UtilsInterface $utils) {
     $this->utils = $utils;
   }

--- a/src/WebformAjax.php
+++ b/src/WebformAjax.php
@@ -21,6 +21,11 @@ class WebformAjax extends WebformCivicrmBase implements WebformAjaxInterface {
 
   private $requestStack;
 
+  /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
   function __construct(RequestStack $requestStack, UtilsInterface $utils) {
     $this->requestStack = $requestStack;
     $this->utils = $utils;

--- a/src/WebformCivicrmConfirmForm.php
+++ b/src/WebformCivicrmConfirmForm.php
@@ -12,6 +12,11 @@ class WebformCivicrmConfirmForm  implements WebformCivicrmConfirmFormInterface {
   private $form_state;
 
   /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
+  /**
    * Static cache.
    *
    * @var bool

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -51,6 +51,12 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * @var \Drupal\webform\WebformSubmissionInterface
    */
   private $submission;
+
+  /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
   private $all_fields;
   private $all_sets;
   private $shared_address = [];

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -31,6 +31,11 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
   private $all_fields;
   private $all_sets;
 
+  /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
   public function __construct(UtilsInterface $utils) {
     $this->utils = $utils;
   }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -55,6 +55,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   protected $adminUser;
 
   /**
+   * @var \Drupal\webform_civicrm\UtilsInterface
+   */
+  protected $utils;
+
+  /**
    * {@inheritdoc}
    */
   protected function setUp(): void {


### PR DESCRIPTION
Overview
----------------------------------------
Fix php8.2 warnings

Before
----------------------------------------
Warnings/Notices on every page of webform with PHP 8.2

![image](https://github.com/colemanw/webform_civicrm/assets/5929648/9f520b7c-b738-413a-a689-4ea622e615ac)

After
----------------------------------------
Fixed.
