### PR TITLE
Adjust for spacing change in emails in 10.3

### DIFF
--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -378,11 +378,15 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     // Check if email was sent to contact 1.
     $this->assertStringContainsString('frederick@pabst.io', $sent_email[0]['to']);
 
+    // Something new in 10.3
+    $weirdoExtraSpaces = version_compare(\Drupal::VERSION, '10.3.2', '>=') ? '  ' : '';
+    // And now there is no longer a newline
+    $weirdoNewline = version_compare(\Drupal::VERSION, '10.3.2', '<') ? "\n" : '';
+
     // Verify tokens are rendered correctly.
     $this->assertEquals("Submitted Values Are -
 
--------- Contact 1 
------------------------------------------------------------
+-------- Contact 1 {$weirdoNewline}-----------------------------------------------------------
 
 *Existing Contact*
 Frederick Pabst
@@ -402,9 +406,9 @@ United States
 New Jersey
 *Email*
 frederick@pabst.io [1]
-Existing Contact - Frederick Pabst. Activity 1 ID - {$actID1}. Activity 2 ID - {$actID2}.
-Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Links -
-{$cidURL} Country - United
+Existing Contact - Frederick Pabst. Activity 1 ID - {$actID1}. Activity 2 ID - {$actID2}.{$weirdoExtraSpaces}
+Webform CiviCRM Contacts IDs - {$this->rootUserCid}. Webform CiviCRM Contacts Links -{$weirdoExtraSpaces}
+{$cidURL} Country - United{$weirdoExtraSpaces}
 States. State/Province - New Jersey.
 
 [1] mailto:frederick@pabst.io


### PR DESCRIPTION
Overview
----------------------------------------
Some weird spacing happens in the email in the test for webform tokens. It's new in 10.3.

Before
----------------------------------------
No extra spacing at end of line.

After
----------------------------------------
Two spaces oddly added to end of some lines.
One newline that was previously oddly there is now no longer there.

Technical Details
----------------------------------------
I'm not sure this is on purpose upstream. At the same time the email being tested doesn't have any specific formatting and is originally one line run all together, and the spacing isn't what's important in the test. The tokens are still evaluating correctly.

It's the same version of the parent webform being used for both the drupals, so it's not something new there.

Comments
----------------------------------------

