### PR TITLE
Always run the upload artifact naming step in tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,6 +187,7 @@ jobs:
           DEV_EXTENSION_DIR: /home/runner/drupal/web/sites/default/files/civicrm/ext
           DEV_EXTENSION_URL: http://127.0.0.1:8080/sites/default/files/civicrm/ext
       - name: Helper to make unique name for upload
+        if: ${{ failure() || success() }}
         run: |
           # doing this on multiple lines to avoid quote-hell
           cd ${{ runner.temp }}


### PR DESCRIPTION
Overview
----------------------------------------
The upload file doesn't have the interesting part of the filename when it fails

Before
----------------------------------------
Just named "screenshots."

After
----------------------------------------
Filename includes php, drupal, civi version info.

Technical Details
----------------------------------------
The github action used to make the zip file changed how it worked a while ago, and the filename now has to be unique within a run when there's multiple matrix combinations. The workflow script has a little section where it generates this name. Normally steps don't run if an earlier one fails - this step was missing the line that tells it to also run on fail.

Comments
----------------------------------------
When two or more matrix combinations failed within a run, it would then also generate an additional confusing error because you can't have two files named "screenshots."
