### PR TITLE
D11 support

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -821,11 +821,17 @@ abstract class WebformCivicrmBase {
     }
     $file = $this->utils->wf_crm_apivalues('Attachment', 'get', $val);
     if (!empty($file[$val])) {
+      if (function_exists('file_icon_class')) {
+        $icon_class = file_icon_class($file[$val]['mime_type']);
+      }
+      else {
+        $icon_class = \Drupal\file\IconMimeTypes::getIconClass($file[$val]['mime_type']);
+      }
       return [
         'data_type' => 'File',
         'name' => $file[$val]['name'],
         'file_url'=> $file[$val]['url'],
-        'icon' => file_icon_class($file[$val]['mime_type']),
+        'icon' => $icon_class,
       ];
     }
     return NULL;

--- a/webform_civicrm.info.yml
+++ b/webform_civicrm.info.yml
@@ -1,7 +1,7 @@
 name: 'Webform CiviCRM'
 type: module
 description: 'Webform CiviCRM Integration'
-core_version_requirement: ^9.4 || ^10
+core_version_requirement: ^9.4 || ^10 || ^11
 package: 'CiviCRM'
 dependencies:
   - drupal:webform


### PR DESCRIPTION
Overview
----------------------------------------
Changes to support Drupal 11


Technical Details
----------------------------------------
Drupal deprecation code analysis provides this output for deprecations needing to be changed in D11
```
 ------ --------------------------------------------------------- 
  Line   src/WebformCivicrmBase.php                               
 ------ --------------------------------------------------------- 
  825    Call to deprecated function file_icon_class():           
         in drupal:10.3.0 and is removed from drupal:11.0.0. Use  
           \Drupal\file\IconMimeTypes::getIconClass() instead.    
 ------ --------------------------------------------------------- 

```
Comments
----------------------------------------
Drupal change record: https://www.drupal.org/node/3411269

To support D9 and D11, we have to check if function exists, and then use full object path. 
When D9 support is dropped, should add a "use" statement and remove the conditional


