### PR TITLE
optimize event loading

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -131,11 +131,15 @@ class Utils implements UtilsInterface {
    * @return array
    */
   function wf_crm_get_events($reg_options, $context) {
-    $ret = [];
+    static $ret = [];
+    if ($ret && $context !== 'config_form') {
+      return $ret;
+    }
     $format = wf_crm_aval($reg_options, 'title_display', 'title');
     $sort_field = wf_crm_aval($reg_options, 'event_sort_field', 'start_date');
     $sort_order = ($context == 'config_form' && $sort_field === 'start_date') ? ' DESC' : '';
     $params = [
+      'return' => ['id', 'title', 'start_date', 'end_date', 'event_type_id', 'max_participants'],
       'is_template' => 0,
       'is_active' => 1,
     ];


### PR DESCRIPTION
Overview
----------------------------------------
Loading events into the event selector is *slow*.  I have a registration form that allows you to select 4 events for up to 5 people.  XDebug profiling showed that about 2/3 of the page load time was just loading events.

So I made two optimizations:
* We request all the event fields - with API3, so it's even joining to custom tables.  We only need 5 fields to calculate the event selector.
* It's not possible to load different events per event selector, but we look up the events separately for every event selector (twice!).

Before
----------------------------------------
I loaded the form 3 times.  The average load time was 13.45 seconds.

After
----------------------------------------
Limiting the fields returned from API3 got the average to 5.81 seconds.
Caching the returned results got the average to 5.20 seconds.
Limiting fields AND caching results got us down to 5.04 seconds - optimizing event lookup reduced the *entire page load time* by 5/8ths. And look how easy this is to review :)

Comments
----------------------------------------
This was just the easy optimizations!  With API4, you could get rid of a lot more of this code.  I also considered lazy loading, but once we cached the values, it seems like that would make things slower, not faster.