### PR TITLE
fix stars/notes functionality when country_id is in submission

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -196,42 +196,44 @@ function _fillCiviCRMData($data, $webformSubmission) {
   \Drupal::service('civicrm')->initialize();
   $utils = \Drupal::service('webform_civicrm.utils');
   $webform = $webformSubmission->getWebform();
-  foreach ($data as $key => $val) {
-    $element = $webform->getElement($key);
-    if ($element && !empty($val) && $element['#type'] == 'civicrm_options') {
-      if (!empty($element['#webform_multiple'])) {
-        foreach ($val as $k => $v) {
-          if (isset($element['#options'][$v])) {
-            $data[$key]["{$k}_raw"] = $data[$key][$k];
-            $data[$key][$k] = $element['#options'][$v];
+  if (\Drupal::routeMatch()->getRouteName() == 'entity.webform.results_submissions') {
+    foreach ($data as $key => $val) {
+      $element = $webform->getElement($key);
+      if ($element && !empty($val) && $element['#type'] == 'civicrm_options') {
+        if (!empty($element['#webform_multiple'])) {
+          foreach ($val as $k => $v) {
+            if (isset($element['#options'][$v])) {
+              $data[$key]["{$k}_raw"] = $data[$key][$k];
+              $data[$key][$k] = $element['#options'][$v];
+            }
           }
         }
-      }
-      elseif (isset($element['#options'][$val])) {
-        $data["{$key}_raw"] = $data[$key];
-        $data[$key] = $element['#options'][$val];
-      }
-      elseif (strpos($key, 'state_province_id') !== false) {
-        $country_key = str_replace('state_province_id', 'country_id', $key);
-        $country_id = $data["{$country_key}_raw"] ?? $data[$country_key] ?? NULL;
-        $params = [
-          'sequential' => 1,
-          'country_id' => $country_id,
-        ];
-        $is_abbr = $utils->wf_civicrm_api4('StateProvince', 'get', [
-          'select' => ['row_count'],
-          'where' => [['abbreviation', '=', $val]],
-        ])->count() > 0;
-        if (is_numeric($val)) {
-          $params['id'] = $val;
+        elseif (isset($element['#options'][$val])) {
+          $data["{$key}_raw"] = $data[$key];
+          $data[$key] = $element['#options'][$val];
         }
-        elseif ($is_abbr) {
-          $params['abbreviation'] = $val;
+        elseif (strpos($key, 'state_province_id') !== false) {
+          $country_key = str_replace('state_province_id', 'country_id', $key);
+          $country_id = $data["{$country_key}_raw"] ?? $data[$country_key] ?? NULL;
+          $params = [
+            'sequential' => 1,
+            'country_id' => $country_id,
+          ];
+          $is_abbr = $utils->wf_civicrm_api4('StateProvince', 'get', [
+            'select' => ['row_count'],
+            'where' => [['abbreviation', '=', $val]],
+          ])->count() > 0;
+          if (is_numeric($val)) {
+            $params['id'] = $val;
+          }
+          elseif ($is_abbr) {
+            $params['abbreviation'] = $val;
+          }
+          else {
+            continue;
+          }
+          $data[$key] = $utils->wf_crm_apivalues('StateProvince', 'get', $params, 'name')[0] ?? $data[$key];
         }
-        else {
-          continue;
-        }
-        $data[$key] = $utils->wf_crm_apivalues('StateProvince', 'get', $params, 'name')[0] ?? $data[$key];
       }
     }
   }


### PR DESCRIPTION
Overview
----------------------------------------
@jitendrapurohit removed this from #880, and it failed tests.  But I've found a bug caused by this code.

`fillCiviCRMData()` is called when:
* Rendering tokens
* Loading webform submissions
* Editing webform submissions via AJAX (by adding the star or notes from the submissions tab).

We thought the latter two were unnecessary, since Webform calls the token renderer when loading this page.  So we removed it, and it failed a test.  But in the third case, it's called *before* the data is saved, so for any option value fields, we pass the label as the ID.

Many fields will accept this. `country_id` will not.  So you get a 500 error on any AJAX webform submission stars/notes when the country is present.

I'm submitting this so I can see the exact tests that are failing and see if there's a resolution.