### PR TITLE
Add is email receipt as doPayment parameter

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2160,6 +2160,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $params['cancelURL'] = $this->getIpnRedirectUrl('cancel');
     }
 
+    $params['is_email_receipt'] = wf_crm_aval($this->data, "receipt:number_number_of_receipt", FALSE);
+
     $this->form_state->set(['civicrm', 'doPayment'], $params);
 
   }


### PR DESCRIPTION
Overview
----------------------------------------
This little modification allows transfer if the Webform takes care of sending the receipt to doPayment function.

This can allow, for example, payment gateways like [Redsys](https://lab.civicrm.org/extensions/redsys) to decide whether to manage the sending of receipts or delegate it to the webform.