### PR TITLE
D10 - Fatal error on empty group submission if configured as public group in settings

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2504,7 +2504,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           if (substr($name, 0, 6) === 'custom' || ($table == 'other' && in_array($name, ['group', 'tag']))) {
             $val = array_filter($val);
             if ($name === 'group') {
-              unset($val['public_groups']);
+              unset($val['public_groups'], $this->data[$ent][$c][$table][$n][$name]['public_groups']);
             }
           }
 


### PR DESCRIPTION
Overview
----------------------------------------
Fatal error on empty group submission if configured as public group in settings

Before
----------------------------------------
To replicate

- Create a webform with group = Public Group
- Submit the form as anonymous user without enabling any options for the group field.
- Error
>Drupal\Core\Entity\EntityStorageException: 'public_groups' is not a valid option for field group_id in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 817 of core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).


After
----------------------------------------
Fixed.

Technical Details
----------------------------------------
Unsetting $val works fine for logged-in or authorized users because it assigns it to $this->data only if the contact is logged in - https://github.com/colemanw/webform_civicrm/blob/6.x/src/WebformCivicrmPostProcess.php#L2579-L2583

For anonymous users, the key remains in `$this->data`, leading to an error. Removing it immediately fixes the error.