### PR TITLE
D10 - Fix intermittent test failure with billing blocks

### DIFF
--- a/tests/src/FunctionalJavascript/ContactRelationshipTest.php
+++ b/tests/src/FunctionalJavascript/ContactRelationshipTest.php
@@ -57,7 +57,7 @@ final class ContactRelationshipTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_relationship_relationship_type_id[]', 'create_civicrm_webform_element');
 
-    $this->createScreenshot($this->htmlOutputDirectory . '/adminscreen.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/adminscreen.png');
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/ContactRelationshipTest.php
+++ b/tests/src/FunctionalJavascript/ContactRelationshipTest.php
@@ -57,7 +57,7 @@ final class ContactRelationshipTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_relationship_relationship_type_id[]', 'create_civicrm_webform_element');
 
-    // $this->createScreenshot($this->htmlOutputDirectory . '/adminscreen.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/adminscreen.png');
     $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('canonical'));

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -266,7 +266,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
-    // $this->createScreenshot($this->htmlOutputDirectory . '/legacy289.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/legacy289.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->waitForText('New submission added to CiviCRM Webform Test.');
@@ -402,9 +402,8 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     ];
     $this->fillBillingFields($billingValues);
     // Wait for the ACHEFT form to load in.
-    $this->getSession()->wait(5000);
+    $this->waitUntilStyleChange('#billing-payment-block', 'display', 'block');
     $this->assertSession()->waitForElementVisible('css', '#account_holder');
-    $this->createScreenshot($this->htmlOutputDirectory . '/acheft_iats.png');
 
     $this->getSession()->getPage()->fillField('bank_account_number', '12345678');
     $this->getSession()->getPage()->fillField('bank_identification_number', '111111111');

--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -266,7 +266,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->fillBillingFields($billingValues);
     $this->getSession()->getPage()->pressButton('Submit');
     // throw new \Exception(var_export($this->htmlOutputDirectory, TRUE));
-    $this->createScreenshot($this->htmlOutputDirectory . '/legacy289.png');
+    // $this->createScreenshot($this->htmlOutputDirectory . '/legacy289.png');
     $this->htmlOutput();
     $this->assertPageNoErrorMessages();
     $this->assertSession()->waitForText('New submission added to CiviCRM Webform Test.');
@@ -364,27 +364,18 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
     ]));
-    // The label has a <div> in it which can cause weird failures here.
-    $this->assertSession()->waitForText('Enable CiviCRM Processing');
-    $this->assertSession()->waitForField('nid');
-    $this->getSession()->getPage()->checkField('nid');
-    $this->getSession()->getPage()->clickLink('Contribution');
-    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contribution_1_contribution_enable_contribution', 1);
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->assertSession()->pageTextContains('You must enable an email field for Contact 1 in order to process transactions.');
-    $this->getSession()->getPage()->pressButton('Enable It');
-    $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->getSession()->getPage()->checkField('Contribution Amount');
-    $this->getSession()->getPage()->selectFieldOption('Currency', 'USD');
-    $this->getSession()->getPage()->selectFieldOption('Financial Type', 1);
 
+    $this->enableCivicrmOnWebform();
+    $params = [
+      'payment_processor_id' => $this->payment_processor_legacy_acheft['id'],
+    ];
+    $this->configureContributionTab($params);
+    $this->getSession()->getPage()->checkField('Contribution Amount');
     $this->assertCount(5, $this->getOptions('Payment Processor'));
-    $this->getSession()->getPage()->selectFieldOption('Payment Processor',  $this->payment_processor_legacy_acheft['id']);
 
     $this->enableBillingSection();
 
-    $this->getSession()->getPage()->pressButton('Save Settings');
-    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->saveCiviCRMSettings();
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
@@ -400,13 +391,6 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '99.00');
 
-    // Wait for the ACHEFT form to load in.
-    $this->assertSession()->waitForField('account_holder');
-    $this->getSession()->getPage()->fillField('Account Holder', 'CiviCRM user');
-    $this->getSession()->getPage()->fillField('Account No.', '12345678');
-    $this->getSession()->getPage()->fillField('Bank Identification Number', '111111111');
-    $this->getSession()->getPage()->fillField('Bank Name', 'Bank of CiviCRM');
-    $this->getSession()->getPage()->selectFieldOption('bank_account_type', 'Savings');
     $billingValues = [
       'first_name' => 'Frederick',
       'last_name' => 'Pabst',
@@ -417,6 +401,16 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
       'postal_code' => '53177',
     ];
     $this->fillBillingFields($billingValues);
+    // Wait for the ACHEFT form to load in.
+    $this->getSession()->wait(5000);
+    $this->assertSession()->waitForElementVisible('css', '#account_holder');
+    $this->createScreenshot($this->htmlOutputDirectory . '/acheft_iats.png');
+
+    $this->getSession()->getPage()->fillField('bank_account_number', '12345678');
+    $this->getSession()->getPage()->fillField('bank_identification_number', '111111111');
+    $this->getSession()->getPage()->fillField('bank_name', 'Bank of CiviCRM');
+    $this->getSession()->getPage()->fillField('account_holder', 'CiviCRM user');
+    $this->getSession()->getPage()->selectFieldOption('bank_account_type', 'Savings');
     $this->getSession()->getPage()->pressButton('Submit');
 
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
@@ -430,7 +424,6 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
     $this->assertEquals('99.00', $contribution['total_amount']);
     $this->assertEquals('Pending', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
-
   }
 
   public function testSubmitRecurringContribution() {

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -718,7 +718,8 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->fillBillingFields($billingValues);
     }
     // Wait for the credit card form to load in.
-    $this->getSession()->wait(5000);
+    $this->waitUntilStyleChange('#billing-payment-block', 'display', 'block');
+
     $this->assertSession()->waitForField('credit_card_number');
     $this->createScreenshot($this->htmlOutputDirectory . '/credit_card.png');
     $this->getSession()->getPage()->fillField('credit_card_number', '4222222222222220');
@@ -809,5 +810,24 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     }
     return 'credit_card_exp_date[m]';
   }
+
+  /**
+   * Wait until a specified style property of an element changes to a specified value.
+   *
+   * @param string $selector
+   * @param string $prop
+   *   The style property
+   * @param string $value
+   *   The style value.
+   */
+  public function waitUntilStyleChange($selector, $prop, $value) {
+    $this->getSession()->wait(10000, sprintf(
+      'document.querySelector("%s").style.%s === "%s"',
+      $selector,
+      $prop,
+      $value
+    ));
+  }
+
 
 }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -681,12 +681,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     $this->getSession()->getPage()->fillField('Billing Last Name', $params['last_name']);
     $this->getSession()->getPage()->fillField('Street Address', $params['street_address']);
     $this->getSession()->getPage()->fillField('City', $params['city']);
+    $this->getSession()->getPage()->fillField('Postal Code', $params['postal_code']);
 
     $this->getSession()->getPage()->selectFieldOption('Country', $params['country']);
     $this->getSession()->wait(1000);
     $this->getSession()->getPage()->selectFieldOption('State/Province', $params['state_province']);
-
-    $this->getSession()->getPage()->fillField('Postal Code', $params['postal_code']);
   }
 
   /**
@@ -719,7 +718,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->fillBillingFields($billingValues);
     }
     // Wait for the credit card form to load in.
+    $this->getSession()->wait(5000);
     $this->assertSession()->waitForField('credit_card_number');
+    $this->createScreenshot($this->htmlOutputDirectory . '/credit_card.png');
     $this->getSession()->getPage()->fillField('credit_card_number', '4222222222222220');
     $this->getSession()->getPage()->fillField('cvv2', '123');
     $this->getSession()->getPage()->selectFieldOption($this->getCreditCardMonthFieldName(), '11');


### PR DESCRIPTION
Overview
----------------------------------------
Fix iats test failure

Before
----------------------------------------
Fails https://github.com/colemanw/webform_civicrm/actions/runs/9020820999

```
Drupal\\Tests\\webform\_civicrm\\FunctionalJavascript\\ContributionIatsTest::testSubmitACHEFTContribution

[28](https://github.com/colemanw/webform_civicrm/actions/runs/9020820999/job/24800162518#step:24:29)
Behat\\Mink\\Exception\\ElementNotFoundException: 
Form field with id|name|label|value|placeholder "Account Holder" not found.
```

After
----------------------------------------
Pass

Technical Details
----------------------------------------
Add values to billing fields before filling iats fields, so it gets time to load.

Comments
----------------------------------------
@KarinG 