### PR TITLE
smarty4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,11 @@ jobs:
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.drastikbydesign.stripe
           /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.iatspayments.civicrm
           /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.aghstrategies.uscounties
+      - name: temp patch iats for smarty4
+        run: |
+          cd ~/drupal/web/sites/default/files/civicrm/ext/com.iatspayments.civicrm
+          curl -L -O https://github.com/iATSPayments/com.iatspayments.civicrm/pull/449.patch
+          git apply 449.patch
       - uses: nanasess/setup-chromedriver@master
       - name: Run chromedriver
         run: chromedriver &


### PR DESCRIPTION
Overview
----------------------------------------
civi master tests fail since smarty4 is now the default there but iats 1.8.0 doesn't have patch 449

Before
----------------------------------------
crash with `SmartyCompilerException: "Syntax error in template &quot;file:\ext\com.iatspayments.civicrm\templates\CRM\Iats\BillingBlockDirectDebitExtra_USD.tpl &quot;on line 8 &quot;&lt;div class=&quot;content &quot;&gt;&lt;img width=500 height=303 src=&quot;{crmResURL ext=com.iatspayments.civicrm file=templates/CRM/Iats/USD_check_500x.jpg}&quot;&gt;&lt;/div &gt;&quot;- Unexpected &quot;.&quot;, expected one of: &quot;}&quot;"</b>`


After
----------------------------------------


Technical Details
----------------------------------------


Comments
----------------------------------------

