### PR TITLE
#3402697 Prevent "required" error on existing contact locked fields

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -145,7 +145,10 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       if ($existing_component && empty($submitted_contacts[$c])) {
         // When the contact has been manually selected/entered and the form has therefore been filled via
         // an ajax request, we must make the selected contact_id value available to findContact()
-        $this->ent['contact'][$c]['id'] = $this->form_state->getUserInput()[$existing_component['#form_key']];
+        $user_input = $this->form_state->getUserInput();
+        if (isset($user_input[$existing_component['#form_key']])) {
+          $this->ent['contact'][$c]['id'] = $user_input[$existing_component['#form_key']];
+        }
         $this->findContact($existing_component);
       }
       // Fill cid with '0' if unknown

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -143,6 +143,9 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       $existing_component = $this->node->getElement("civicrm_{$c}_contact_1_contact_existing");
       // Search for contact if the user hasn't already chosen one
       if ($existing_component && empty($submitted_contacts[$c])) {
+        // When the contact has been manually selected/entered and the form has therefore been filled via
+        // an ajax request, we must make the selected contact_id value available to findContact()
+        $this->ent['contact'][$c]['id'] = $this->form_state->getUserInput()[$existing_component['#form_key']];
         $this->findContact($existing_component);
       }
       // Fill cid with '0' if unknown


### PR DESCRIPTION
Overview
----------------------------------------
Corrects issue [3402697](https://www.drupal.org/project/webform_civicrm/issues/3402697).

Before
----------------------------------------
"Field is required" error occurs upon submission of a required field that is locked by an Existing Contact widget when that widget is configured in a non-static mode, e.g. AutoComplete.

After
----------------------------------------
The submission completes without error.

Technical Details
----------------------------------------
Currently, the submitted contact_id value from the Existing Contact element in the non-static modes modes is ignored within WebformCivicrmPreProcess::alterForm(), This change causes the submitted contact_id value be utilized in a manner similar to the operation in the static modes, e.g. contact_id from URL or from Current User.