### PR TITLE
Don't search related tables when filtering a contact reference field.

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -148,6 +148,12 @@ class ContactComponent implements ContactComponentInterface {
     if ($str) {
       $searchFields = [];
       foreach ($display_fields as $fld) {
+        // Don't search related tables - not intuitive and also when searching a
+        // :label version of a related record, the LEFT join causes CiviCRM to
+        // return all records.
+        if (preg_match('/^(address|phone|email)/', $fld)) {
+          continue;
+        }
         $searchFields[] = [$fld, 'CONTAINS', $str];
       }
       $params['where'][] = ['OR', $searchFields];


### PR DESCRIPTION
Overview
----------------------------------------

If you have an "Existing Contact" field, and, in the Builder tab, in the field definition's "Form display" section you configure the "Contact Display Fields" to display the State/Province, you will not get accurate results when entering a string to filter the results by. The field will display all results.

The problem is that the code builds the WHERE clause using every field entered as a display field. However, perhaps because the contact tables are LEFT JOIN'ed and the WHERE clause is an OR clause, the query somehow fails to filter the given string at all.

Since it's unlikely and even unexpected to have your search term applied to the address, email or phone tables, this patch simply removes that clause.

Before
----------------------------------------
Contact reference fields that include the "State/Province" as a display field fail to filter properly.

After
----------------------------------------
Contact reference fields, regardless of the display fields configured, are properly filtered.

