### PR TITLE
D9/10 - Fix display of contact fields, if hidden in settings

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -43,7 +43,7 @@
             true,
             field.data('form-defaults'),
           );
-        });
+        }).change();
 
         //In case of error, highlight the token-input field.
         if (field.hasClass('error')) {

--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -9,8 +9,9 @@
         }
         var autocompleteUrl = D.url('webform-civicrm/js/' + field.data('form-id') + '/' + field.data('civicrm-field-key'));
         var isSelect = field.data('is-select');
-        if (!isSelect) {
-          var tokenValues = field.data('is-contactid') ? false : {
+        var tokenValues = false;
+        if (!isSelect && !field.data('is-contactid')) {
+          tokenValues = {
             hintText: field.data('search-prompt'),
             noResultsText: field.data('none-prompt'),
             resultsFormatter: formatChoices,
@@ -18,10 +19,7 @@
             enableHTML: true
           };
         }
-        else {
-          var tokenValues = false;
-        }
-        
+
         wfCivi.existingInit(
           field,
           field.data('civicrm-contact'),
@@ -43,7 +41,7 @@
             true,
             field.data('form-defaults'),
           );
-        }).change();
+        });
 
         //In case of error, highlight the token-input field.
         if (field.hasClass('error')) {


### PR DESCRIPTION
Overview
----------------------------------------
Contact field is displayed even if hidden in settings.

Before
----------------------------------------
To replicate:
- Create a webform with 2 contacts.
- Set the type of second contact to Organization and enable Org Name field.
- Open the Build form, edit the 2nd Existing Contact element:
-- Form Widget = Select
-- Field to Lock = Name
-- Locked Fields should be = Hidden
- Visit the webform page.
- Org Name element is still displayed.
![image](https://github.com/colemanw/webform_civicrm/assets/5929648/3bfc2144-1007-499f-901d-2e4645b79c67)
- Choose an org name, the field is hidden correctly.
- After reverting the option back to `Choose Existing`, the field remains hidden correctly.
 ![image](https://github.com/colemanw/webform_civicrm/assets/5929648/796fca89-42a9-4611-864c-f8528f2bbffd)
- The issue appears to occur only when the page is visited or loaded.

After
----------------------------------------
Fixed. The field is hidden on page load too.

Technical Details
----------------------------------------
triggers the change event on page load.

