### PR TITLE
D10: Update soft credit implementation

### DIFF
--- a/js/webform_civicrm_admin.js
+++ b/js/webform_civicrm_admin.js
@@ -500,25 +500,6 @@ var wfCiviAdmin = (function (D, $, once) {
         changeContactLabel.call(this);
       });
 
-      // Contribution honoree fields
-      $(once('crm-contrib', 'select[name$=contribution_honor_contact_id]', context)).change(function() {
-        if ($(this).val() == '0') {
-          $('.form-item-civicrm-1-contribution-1-contribution-honor-type-id').hide();
-        }
-        else {
-          $('.form-item-civicrm-1-contribution-1-contribution-honor-type-id').show();
-        }
-      }).change();
-      $(once('crm-contrib', 'select[name$=contribution_honor_type_id]', context)).change(function() {
-        var $label = $('.form-item-civicrm-1-contribution-1-contribution-honor-contact-id label');
-        if ($(this).val() == 'create_civicrm_webform_element') {
-          $label.html(Drupal.t('In Honor/Memory of'));
-        }
-        else {
-          $label.html($('option:selected', this).html());
-        }
-      }).change();
-
       // Membership constraints
       $(once('crm-mem-date', 'select[name$=_membership_num_terms]', context)).change(function(e, type) {
         var $dateWrappers = $(this).parent().siblings('[class$="-date"]').not('[class$="-status-override-end-date"]');

--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -109,12 +109,17 @@ class FieldOptions implements FieldOptionsInterface {
       else {
         $params = ['field' => $name, 'context' => 'create'];
         // Special case for contribution_recur fields
-        if ($table == 'contribution' && strpos($name, 'frequency_') === 0) {
-          $table = 'contribution_recur';
-        }
-        if ($table == 'contribution' && strpos($name, 'billing_address_') === 0) {
-          $table = 'address';
-          $params['field'] = str_replace('billing_address_', '', $params['field']);
+        if ($table === 'contribution') {
+          if (str_starts_with($name, 'frequency_')) {
+            $table = 'contribution_recur';
+          }
+          elseif ($name === 'soft_credit_type_id') {
+            $table = 'contribution_soft';
+          }
+          elseif (str_starts_with($name, 'billing_address_')) {
+            $table = 'address';
+            $params['field'] = str_replace('billing_address_', '', $params['field']);
+          }
         }
         // Use the Contribution table to pull up financial type id-s
         if ($table == 'membership' && $name == 'financial_type_id') {

--- a/src/Fields.php
+++ b/src/Fields.php
@@ -719,28 +719,6 @@ class Fields implements FieldsInterface {
           'type' => 'textarea',
           'parent' => 'contribution_pagebreak',
         ];
-        $fields['contribution_soft'] = [
-          'name' => t('Soft Credit To'),
-          'type' => 'select',
-          'expose_list' => TRUE,
-          'extra' => ['multiple' => TRUE],
-          'data_type' => 'ContactReference',
-          'parent' => 'contribution_pagebreak',
-        ];
-        $fields['contribution_honor_contact_id'] = [
-          'name' => t('In Honor/Memory of'),
-          'type' => 'select',
-          'expose_list' => TRUE,
-          'empty_option' => t('No One'),
-          'data_type' => 'ContactReference',
-          'parent' => 'contribution_pagebreak',
-        ];
-        $fields['contribution_honor_type_id'] = [
-          'name' => t('Honoree Type'),
-          'type' => 'select',
-          'expose_list' => TRUE,
-          'parent' => 'contribution_pagebreak',
-        ];
         $fields['contribution_source'] = [
           'name' => t('Contribution Source'),
           'type' => 'textfield',
@@ -793,6 +771,28 @@ class Fields implements FieldsInterface {
           'set' => 'line_items',
           'fid' => 'contribution_financial_type_id',
         ];
+
+        // Soft Credit
+        $sets['contributionSoft'] = ['entity_type' => 'contribution', 'label' => t('Soft Credit')];
+        $fields['contribution_soft'] = [
+          'name' => t('Soft Credit To'),
+          'type' => 'select',
+          'expose_list' => TRUE,
+          'extra' => ['multiple' => TRUE],
+          'data_type' => 'ContactReference',
+          'parent' => 'contribution_pagebreak',
+          'set' => 'contributionSoft',
+        ];
+        $fields['contribution_soft_credit_type_id'] = [
+          'name' => t('Soft Credit Type'),
+          'type' => 'select',
+          'expose_list' => TRUE,
+          'civicrm_live_options' => TRUE,
+          'empty_option' => t('None'),
+          'parent' => 'contribution_pagebreak',
+          'set' => 'contributionSoft',
+        ];
+
         $sets['contributionRecur'] = ['entity_type' => 'contribution', 'label' => t('Recurring Contribution')];
         $fields['contribution_frequency_unit'] = [
           'name' => t('Frequency of Installments'),

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2273,7 +2273,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
 
     // Save this stuff for later
-    unset($params['soft'], $params['honor_contact_id'], $params['honor_type_id']);
+    unset($params['soft'], $params['soft_credit_type_id']);
     return $params;
   }
 
@@ -2302,20 +2302,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           'contribution_id' => $id,
           'amount' => $amount,
           'currency' => wf_crm_aval($this->data, "contribution:1:currency"),
-          'soft_credit_type_id' => $default_soft_credit_type['value'],
+          'soft_credit_type_id' => $contribution['soft_credit_type_id'] ?? $default_soft_credit_type['value'],
         ]);
       }
     }
-    // Save honoree
-    if (!empty($contribution['honor_contact_id']) && !empty($contribution['honor_type_id'])) {
-      $this->utils->wf_civicrm_api('contribution_soft', 'create', [
-        'contribution_id' => $id,
-        'amount' => $contribution['total_amount'],
-        'contact_id' => $contribution['honor_contact_id'],
-        'soft_credit_type_id' => $contribution['honor_type_id'],
-      ]);
-    }
-
     $contributionResult = \CRM_Contribute_BAO_Contribution::getValues(['id' => $id], \CRM_Core_DAO::$_nullArray, \CRM_Core_DAO::$_nullArray);
 
     // Save line-items

--- a/tests/src/FunctionalJavascript/ContributionSoftTest.php
+++ b/tests/src/FunctionalJavascript/ContributionSoftTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
+
+use Civi\Api4\Contribution;
+use Drupal\Core\Url;
+
+final class ContributionSoftTest extends WebformCivicrmTestBase {
+
+  /**
+   * Test contribution with soft-credit
+   */
+  public function testSoftCredit() {
+    $this->drupalLogin($this->rootUser);
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->selectFieldOption('number_of_contacts', 2);
+    $this->htmlOutput();
+
+    $params = [
+      'payment_processor_id' => 'Pay Later',
+      'soft' => 'Contact 2',
+      'soft_credit_type_id' => 'In Memory of',
+    ];
+    $this->configureContributionTab($params);
+
+    $this->getSession()->getPage()->selectFieldOption('Enable Billing Address?', 'No');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->checkField('Contribution Amount');
+
+    $this->saveCiviCRMSettings();
+
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+
+    $this->getSession()->getPage()->fillField('civicrm_1_contact_1_contact_first_name', 'Frederick');
+    $this->getSession()->getPage()->fillField('civicrm_1_contact_1_contact_last_name', 'Pabst');
+    $this->getSession()->getPage()->fillField('civicrm_1_contact_1_email_email', 'fred@example.com');
+
+    // Second contact to assign the soft credit.
+    $this->getSession()->getPage()->fillField('civicrm_2_contact_1_contact_first_name', 'Max');
+    $this->getSession()->getPage()->fillField('civicrm_2_contact_1_contact_last_name', 'Plank');
+
+    $this->getSession()->getPage()->pressButton('Next >');
+    $this->assertPageNoErrorMessages();
+    $this->getSession()->getPage()->fillField('Contribution Amount', '20');
+
+    $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
+    $this->htmlOutput();
+    $this->assertSession()->elementTextContains('css', '#wf-crm-billing-total', '20.00');
+
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    $contribution = Contribution::get(TRUE)
+      ->addSelect('contribution_soft.amount', 'contribution_soft.soft_credit_type_id:label', 'contribution_soft.contact_id.display_name', 'contact_id.display_name')
+      ->addJoin('ContributionSoft AS contribution_soft', 'LEFT')
+      ->execute()
+      ->first();
+    $this->assertEquals('Frederick Pabst', $contribution['contact_id.display_name']);
+    $this->assertEquals('20', $contribution['contribution_soft.amount']);
+    $this->assertEquals('In Memory of', $contribution['contribution_soft.soft_credit_type_id:label']);
+    $this->assertEquals('Max Plank', $contribution['contribution_soft.contact_id.display_name']);
+  }
+
+}

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -243,6 +243,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if (!empty($params['payment_processor_id'])) {
       $this->getSession()->getPage()->selectFieldOption('Payment Processor', $params['payment_processor_id']);
     }
+    if (!empty($params['soft'])) {
+      $this->getSession()->getPage()->selectFieldOption('Soft Credit To', $params['soft']);
+      $this->getSession()->getPage()->selectFieldOption('Soft Credit Type', $params['soft_credit_type_id']);
+    }
 
     if (!empty($params['receipt'])) {
       $this->getSession()->getPage()->selectFieldOption('Enable Receipt?', 'Yes');

--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -397,7 +397,7 @@ function webform_civicrm_update_8006() {
         }
       }
     }
-    // Update data key in settings to have the correct case for subtype. 
+    // Update data key in settings to have the correct case for subtype.
     $data = &$settings['data'];
     foreach ($data['contact'] as $key => &$contact) {
       if (!empty($contact['contact'][1]['contact_sub_type'])) {
@@ -412,6 +412,32 @@ function webform_civicrm_update_8006() {
     }
 
     if ($settings_updated) {
+      $handler->setConfiguration($config);
+      $webform->save();
+    }
+  }
+}
+
+/**
+ * Fix old soft credit data.
+ */
+function webform_civicrm_update_8007() {
+  \Drupal::service('civicrm')->initialize();
+  $webforms = Webform::loadMultiple();
+  foreach ($webforms as $webform) {
+    $handler = $webform->getHandlers('webform_civicrm');
+    $config = $handler->getConfiguration();
+    if (empty($config['webform_civicrm'])) {
+      continue;
+    }
+    $data = &$config['webform_civicrm']['settings']['data'];
+    if (empty($data['contribution'][1]['contribution'][1])) {
+      continue;
+    }
+    $contribution = $data['contribution'][1]['contribution'][1];
+    if (!empty($contribution['honor_contact_id']) && !empty($contribution['honor_type_id'])) {
+      $data['contribution'][1]['contribution'][1]['soft'][$contribution['honor_contact_id']] = $contribution['honor_contact_id'];
+      $data['contribution'][1]['contribution'][1]['soft_credit_type_id'] = $contribution['honor_type_id'];
       $handler->setConfiguration($config);
       $webform->save();
     }


### PR DESCRIPTION
Overview
----------------------------------------
Revise soft credit implementation to make it in line with latest CiviCRM.

Before
----------------------------------------
Code still uses the 4.x civicrm format of `honor_type_id` & `honor_contact_id`

![image](https://github.com/colemanw/webform_civicrm/assets/5929648/23293446-f413-4496-b1ef-8981f96ebbab)

After
----------------------------------------
Soft Credit section added for admins to configure type and contact.

![image](https://github.com/colemanw/webform_civicrm/assets/5929648/95bbdbb4-e6a9-4049-9fc3-3db550544dcd)

Comments
----------------------------------------
The PR includes an upgrade code to update all existing webforms using honor_type_id, assigning it to the soft_credit_type_id element as needed.

The only limitation is that it does not support assigning multiple soft_credit_type values to contacts. This can be added in a follow-up if required.

With this PR, multiple contact IDs can be selected for a single soft credit type.