### PR TITLE
d10 - Fix default load of yesno custom field

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -574,7 +574,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
               if (!is_array($val) && !isset($element['#options'][$val])) {
                 $val = NULL;
               }
-              if ((empty($val) || (is_array($val) && empty(array_filter($val)))) && !empty($this->form['#attributes']['data-form-defaults'])) {
+              if ((is_null($val) || (is_array($val) && empty(array_filter($val)))) && !empty($this->form['#attributes']['data-form-defaults'])) {
                 $formDefaults = Json::decode($this->form['#attributes']['data-form-defaults']);
                 $key = str_replace('_', '-', $element['#form_key']);
                 if (isset($formDefaults[$key])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix default load of yesno custom field

Before
----------------------------------------
To replicate:
- Create a custom set and a field of data type yesno in CiviCRM.
- Add this field to a webform.
- Provide a default value to the webform element. Eg Yes.
- Load the form with the default cid
- Choose custom field value = No
![image](https://github.com/colemanw/webform_civicrm/assets/5929648/d0072ba0-d440-4f69-a58e-4c5b3e982c81)
- Submit the form. Notice the value is correctly saved to civicrm.
- Load the form again.
- The value `Yes` is loaded by default instead of `No` existing on the contact.

After
----------------------------------------
Correct default value from the contact is loaded on the form.


