### PR TITLE
Honor submitted cid value in existing_contact

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -17,15 +17,19 @@
             searchingText: "Searching...",
             enableHTML: true
           };
-          wfCivi.existingInit(
-            field,
-            field.data('civicrm-contact'),
-            field.data('form-id'),
-            autocompleteUrl,
-            toHide,
-            tokenValues
-          );
         }
+        else {
+          var tokenValues = false;
+        }
+        
+        wfCivi.existingInit(
+          field,
+          field.data('civicrm-contact'),
+          field.data('form-id'),
+          autocompleteUrl,
+          toHide,
+          tokenValues
+        );
 
         field.change(function () {
           wfCivi.existingSelect(

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -32,7 +32,7 @@ abstract class WebformCivicrmBase {
   protected $line_items = [];
   protected $membership_types = [];
   protected $loadedContacts = [];
-  protected $editingSubmission;
+  protected $submission_id;
 
   // No direct access - storage for variables fetched via __get
   private $_payment_processor;
@@ -75,7 +75,7 @@ abstract class WebformCivicrmBase {
         return \CRM_Utils_System::version();
 
       default:
-        throw new Exception('Unknown property');
+        throw new \Exception('Unknown property');
     }
   }
 
@@ -262,9 +262,19 @@ abstract class WebformCivicrmBase {
     list(, $c,) = explode('_', $component['#form_key'], 3);
     $filters = $contactComponent->wf_crm_search_filters($this->node, $component);
 
-    // If a valid cid value is being submitted for the existing contact, then no need to continue.
-    if (!empty($cid_submitted_value) && $contactComponent->wf_crm_contact_access($component, $filters, $cid_submitted_value) != FALSE) {
-      $this->ent['contact'][$c]['id'] = $cid_submitted_value;
+    // If we have a submitted value for the existing contact then no need to
+    // examine the URL params or default settings.
+    if (!is_null($cid_submitted_value)) {
+      if ($this->utils->wf_crm_is_positive($cid_submitted_value)
+        && !empty($this->enabled[$component['#form_key']])
+        && $contactComponent->wf_crm_contact_access($component, $filters, $cid_submitted_value) != FALSE) {
+        $this->ent['contact'][$c]['id'] = $cid_submitted_value;
+      }
+      else {
+        // We arrive here if an existing_contact field is blank or set to
+        // "Create New" ($cid_submitted_value starts with "-").
+        $this->ent['contact'][$c]['id'] = 0;
+      }
       return;
     }
 

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -255,12 +255,19 @@ abstract class WebformCivicrmBase {
    * @param array $component
    *   Webform component of type 'civicrm_contact'
    */
-  protected function findContact($component) {
+  protected function findContact($component, $cid_submitted_value = null) {
     $contactComponent = \Drupal::service('webform_civicrm.contact_component');
     $component['#form_key'] = $component['#form_key'] ?? $component['#webform_key'];
 
     list(, $c,) = explode('_', $component['#form_key'], 3);
     $filters = $contactComponent->wf_crm_search_filters($this->node, $component);
+
+    // If a valid cid value is being submitted for the existing contact, then no need to continue.
+    if (!empty($cid_submitted_value) && $contactComponent->wf_crm_contact_access($component, $filters, $cid_submitted_value) != FALSE) {
+      $this->ent['contact'][$c]['id'] = $cid_submitted_value;
+      return;
+    }
+
     // Start with the url - that trumps everything.
     $element_manager = \Drupal::getContainer()->get('plugin.manager.webform.element');
     $existing_component_plugin = $element_manager->getElementInstance($component);

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -26,14 +26,14 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivicrmPreProcessInterface {
 
   private $form;
-  private $form_state;
   private $info = [];
   private $all_fields;
   private $all_sets;
 
-  /**
-   * @var \Drupal\webform_civicrm\UtilsInterface
-   */
+  /** @var \Drupal\Core\Form\FormState  */
+  private $form_state;
+
+  /** @var \Drupal\webform_civicrm\UtilsInterface */
   protected $utils;
 
   public function __construct(UtilsInterface $utils) {
@@ -59,12 +59,12 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     $this->all_sets = $this->utils->wf_crm_get_fields('sets');
     $this->enabled = $this->utils->wf_crm_enabled_fields($handler->getWebform());
     $this->line_items = $form_state->get(['civicrm', 'line_items']) ?: [];
-    $this->editingSubmission = $webform_submission->id();
+    $this->submission_id = $webform_submission->id();
     // If editing an existing submission, load entity data
-    if ($this->editingSubmission) {
+    if ($this->submission_id) {
       $query = \Drupal::database()->select('webform_civicrm_submissions', 'wcs')
         ->fields('wcs', ['civicrm_data'])
-        ->condition('sid', $this->editingSubmission, '=');
+        ->condition('sid', $this->submission_id, '=');
       $content = $query->execute()->fetchAssoc();
       if (!empty($content['civicrm_data'])) {
         $this->ent = unserialize($content['civicrm_data']);
@@ -89,23 +89,6 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     if (!empty($this->form_state->get('civicrm'))) {
       $this->ent = $this->form_state->get(['civicrm', 'ent']);
     }
-    $submitted_contacts = [];
-    // Keep track of cids across multipage forms
-    // @TODO this block appears to be left over from D7 and is never executed(?)
-    if (!empty($this->form_state->getValue('submitted')) && $this->form_state->get(['webform','page_count']) > 1) {
-      foreach ($this->enabled as $k => $v) {
-        // @TODO review the usage of the existing element.
-        if (substr($k, -8) == 'existing' && $this->form_state->getValue(['submitted', $v])) {
-          list(, $c) = explode('_', $k);
-          $val = $this->form_state->getValue(['submitted', $v]);
-          $cid_data["cid$c"] = $this->ent['contact'][$c]['id'] = (int) (is_array($val) ? $val[0] : $val);
-          $submitted_contacts[$c] = TRUE;
-        }
-      }
-      if (!empty($cid_data)) {
-        $this->form['#attributes']['data-civicrm-ids'] = Json::encode($cid_data);
-      }
-    }
     $this->form['#attributes']['data-form-defaults'] = Json::encode($this->getWebformDefaults());
     // Early return if the form (or page) was already submitted
     $triggering_element = $this->form_state->getTriggeringElement();
@@ -117,20 +100,29 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       return;
     }
 
-    if ($triggering_element && $triggering_element['#id'] == 'edit-wizard-prev'
-      || (empty($this->form_state->isRebuilding()) && !empty($this->form_state->getValues()) && empty($this->form['#submission']->is_draft))
-      // When resuming from a draft
-      || (!empty($this->form_state->getFormObject()->getEntity()->isDraft()) && empty($this->form_state->getUserInput()))
-    ) {
-      $this->fillForm($this->form, $this->form_state->getValues());
-      return;
-    }
-    // If this is an edit op, use the original IDs and return
-    // @TODO this block appears to be left over from D7 and is never executed(?)
-    if (isset($this->form['#submission']->sid) && $this->form['#submission']->is_draft != '1') {
-      if (isset($this->form['#submission']->civicrm)) {
-        $this->form_state['civicrm']['ent'] = $this->form['#submission']->civicrm;
-        foreach ($this->form_state['civicrm']['ent']['contact'] as $c => $contact) {
+    $userInput = $this->form_state->getUserInput();
+    $values = $this->form_state->getValues();
+
+    // We need to fill element default values with CiviCRM data when:
+    // * Loading a virgin form.
+    // * Upon Next/Prev/SaveDraft when there might be locked/hidden fields as
+    //   those elements are not submitted.
+    // We specifically do NOT want to modify element default values on a
+    // submitted form. This includes loading a draft on the front end (where the
+    // user may have updated existing CiviCRM contact data), and when
+    // editing a draft/final submission in the back end (where we want to
+    // preserve the submitted data). A consequence of this is that when a
+    // submitted form is saved, there is a potential to overwrite CiviCRM data
+    // which might have been changed subsequent to the prior submission.
+    $populate_contact_data = !($this->submission_id && empty($values));
+
+    if (!$populate_contact_data) {
+      if ($this->submission_id) {
+        // When loading a submitted form, we restore the previously saved
+        // contact_id values to ensure that upon Submit we update
+        // existing contacts rather than create new ones.
+        $this->form_state->set(['civicrm', 'ent'], $this->ent);
+        foreach ($this->ent['contact'] ?? [] as $c => $contact) {
           $this->info['contact'][$c]['contact'][1]['existing'] = wf_crm_aval($contact, 'id', 0);
         }
       }
@@ -139,14 +131,22 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     }
 
     // Search for existing contacts
-    $user_input = $this->form_state->getUserInput();
     $counts_count = count($this->data['contact']);
     for ($c = 1; $c <= $counts_count; ++$c) {
       $this->ent['contact'][$c] = wf_crm_aval($this->ent, "contact:$c", []);
       $existing_component = $this->node->getElement("civicrm_{$c}_contact_1_contact_existing");
+      // Ensure that a user-entered cid overrides any default created during
+      // the page load.
       if ($existing_component) {
-        // Ensure that a user-entered cid overrides any default created during the page load
-        $cid_user_input = $user_input["civicrm_{$c}_contact_1_contact_existing"] ?? null;
+        // On the first Next/Prev/SaveDraft after a virgin or draft form load,
+        // we arrive here pre-validation with no element defaults and need to
+        // set all of them. At this point we have an empty $values array, and
+        // so we need to instead use $userInput to ensure that an
+        // existing_contact value which has just been modified from its
+        // default will be honored as we set the default contact values.
+        $cid_user_input = $userInput["civicrm_{$c}_contact_1_contact_existing"] ??
+                          $values["civicrm_{$c}_contact_1_contact_existing"] ??
+                          null;
         $this->findContact($existing_component, $cid_user_input);
       }
       // Fill cid with '0' if unknown
@@ -548,77 +548,98 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
             }
             $element['#options'] = $new;
           }
-          // If the user has already entered a value for this field, don't change it
-          if (isset($this->info[$ent][$c][$table][$n][$name])
-            && !(isset($element['#form_key']) && isset($submitted[$element['#form_key']]))) {
+
+          if (isset($this->info[$ent][$c][$table][$n][$name])) {
             $val = $this->info[$ent][$c][$table][$n][$name];
-            if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
-              $val = $this->utils->wf_crm_explode_multivalue_str($val);
+            $fieldNotYetSubmitted = !(isset($element['#form_key']) && isset($submitted[$element['#form_key']]));
+
+            // If the field has been locked/hidden by an existing_contact
+            // element, we'll set the default value to the current CiviCRM
+            // value, even if we already have a submitted value for it. This is
+            // required to display the correct locked values e.g. if the user
+            // performs the sequence: Load, Next, change selected
+            // existing_contact, Next, Prev.
+            if ($ent === 'contact' && isset($this->enabled["civicrm_{$c}_contact_1_contact_existing"])) {
+              $component = $this->node->getElement("civicrm_{$c}_contact_1_contact_existing");
+              $type = ($table == 'contact' && strpos($name, 'name')) ? 'name' : $table;
+              $component += ['#hide_fields' => []];
+              // The field is hidden if the component is one of the specified
+              // fields to hide, unless prevented by the "Don't lock fields that
+              // are empty" setting.
+              $fieldIsHidden = in_array($type, $component['#hide_fields']) && !($component['#no_hide_blank'] && empty($val));
+            } else {
+              $fieldIsHidden = false;
             }
-            if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date'
-              && empty($element['#multiple']) && is_array($val)) {
-              // If there's more than one value for a non-multi field, pick the most appropriate
-              if (!empty($element['#options']) && !empty(array_filter($val))) {
-                foreach ($element['#options'] as $k => $v) {
-                  if (in_array($k, $val)) {
-                    $val = $k;
-                    break;
+
+            if ($fieldIsHidden || $fieldNotYetSubmitted) {
+              if (($element['#type'] == 'checkboxes' || !empty($element['#multiple'])) && !is_array($val)) {
+                $val = $this->utils->wf_crm_explode_multivalue_str($val);
+              }
+              if ($element['#type'] != 'checkboxes' && $element['#type'] != 'date'
+                && empty($element['#multiple']) && is_array($val)) {
+                // If there's more than one value for a non-multi field, pick the most appropriate
+                if (!empty($element['#options']) && !empty(array_filter($val))) {
+                  foreach ($element['#options'] as $k => $v) {
+                    if (in_array($k, $val)) {
+                      $val = $k;
+                      break;
+                    }
+                  }
+                }
+                else {
+                  $val = array_pop($val);
+                }
+              }
+              if ($element['#type'] == 'autocomplete' && is_string($val) && strlen($val)) {
+                $options = $this->utils->wf_crm_field_options($element, '', $this->data);
+                $val = wf_crm_aval($options, $val);
+              }
+              //Ensure value from webform default is loaded when the field is null in civicrm.
+              if (!empty($element['#options']) && isset($val)) {
+                if (!is_array($val) && !isset($element['#options'][$val])) {
+                  $val = NULL;
+                }
+                if ((empty($val) || (is_array($val) && empty(array_filter($val)))) && !empty($this->form['#attributes']['data-form-defaults'])) {
+                  $formDefaults = Json::decode($this->form['#attributes']['data-form-defaults']);
+                  $key = str_replace('_', '-', $element['#form_key']);
+                  if (isset($formDefaults[$key])) {
+                    $val = $formDefaults[$key];
                   }
                 }
               }
-              else {
-                $val = array_pop($val);
-              }
-            }
-            if ($element['#type'] == 'autocomplete' && is_string($val) && strlen($val)) {
-              $options = $this->utils->wf_crm_field_options($element, '', $this->data);
-              $val = wf_crm_aval($options, $val);
-            }
-            //Ensure value from webform default is loaded when the field is null in civicrm.
-            if (!empty($element['#options']) && isset($val)) {
-              if (!is_array($val) && !isset($element['#options'][$val])) {
-                $val = NULL;
-              }
-              if ((empty($val) || (is_array($val) && empty(array_filter($val)))) && !empty($this->form['#attributes']['data-form-defaults'])) {
-                $formDefaults = Json::decode($this->form['#attributes']['data-form-defaults']);
-                $key = str_replace('_', '-', $element['#form_key']);
-                if (isset($formDefaults[$key])) {
-                  $val = $formDefaults[$key];
-                }
-              }
-            }
-            // Contact image & custom file fields
-            if ($dt == 'File') {
-              $fileInfo = $this->getFileInfo($name, $val, $ent, $n);
+              // Contact image & custom file fields
+              if ($dt == 'File') {
+                $fileInfo = $this->getFileInfo($name, $val, $ent, $n);
 
-              if ($fileInfo && in_array($element['#type'], ['file', 'managed_file'])) {
-                $this->form['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
-                  'eid' => $eid,
-                  'fileInfo' => $fileInfo
-                ];
-                // Unset required attribute on the file if its loaded from civicrm.
-                if (!empty($val)) {
-                  $element['#required'] = FALSE;
-                  unset($element['#states']['required']);
+                if ($fileInfo && in_array($element['#type'], ['file', 'managed_file'])) {
+                  $this->form['#attached']['drupalSettings']['webform_civicrm']['fileFields'][] = [
+                    'eid' => $eid,
+                    'fileInfo' => $fileInfo
+                  ];
+                  // Unset required attribute on the file if its loaded from civicrm.
+                  if (!empty($val)) {
+                    $element['#required'] = FALSE;
+                    unset($element['#states']['required']);
+                  }
                 }
               }
-            }
-            // Set value for "secure value" elements
-            elseif ($element['#type'] == 'value') {
-              $element['#value'] = $val;
-            }
-            elseif ($element['#type'] == 'datetime' || $element['#type'] == 'datelist') {
-              if (!empty($val)) {
-                $element['#default_value'] = DrupalDateTime::createFromTimestamp(strtotime($val));
+              // Set value for "secure value" elements
+              elseif ($element['#type'] == 'value') {
+                $element['#value'] = $val;
               }
-            }
-            elseif ($element['#type'] == 'date') {
-              // Must pass date only
-              $element['#default_value'] = substr($val, 0, 10);
-            }
-            // Set default value
-            else {
-              $element['#default_value'] = $val;
+              elseif ($element['#type'] == 'datetime' || $element['#type'] == 'datelist') {
+                if (!empty($val)) {
+                  $element['#default_value'] = DrupalDateTime::createFromTimestamp(strtotime($val));
+                }
+              }
+              elseif ($element['#type'] == 'date') {
+                // Must pass date only
+                $element['#default_value'] = substr($val, 0, 10);
+              }
+              // Set default value
+              else {
+                $element['#default_value'] = $val;
+              }
             }
           }
           if (in_array($name, ['state_province_id', 'county_id', 'billing_address_state_province_id', 'billing_address_county_id'])) {

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -91,6 +91,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     }
     $submitted_contacts = [];
     // Keep track of cids across multipage forms
+    // @TODO this block appears to be left over from D7 and is never executed(?)
     if (!empty($this->form_state->getValue('submitted')) && $this->form_state->get(['webform','page_count']) > 1) {
       foreach ($this->enabled as $k => $v) {
         // @TODO review the usage of the existing element.
@@ -125,6 +126,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
       return;
     }
     // If this is an edit op, use the original IDs and return
+    // @TODO this block appears to be left over from D7 and is never executed(?)
     if (isset($this->form['#submission']->sid) && $this->form['#submission']->is_draft != '1') {
       if (isset($this->form['#submission']->civicrm)) {
         $this->form_state['civicrm']['ent'] = $this->form['#submission']->civicrm;
@@ -137,17 +139,20 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
     }
 
     // Search for existing contacts
+    $user_input = $this->form_state->getUserInput();
     $counts_count = count($this->data['contact']);
     for ($c = 1; $c <= $counts_count; ++$c) {
       $this->ent['contact'][$c] = wf_crm_aval($this->ent, "contact:$c", []);
       $existing_component = $this->node->getElement("civicrm_{$c}_contact_1_contact_existing");
-      // Search for contact if the user hasn't already chosen one
-      if ($existing_component && empty($submitted_contacts[$c])) {
-        $this->findContact($existing_component);
+      if ($existing_component) {
+        // Ensure that a user-entered cid overrides any default created during the page load
+        $cid_user_input = $user_input["civicrm_{$c}_contact_1_contact_existing"] ?? null;
+        $this->findContact($existing_component, $cid_user_input);
       }
       // Fill cid with '0' if unknown
       $this->ent['contact'][$c] += ['id' => 0];
     }
+
     // Search for other existing entities
     if (empty($this->form_state->get('civicrm'))) {
       if (!empty($this->data['case']['number_of_case'])) {

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -4,6 +4,9 @@ namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
 
 use Drupal\Core\Url;
 use Drupal\Core\Test\AssertMailTrait;
+use Drupal\webform\Entity\WebformSubmission;
+use Drupal\webform\Entity\Webform;
+use Drupal\Core\Serialization\Yaml;
 
 /**
  * Tests submitting a Webform with CiviCRM: existing contact element.
@@ -384,7 +387,10 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     $weirdoNewline = version_compare(\Drupal::VERSION, '10.3.2', '<') ? "\n" : '';
 
     // Verify tokens are rendered correctly.
-    $this->assertEquals("Submitted Values Are -
+    // We ignore newlines so that the length of the website's URL (appearing in
+    // $this->cidURL) doesn't cause a failure due to variations in line
+    // wrapping.
+    $this->assertEquals(strtr("Submitted Values Are -
 
 -------- Contact 1 {$weirdoNewline}-----------------------------------------------------------
 
@@ -412,7 +418,615 @@ Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Li
 States. State/Province - New Jersey.
 
 [1] mailto:frederick@pabst.io
-", $sent_email[0]['body']);
+", "\n", ' '), strtr($sent_email[0]['body'], "\n", ' '));
   }
 
+  /**
+   *  Define test-contact parameters and create a subset of them in Civi.
+   *
+   *  @return array
+   *    contains parameter arrays for each test-contact
+   */
+  private function addcontactinfo2() {
+    $currentUserUF = $this->getUFMatchRecord($this->rootUser->id());
+    $contact = [
+      0 => [ // cid = 3
+        'contact_id' => $currentUserUF['contact_id'],
+        'first_name' => 'Jimmy',
+        'last_name' => 'Page',
+        'job_title' => "Guitarist",
+        'contact_type' => 'Individual'
+      ],
+      1 => [ // cid = 4
+        'first_name' => 'Robert',
+        'last_name' => 'Plant',
+        'job_title' => "Vocalist",
+        'contact_type' => 'Individual'
+      ],
+      2 => [ // cid = 5
+        'first_name' => 'John Paul',
+        'last_name' => 'Jones',
+        'job_title' => "Bassist",
+        'contact_type' => 'Individual'
+      ],
+      3 => [ // cid = 6
+        'first_name' => 'John',
+        'last_name' => 'Bonham',
+        'job_title' => "Drummer",
+        'contact_type' => 'Individual'
+      ],
+      4 => [ // cid = 7
+        'first_name' => 'Janis',
+        'last_name' => 'Joplin',
+        'job_title' => "Singer",
+        'contact_type' => 'Individual'
+      ],
+      5 => [ // not initiallly created
+        'first_name' => 'Marvin',
+        'last_name' => 'Gaye',
+        'job_title' => "Vocals",
+        'contact_type' => 'Individual'
+      ],
+      6 => [ // not initiallly created
+        'first_name' => 'Bob',
+        'last_name' => 'Dylan',
+        'job_title' => "Vocals, Harmonica",
+        'contact_type' => 'Individual'
+      ],
+      7 => [ // null contact, not initiallly created
+        'first_name' => '',
+        'last_name' => '',
+        'job_title' => '',
+        'contact_type' => 'Individual'
+      ],
+      8 => [ // cid = 8
+        'first_name' => 'Prince',
+        'last_name' => '',
+        'job_title' => "Guitar, vocals",
+        'contact_type' => 'Individual'
+      ],
+      9 => [ // cid = 9
+        'first_name' => 'Madona',
+        'last_name' => '',
+        'job_title' => "Vocals, drummer",
+        'contact_type' => 'Individual'
+      ],
+    ];
+    $utils = \Drupal::service('webform_civicrm.utils');
+    foreach ($contact as $key => $c) {
+      if (in_array($key, [0, 1, 2, 3, 4, 8, 9])) {
+        $result = $utils->wf_civicrm_api('Contact', 'create', $c);
+        $this->assertEquals(0, $result['is_error']);
+        $this->assertEquals(1, $result['count']);
+      }
+    }
+    return $contact;
+  }
+
+  /**
+   * Sets the contact fields used by testNextPrevSaveLoad()
+   *
+   * @param array $contact
+   *   contact parameters to be set
+   */
+  private function setContactFields($contact) {
+    $this->getSession()->getPage()->fillField('First Name', $contact['first_name']);
+    $this->getSession()->getPage()->fillField('Last Name',  $contact['last_name']);
+    $this->getSession()->getPage()->fillField('Job Title',  $contact['job_title']);
+  }
+
+  /**
+   * Checks the contact fields used by testNextPrevSaveLoad()
+   *
+   * @param array $contact
+   *   contact parameters to be checked
+   */
+  private function checkContactFields($contact) {
+    $this->assertSession()->fieldValueEquals('First Name', $contact['first_name']);
+    $this->assertSession()->fieldValueEquals('Last Name',  $contact['last_name']);
+    $this->assertSession()->fieldValueEquals('Job Title',  $contact['job_title']);
+  }
+
+  /**
+  * Test locked/unlocked and blank/filled fields during Next/Previous/Save Draft/Load Draft/Submit operations
+  */
+  public function testNextPrevSaveLoad() {
+    $contact = $this->addcontactinfo2();
+
+    $this->drupalLogin($this->rootUser);
+
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->enableCivicrmOnWebform();
+
+    // Enable 3 contacts each with first name, last name, job title
+    $this->getSession()->getPage()->selectFieldOption("number_of_contacts", 3);
+    foreach ([1, 2, 3] as $c) {
+      $this->getSession()->getPage()->clickLink("Contact {$c}");
+      $this->getSession()->getPage()->checkField("civicrm_{$c}_contact_1_contact_existing");
+      $this->assertSession()->checkboxChecked("civicrm_{$c}_contact_1_contact_existing");
+      $this->getSession()->getPage()->checkField("civicrm_{$c}_contact_1_contact_job_title");
+      $this->assertSession()->checkboxChecked("civicrm_{$c}_contact_1_contact_job_title");
+    }
+
+    $this->saveCiviCRMSettings();
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+
+    // Edit contact element 1.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'title' => 'Contact 1',
+      'widget' => 'Select List',
+      'hide_fields' => 'Name',
+      'hide_method' => 'Disabled',
+      'no_hide_blank' => TRUE,
+      'submit_disabled' => TRUE,
+      'default' => 'Specified Contact',
+      'default_contact_id' => 3
+    ];
+    $this->editContactElement($editContact);
+
+    // Edit contact element 2.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-2-contact-1-contact-existing-operations',
+      'title' => 'Contact 2',
+      'widget' => 'Select List',
+      'hide_fields' => 'Name',
+      'hide_method' => 'Disabled',
+      'no_hide_blank' => TRUE,
+      'submit_disabled' => TRUE,
+      'default' => 'None',
+      //'default_contact_id' => 4
+    ];
+    $this->editContactElement($editContact);
+
+    // Edit contact element 3.
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-3-contact-1-contact-existing-operations',
+      'title' => 'Contact 3',
+      'widget' => 'Select List',
+      'hide_fields' => 'Name',
+      'hide_method' => 'Disabled',
+      'no_hide_blank' => TRUE,
+      'submit_disabled' => TRUE,
+      'default' => 'Specified Contact',
+      'default_contact_id' => 5
+    ];
+    $this->editContactElement($editContact);
+
+    // Make first/last name required for all contacts
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_1_contact_1_contact_first_name][required]");
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_2_contact_1_contact_first_name][required]");
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_3_contact_1_contact_first_name][required]");
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_1_contact_1_contact_last_name][required]");
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_2_contact_1_contact_last_name][required]");
+    $this->getSession()->getPage()->checkField("webform_ui_elements[civicrm_3_contact_1_contact_last_name][required]");
+    $this->getSession()->getPage()->pressButton('Save elements');
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    $this->htmlOutput();
+
+    // Place fields for each contact on their own page and enable saving drafts
+    $webform =  Webform::load($this->webform->getOriginalId());
+    $elements = Yaml::decode($webform->get('elements'));
+    $elements_new = [
+      'page1' => ['#type' => 'webform_wizard_page', '#title' => 'Page 1', 'civicrm_1_contact_1_fieldset_fieldset' => $elements["civicrm_1_contact_1_fieldset_fieldset"]],
+      'page2' => ['#type' => 'webform_wizard_page', '#title' => 'Page 2', 'civicrm_2_contact_1_fieldset_fieldset' => $elements["civicrm_2_contact_1_fieldset_fieldset"]],
+      'page3' => ['#type' => 'webform_wizard_page', '#title' => 'Page 3', 'civicrm_3_contact_1_fieldset_fieldset' => $elements["civicrm_3_contact_1_fieldset_fieldset"]],
+    ];
+    $webform->set('elements', Yaml::encode($elements_new));
+    $webform->setSetting('draft', 'all');
+    $webform->save();
+
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    $this->htmlOutput();
+
+    $this->drupalGet($this->webform->toUrl('canonical'));
+
+    $this->assertPageNoErrorMessages();
+    $this->htmlOutput();
+
+
+    //** Setup complete Begin tests. **
+    // "{Contacts: x, y, z}" below refers to the current form contents (three elements of $contacts[] array)
+
+    // Page 1 {Contacts: 0, none, 2}: Check initial values.
+    $this->checkContactFields($contact[0]);
+
+    // Confirm first name is disabled
+    $field_disabled = $this->getSession()->evaluateScript("document.getElementById('edit-civicrm-1-contact-1-contact-first-name').disabled");
+    $this->assertEquals(true, $field_disabled, 'First name is disabled');
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 0, none, 2}: Check initial values.
+    $this->checkContactFields($contact[7]); // 7 is the blank contact
+
+    // Page 2 {Contacts: 0, none, 2}: Confirm that locked blank fields can be modified
+    $this->getSession()->getPage()->fillField('First Name', 'FIRST');
+    $this->assertSession()->fieldValueEquals('First Name', 'FIRST');
+
+    // Page 2 {Contacts: 0, none, 2}: Select $contact[1].
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[1]['first_name']} {$contact[1]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[1]);
+
+    // Page 2 {Contacts: 0, 1, 2}: Test that locked nonblank fields are disabled.
+    $field_disabled = $this->getSession()->evaluateScript("document.getElementById('edit-civicrm-2-contact-1-contact-first-name').disabled");
+    $this->assertEquals(true, $field_disabled, 'First name is disabled');
+    $this->getSession()->getPage()->pressButton('Next >');
+    $this->assertPageNoErrorMessages();
+
+    // Page 3 {Contacts: 0, 1, 2}: Check initial values.
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 0, 1, 2}: Check entered contact data ($contact[1]).
+    $this->checkContactFields($contact[1]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 0, 1, 2}: check initial values.
+    $this->checkContactFields($contact[0]);
+
+    // Page 1 {Contacts: 0, 1, 2}: Select $contact[3]
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_contact_existing', "{$contact[3]['first_name']} {$contact[3]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 1, 2}: Check still has $contact[1]
+    $this->checkContactFields($contact[1]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1: {Contacts: 3, 1, 2}: Check still has $contact[3]
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 1, 2}: Check still has $contact[1]
+    $this->checkContactFields($contact[1]);
+
+    // Page 2 {Contacts: 3, 1, 2}: Create a new contact ($contact[4])
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "+ Create new +");
+    $this->setContactFields($contact[4]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 3, 4, 2}: check still has $contact[3]
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 4, 2}: Check still has $contact[4]
+    $this->checkContactFields($contact[4]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 4, 2}: Check initial state
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 3, 4, 2}: check still has $contact[4]
+    $this->checkContactFields($contact[4]);
+
+    // Page 2 {Contacts: 3, 4, 2}: Create a new contact ($contact[5])
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "+ Create new +");
+    $this->setContactFields($contact[5]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 5, 2}: Check initial state
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 3, 5, 2}: check still has $contact[5]
+    $this->checkContactFields($contact[5]);
+
+    // Page 2 {Contacts: 3, 5, 2}: Create a new contact ($contact[6])
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "+ Create new +");
+    $this->setContactFields($contact[6]);
+
+    // Page 2 {Contacts: 3, 6, 2}: Save draft
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+
+    // Page 2 {Contacts: 3, 6, 2}: Reload form, check still has $contact[6]
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+    $this->checkContactFields($contact[6]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 3, 6, 2}: Check still has $contact[3]
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 6, 2}: Check still has $contact[6]
+    $this->checkContactFields($contact[6]);
+
+
+    //*** Test sequence: modify, prev, save draft, load, next, next, ***
+    // Page 2 {Contacts: 3, 6, 2}: Select $contact[1]
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[1]['first_name']} {$contact[1]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[1]);
+
+    // Page 2 {Contacts: 3, 6, 2}: Modify the job field
+    $contact['1m'] = $contact[1];
+    $contact['1m']['job_title'] = 'MODIFIED JOB TITLE 1';
+    $this->getSession()->getPage()->fillField('Job Title', $contact['1m']['job_title']);
+    $this->getSession()->getPage()->pressButton('< Prev');
+    $this->checkContactFields($contact[3]);
+
+    // Page 1 {Contacts: 3, 1m, 2}: Save/load the draft
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+
+    // Page 1 {Contacts: 3, 1m, 2}: Confirm contact
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 1m, 2}: Confirm modified contact
+    $this->checkContactFields($contact['1m']);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 1m, 2}: Confirm the job is still modified
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 3, 1m, 2}: Confirm the contact
+    $this->checkContactFields($contact['1m']);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 3, 1m, 2}: Confirm the contact
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+
+    //*** Test sequence: modify, next, save, load draft, prev, prev, next, next  ***
+    // Page 2 {Contacts: 3, 6, 2}: Select $contact[1] (must first select a different $contact)
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[0]['first_name']} {$contact[0]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[1]['first_name']} {$contact[1]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[1]);
+
+    // Page 2 {Contacts: 3, 6, 2}: Modify the job field
+    $contact['1m'] = $contact[1];
+    $contact['1m']['job_title'] = 'MODIFIED JOB TITLE 1A';
+    $this->getSession()->getPage()->fillField('Job Title', $contact['1m']['job_title']);
+    $this->getSession()->getPage()->pressButton('Next >');
+    $this->checkContactFields($contact[2]);
+
+    // Page 3 {Contacts: 3, 1m, 2}: Save/load the draft
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+
+    // Page 3 {Contacts: 3, 1m, 2}: Confirm contact
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 3, 1m, 2}: Confirm modified contact
+    $this->checkContactFields($contact['1m']);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 3, 1m, 2}: Confirm the job is still modified
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 3, 1m, 2}: Confirm the contact
+    $this->checkContactFields($contact['1m']);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 1m, 2}: Confirm the job is still modified
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+
+    // Page 2 {Contacts: 3, 6, 2}: Select $contact[4]
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[4]['first_name']} {$contact[4]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[4]);
+
+    // Page 2 {Contacts: 3, 4, 2}: Save draft
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+
+    // Page 2 {Contacts: 3, 4, 2}: Reload form, check still has $contact[4]
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+    $this->checkContactFields($contact[4]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 4, 2}: Check initial state
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2  {Contacts: 3, 4, 2}: Check still has $contact[4]
+    $this->checkContactFields($contact[4]);
+
+    // Page 2 {Contacts: 3, 4, 2}: Create a new contact ($contact[5])
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "+ Create new +");
+    $this->setContactFields($contact[5]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 3, 5, 2}: Check initial state
+    $this->checkContactFields($contact[2]);
+
+    // Page 3  {Contacts: 3, 5, 2}: create a new contact ($contact[6])
+    $this->getSession()->getPage()->selectFieldOption('civicrm_3_contact_1_contact_existing', "+ Create new +");
+    $this->setContactFields($contact[6]);
+
+    // Page 3  {Contacts: 3, 5, 6}: Submit
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    // Confirm existing $contact[3] is unchanged, and $contact[5,6] have been created in Civi
+    foreach ([3,5,6] as $key) {
+      $result = $this->utils->wf_civicrm_api('Contact', 'get', [
+        'first_name' => $contact[$key]['first_name'],
+        'last_name' => $contact[$key]['last_name'],
+        'job_title' => $contact[$key]['job_title'],
+      ]);
+      $this->assertEquals(0, $result['is_error']);
+      $this->assertEquals(1, $result['count']);
+    }
+
+
+    //*** Check handling of existing contact with blank required field ***
+    $this->drupalGet($this->webform->toUrl('canonical'));
+
+    // Page 1 {Contacts: 0, none, 2}: Check initial values.
+    $this->assertSession()->pageTextContains('You have already submitted this webform. View your previous submission.');
+    $this->checkContactFields($contact[0]);
+
+    // Page 1 {Contacts: 0, none, 2}: Select $contact[8] (no last name)
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_contact_existing', "{$contact[8]['first_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[8]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 1 {Contacts: 8, none, 2}: Still on Page 1 because Last Name is blank and required
+    $this->checkContactFields($contact[8]);
+    $field_valid = $this->getSession()->evaluateScript("document.getElementById('edit-civicrm-1-contact-1-contact-last-name').reportValidity()");
+    $this->assertEquals(false, $field_valid, 'Last Name field is not invalid.');
+
+    $contact['8m'] = $contact[8];
+    $contact['8m']['last_name'] = 'CONTACT 8 LAST NAME';
+    $this->getSession()->getPage()->fillField('Last Name', $contact['8m']['last_name']);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 8m, none, 2}: Check $contact[7] (null contact)
+    $this->checkContactFields($contact[7]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 8m, none, 2}: Check $contact[8m]
+    $this->checkContactFields($contact['8m']);
+
+
+    //*** Check Draft Save/Load with blank required field ***
+    $this->drupalGet($this->webform->toUrl('canonical'));
+
+    // Page 1 {Contacts: 0, none, 2}: Check initial values.
+    $this->assertSession()->pageTextContains('You have already submitted this webform. View your previous submission.');
+    $this->checkContactFields($contact[0]);
+
+    // Page 1 {Contacts: 0, none, 2}: Select $contact[8] (no last name)
+    $this->getSession()->getPage()->selectFieldOption('civicrm_1_contact_1_contact_existing', "{$contact[8]['first_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[8]);
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+
+    // Page 1 {Contacts: 8, none, 2}: Reload form, check still has $contact[8]
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+    $this->checkContactFields($contact[8]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 1 {Contacts: 8, none, 2}: Still on Page 1 because Last Name is blank and required
+    $this->checkContactFields($contact[8]);
+    $field_valid = $this->getSession()->evaluateScript("document.getElementById('edit-civicrm-1-contact-1-contact-last-name').reportValidity()");
+    $this->assertEquals(false, $field_valid, 'Last Name field is not invalid.');
+
+    // Page 1 {Contacts: 8, none, 2}: Add last name to $contact[8]
+    $contact['8m'] = $contact[8];
+    $contact['8m']['last_name'] = 'CONTACT 8 LAST NAME';
+    $this->getSession()->getPage()->fillField('Last Name', $contact['8m']['last_name']);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 8m, none, 2}: Check $contact[7] (null contact)
+    $this->checkContactFields($contact[7]);
+    $this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 1 {Contacts: 8m, none, 2}: Check $contact[8m]
+    $this->checkContactFields($contact['8m']);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 8m, none, 2}: Check $contact[7] (null contact)
+    $this->checkContactFields($contact[7]);
+    //$this->getSession()->getPage()->pressButton('< Prev');
+
+    // Page 2 {Contacts: 8m, none, 2}: Select $contact[5]
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[5]['first_name']} {$contact[5]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 8m, 5, 2}: Check initial state
+    $this->checkContactFields($contact[2]);
+
+    // Page 3 {Contacts: 8m, 5, 2}: Select $contact[9] and submit
+    $this->getSession()->getPage()->selectFieldOption('civicrm_3_contact_1_contact_existing', "{$contact[9]['first_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact['9']);
+    $this->getSession()->getPage()->pressButton('Submit');
+
+    // Page 3 {Contacts: 8m, 5, 9}: Still on Page 3 because Last Name is blank and required
+    $this->checkContactFields($contact['9']);
+    $field_valid = $this->getSession()->evaluateScript("document.getElementById('edit-civicrm-3-contact-1-contact-last-name').reportValidity()");
+    $this->assertEquals(false, $field_valid, 'Last Name field is not invalid.');
+
+    // Page 3 {Contacts: 8m, 5, 9}: Add last name and submit
+    $contact['9m'] = $contact[9];
+    $contact['9m']['last_name'] = 'CONTACT 9 LAST NAME';
+    $this->getSession()->getPage()->fillField('Last Name', $contact['9m']['last_name']);
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->htmlOutput();
+
+    // Page 3 {Contacts: 8m, 5, 9m}: Confirm submit OK
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    // Confirm existing $contact[5] is unchanged, and $contact[8,9] now have a last name.
+    foreach (['8m', 5, '9m'] as $key) {
+      $result = $this->utils->wf_civicrm_api('Contact', 'get', [
+        'first_name' => $contact[$key]['first_name'],
+        'last_name' => $contact[$key]['last_name'],
+        'job_title' => $contact[$key]['job_title'],
+      ]);
+      $this->assertEquals(0, $result['is_error']);
+      $this->assertEquals(1, $result['count']);
+    }
+
+
+    //*** Check Draft Save/Load, change selected contact, Submit ***
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertPageNoErrorMessages();
+
+    // Page 1 {Contacts: 0, none, 2}: Check initial values.
+    $this->checkContactFields($contact[0]);
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 2 {Contacts: 0, none, 2}: Check initial values.
+    $this->checkContactFields($contact[7]);
+
+    // Page 2 {Contacts: 0, none, 2}: Select $contact[5]
+    $this->getSession()->getPage()->selectFieldOption('civicrm_2_contact_1_contact_existing', "{$contact[5]['first_name']} {$contact[5]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->getSession()->getPage()->pressButton('Next >');
+
+    // Page 3 {Contacts: 0, 5, 2}: Check initial state, select $contact[3], save draft
+    $this->checkContactFields($contact[2]);
+    $this->getSession()->getPage()->selectFieldOption('civicrm_3_contact_1_contact_existing', "{$contact[3]['first_name']} {$contact[3]['last_name']}");
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Save Draft');
+    $this->checkContactFields($contact[3]);
+    $this->assertSession()->pageTextContains('Submission saved. You may return to this form later and it will restore the current values.');
+    $this->htmlOutput();
+
+    // Page 3 {Contacts: 0, 5, 3}: Reload form, check still has $contact[3] and submit
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->assertSession()->pageTextContains('A partially-completed form was found. Please complete the remaining portions.');
+    $this->checkContactFields($contact[3]);
+    $this->getSession()->getPage()->pressButton('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    $submission = WebformSubmission::load($this->getLastSubmissionId($this->webform));
+    $sub_data = $submission->getData();
+    $this->assertEquals($contact[3]['first_name'], $sub_data['civicrm_3_contact_1_contact_first_name'], 'Submission first name');
+    $this->assertEquals($contact[3]['last_name'], $sub_data['civicrm_3_contact_1_contact_last_name'], 'Submission last name');
+    $this->assertEquals($contact[3]['job_title'], $sub_data['civicrm_3_contact_1_contact_job_title'], 'Submission job title name');
+  }
 }

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -516,6 +516,9 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     if (!empty($params['hide_fields'])) {
       $this->getSession()->getPage()->selectFieldOption('properties[hide_fields][]', $params['hide_fields']);
     }
+    if (!empty($params['hide_method'])) {
+      $this->getSession()->getPage()->selectFieldOption('properties[hide_method]', $params['hide_method']);
+    }
     if (!empty($params['submit_disabled'])) {
       $this->getSession()->getPage()->checkField("properties[submit_disabled]");
     }
@@ -552,6 +555,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->assertSession()->assertWaitOnAjaxRequest();
       $this->getSession()->getPage()->selectFieldOption('Set default contact from', $params['default']);
 
+      if ($params['default'] == 'Specified Contact') {
+        $this->getSession()->getPage()->fillField('default-contact-id', $params['default_contact_id']);
+      }
+
       if ($params['default'] == 'relationship') {
         $this->getSession()->getPage()->selectFieldOption('properties[default_relationship_to]', $params['default_relationship']['default_relationship_to']);
         $this->assertSession()->assertWaitOnAjaxRequest();
@@ -580,6 +587,13 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-validation"]')->click();
       $this->getSession()->getPage()->checkField('properties[required]');
     }
+
+    // Wait for ajax message from previous click of Save button to no longer be
+    // visible to avoid falling through the following waitForElementVisible
+    // prematurely.
+    do {
+      $ajax_message_visible = $this->assertSession()->waitForElementVisible('css', '.webform-ajax-messages', 100);
+    } while ($ajax_message_visible);
 
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->waitForElementVisible('css', '.webform-ajax-messages');


### PR DESCRIPTION
Overview
----------------------------------------
This PR replaces https://github.com/colemanw/webform_civicrm/pull/966.

It ensures that the contact selected in an existing_contact element is honored during preprocessing, rather than using the default cid value specified for the element or the cid URL parameter.

It corrects [Required field fails validation when autocompleted and disabled, even when "Submit disabled field value(s)" checked](https://www.drupal.org/project/webform_civicrm/issues/3402697).

Before
----------------------------------------
"Field is required" error occurs upon submission of a required field that is locked by an Existing Contact widget when that widget is configured in a non-static mode, e.g. AutoComplete.

After
----------------------------------------
The submission completes without error.

Technical Details
----------------------------------------
Currently, the submitted contact_id value from the Existing Contact element in the non-static widget modes is ignored within WebformCivicrmPreProcess::alterForm(). If the cid is changed after the form is loaded, e.g. by choosing a contact from the autocomplete, then the submitted data (provided by an Ajax call) belongs to the selected contact, but the cid used throughout preprocessing remains the default cid value, causing many issues. This change treats the submitted cid value as the highest priority when determining the cid used during preprocessing. 

Following are some related issues corrected by this PR:

ISSUE 2: Wrong data saved in locked fields
------------------------------------

*  __Setup__
        Perform the same steps as described in https://www.drupal.org/project/webform_civicrm/issues/3402697, except:
        Set  the default mode of the existing_contact element to User.
        Enable contributions (Payment Processor Mode: test mode, Payment Processor: Stripe, Enable Billing Address: No).
        Load the form, select a contact other than the current user, and submit
* __Actual__
        The submissions list and sent emails show the user's values for the locked fields (first/last name).
* __Expected__
        The submissions list and sent emails shows the selected contact's values for all fields.

ISSUE 3: Wrong data displayed in  locked fields after Next/Previous
------------------------------------
*  __Setup__
        Same setup as above.
        Load the form, select a contact other than the current user, and click Next and then Previous.
*  __Actual__
        The locked fields (first name, last name) contain values from the current user.
*  __Expected__
        All fields should contain values for the selected contact.

Other
--------------
I came across two blocks of code which I believe are leftovers from Drupal 7 and can never be executed in Drupal 8. I marked them as TODO, but I was reluctant to remove them.