### PR TITLE
Extends FieldInterface interface to add getSets() as service's method

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -55,7 +55,10 @@ class Fields implements FieldsInterface {
     return $this->components;
   }
 
-  protected function getSets(array $components): array {
+  /**
+   * {@inheritdoc}
+   */
+  public function getSets(array $components): array {
     if (empty($this->sets)) {
       $sets = [
         'contact' => ['entity_type' => 'contact', 'label' => t('Contact Fields')],
@@ -123,7 +126,7 @@ class Fields implements FieldsInterface {
    */
   protected function getFieldMetadata(): void {
     $components = $this->getComponents();
-    $setNames = array_keys($this->getSets($components));
+    $setNames = array_keys(\Drupal::service('webform_civicrm.fields')->getSets($components));
     foreach ($setNames as $setName) {
       $result = $this->utils->wf_crm_apivalues($setName, 'getfields');
       if ($result) {
@@ -163,7 +166,7 @@ class Fields implements FieldsInterface {
 
   protected function wf_crm_get_fields($var = 'fields') {
     $components = $this->getComponents();
-    $sets = $this->getSets($components);
+    $sets = \Drupal::service('webform_civicrm.fields')->getSets($components);
     $elements = \Drupal::service('plugin.manager.webform.element')->getInstances();
 
     static $fields = [];

--- a/src/FieldsInterface.php
+++ b/src/FieldsInterface.php
@@ -11,11 +11,19 @@ interface FieldsInterface {
    *   Name of variable to return: fields, tokens, or sets
    *
    * @return array
-   * @return array
    *   fields: The CiviCRM contact fields this module supports
    *   tokens: Available tokens keyed to field ids
    *   sets: Info on fieldsets (entities)
    */
   public function get($var = 'fields');
+
+  /**
+   * Fetches CiviCRM field sets.
+   *
+   * @param array $components
+   *
+   * @return array
+   */
+  public function getSets(array $components): array;
 
 }


### PR DESCRIPTION
Overview
----------------------------------------
Extends `FieldInterface` class and add `getSets()` method as part of it (changed visibility to public) so it will be a public method in services  `webform_civicrm.fields`. 
This change allows to decorate this service's method and add new data sets into the Webform CiviCRM Admin UI from a Drupal 9/10 custom module.

After
----------------------------------------
`getSets()` is a public method for service `webform_civicrm.fields`

Technical Details
----------------------------------------
This was discussed in PR https://github.com/colemanw/webform_civicrm/pull/827.
Once this is in place you will be able to create a Drupal 9/10 custom module to add new sections or change field's metadata in Webform CiviCRM Admin UI


Comments
----------------------------------------
I don't see any drawback on implementing this change, rather than the ones who have already created a custom module and are implementing class `FieldInterface`, will get a new error saying method `getSets()` is not implemented. Easy to fix with a `parent` callback.

