### PR TITLE
Fix fatal error on custom field deletion

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2533,7 +2533,10 @@ class AdminForm implements AdminFormInterface {
       $data = $settings['data'];
       $field_info = $utils->wf_crm_get_field($field_name);
       // $field_info contains old data, so re-fetch
-      $fieldConfigs = $utils->wf_civicrm_api('CustomField', 'getsingle', ['id' => $fid]);
+      $fieldConfigs = [];
+      if ($op !== 'delete' && $op !== 'disable') {
+        $fieldConfigs = $utils->wf_civicrm_api('CustomField', 'getsingle', ['id' => $fid]);
+      }
       $enabled = $utils->wf_crm_enabled_fields($webform, NULL, TRUE);
       $updated = [];
       // Handle update & delete of existing components

--- a/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/CustomFieldSubmissionTest.php
@@ -323,7 +323,7 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
     foreach ($customFieldLabels as $label) {
       $this->assertSession()->pageTextContains($label);
     }
-    //Disable Custom field.
+    // Disable Custom field.
     $fieldURL = Url::fromUri('internal:/civicrm/admin/custom/group/field/update', [
       'absolute' => TRUE,
       'query' => ['reset' => 1, 'action' => 'update', 'gid' => 1, 'id' => $this->_customFields['color_checkboxes']]
@@ -352,6 +352,22 @@ final class CustomFieldSubmissionTest extends WebformCivicrmTestBase {
 
     // Verify if the custom field is back on the page.
     $this->assertSession()->pageTextContains('Label for Custom Checkbox field');
+
+    // Delete Custom field.
+    $fieldURL = Url::fromUri('internal:/civicrm/admin/custom/group/field/delete', [
+      'absolute' => TRUE,
+      'query' => ['reset' => 1, 'id' => $this->_customFields['color_checkboxes']]
+    ])->toString();
+    $this->drupalGet($fieldURL);
+    $this->getSession()->getPage()->pressButton('_qf_DeleteField_next-bottom');
+
+    // Reload the webform page - the custom field should be removed.
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    // Verify if the custom field is removed from the page.
+    $this->assertSession()->pageTextNotContains('Label for Custom Checkbox field');
 
     //Change single radio to static.
     $this->drupalGet($this->webform->toUrl('edit-form'));


### PR DESCRIPTION
Overview
----------------------------------------
Fix fatal error on custom field deletion

Before
----------------------------------------
Deleting a custom fields returns a fatal error if the field is added to a webform dynamically.

To replicate:
- Create a custom group and a field.
- Create a webform and add this custom group with this checkbox -
![image](https://github.com/colemanw/webform_civicrm/assets/5929648/0fb9e3c9-a442-469c-9df0-bf4994f17688)
- Delete this field in civicrm.
- Error.
> Expected one CustomField but found 0

After
----------------------------------------
Fixed.


