### PR TITLE
drupal 11 readiness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,15 +165,15 @@ jobs:
         run: php -S 127.0.0.1:8080 -t ~/drupal/web &
       - name: Run PHPUnit
         run: |
-          mkdir $BROWSERTEST_OUTPUT_DIRECTORY
+          mkdir -p $BROWSERTEST_OUTPUT_DIRECTORY
           cd ~/drupal/web
           ../vendor/bin/phpunit -c core modules/contrib/webform_civicrm
         env:
           SYMFONY_DEPRECATIONS_HELPER: 999999
           SIMPLETEST_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080
-          MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'
-          BROWSERTEST_OUTPUT_DIRECTORY: '${{ runner.temp }}/browser_output'
+          MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'
+          BROWSERTEST_OUTPUT_DIRECTORY: '/home/runner/drupal/web/sites/simpletest/browser_output'
           DEV_EXTENSION_DIR: /home/runner/drupal/web/sites/default/files/civicrm/ext
           DEV_EXTENSION_URL: http://127.0.0.1:8080/sites/default/files/civicrm/ext
       - name: Helper to make unique name for upload


### PR DESCRIPTION
Overview
----------------------------------------
Small test script change that can be done now.

Before
----------------------------------------
* Silent fail where nothing seems to happen during phpunit run and it just skips the test.
* Ignoration (is that a word?) of BROWSER_OUTPUT_DIRECTORY fixed in core. Now it actually uses the variable so it needs to match where the artifact upload step is looking for the files.

After
----------------------------------------
* phpunit runs the test
* Unignoration of BROWSER_OUTPUT_DIRECTORY

Technical Details
----------------------------------------
In phpunit10 you have to give it the argument `--display-skipped` to tell you why it skipped tests. The error was `DevToolsActivePort file doesn't exist) (The process started from chrome location /opt/google/chrome/google-chrome is no longer running`. This turned out to be https://www.drupal.org/node/3240792 - see description API Changes where you now have to use goog:chromeOptions. (Note the deprecation notice does not appear in 11 since they removed the notice, but 10.3 just went beta on the 17th, so that notice wasn't showing up anywhere.)

Comments
----------------------------------------
