### PR TITLE
Jquery deprecations removed from drupal 11

### DIFF
--- a/js/jquery.tokeninput.js
+++ b/js/jquery.tokeninput.js
@@ -581,7 +581,7 @@
       }
 
       function add_freetagging_tokens() {
-          var value = $.trim(input_box.val());
+          var value = input_box.val().trim();
           var tokens = value.split($(input).data("settings").tokenDelimiter);
           $.each(tokens, function(i, token) {
             if (!token) {

--- a/js/jquery.tokeninput.js
+++ b/js/jquery.tokeninput.js
@@ -468,7 +468,7 @@
       hiddenInput.val("");
       var li_data = $(input).data("settings").prePopulate || hiddenInput.data("pre");
 
-      if ($(input).data("settings").processPrePopulate && $.isFunction($(input).data("settings").onResult)) {
+      if ($(input).data("settings").processPrePopulate && (typeof $(input).data("settings").onResult === "function")) {
           li_data = $(input).data("settings").onResult.call(hiddenInput, li_data);
       }
 
@@ -588,7 +588,7 @@
               return;
             }
 
-            if ($.isFunction($(input).data("settings").onFreeTaggingAdd)) {
+            if (typeof $(input).data("settings").onFreeTaggingAdd === "function") {
               token = $(input).data("settings").onFreeTaggingAdd.call(hiddenInput, token);
             }
             var object = {};
@@ -684,7 +684,7 @@
           hide_dropdown();
 
           // Execute the onAdd callback if defined
-          if($.isFunction(callback)) {
+          if (typeof callback === "function") {
               callback.call(hiddenInput,item);
           }
       }
@@ -774,7 +774,7 @@
           }
 
           // Execute the onDelete callback if defined
-          if($.isFunction(callback)) {
+          if (typeof callback === "function") {
               callback.call(hiddenInput,token_data);
           }
       }
@@ -973,7 +973,7 @@
           var cache_key = query + computeURL();
           var cached_results = cache.get(cache_key);
           if (cached_results) {
-              if ($.isFunction($(input).data("settings").onCachedResult)) {
+              if (typeof $(input).data("settings").onCachedResult === "function") {
                 cached_results = $(input).data("settings").onCachedResult.call(hiddenInput, cached_results);
               }
               populateDropdown(query, cached_results);
@@ -1022,7 +1022,7 @@
                   // Attach the success callback
                   ajax_params.success = function(results) {
                     cache.add(cache_key, $(input).data("settings").jsonContainer ? results[$(input).data("settings").jsonContainer] : results);
-                    if($.isFunction($(input).data("settings").onResult)) {
+                    if (typeof $(input).data("settings").onResult === "function") {
                         results = $(input).data("settings").onResult.call(hiddenInput, results);
                     }
 
@@ -1046,7 +1046,7 @@
                   });
 
                   cache.add(cache_key, results);
-                  if($.isFunction($(input).data("settings").onResult)) {
+                  if (typeof $(input).data("settings").onResult === "function") {
                       results = $(input).data("settings").onResult.call(hiddenInput, results);
                   }
                   populateDropdown(query, results);

--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -269,7 +269,7 @@ var wfCiviAdmin = (function (D, $, once) {
         if ($('select[name$="_contact_sub_type[]"]', context).val()) {
           var first = true;
           $('select[name$="_contact_sub_type[]"] option:selected', context).each(function() {
-            label += (first ? ' (' : ', ') + $.trim($(this).text());
+            label += (first ? ' (' : ', ') + $(this).text().trim();
             first = false;
           });
           label += ')';
@@ -325,7 +325,7 @@ var wfCiviAdmin = (function (D, $, once) {
       $(once('wf-civi', 'details#edit-additional-options', context)).drupalSetSummary(function (context) {
         var label = [];
         $(':checked', context).each(function() {
-          label.push($.trim($(this).siblings('label').contents().first().text()));
+          label.push($(this).siblings('label').contents().first().text().trim());
         });
         return label.join(', ') || Drupal.t('- None -');
       });


### PR DESCRIPTION
Overview
----------------------------------------
Replace jquery functions that no longer exist in the jquery version included in drupal 11

Before
----------------------------------------
[trim()](https://api.jquery.com/jQuery.trim) and [isFunction()](https://api.jquery.com/jQuery.isFunction) deprecated since jquery 3.5 and 3.3, and are errors in drupal 11.

After
----------------------------------------
Regular javascript which has long been supported in all browsers.
* trim() replaced with trim()
* isFunction replaced with typeof

Technical Details
----------------------------------------
See also https://www.drupal.org/project/drupal/issues/3239132

Comments
----------------------------------------
