### PR TITLE
Stripetest - remove call to deprecated function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,10 +175,6 @@ jobs:
           git apply 456.diff
           git apply 457.diff
           git apply 458.diff
-          # temporary patch for stripe keys
-          cd ../com.drastikbydesign.stripe
-          curl -L -o stripekeys.diff https://lab.civicrm.org/extensions/stripe/-/commit/916668c5e192050997e4fe687e3c053bed6a7fdc.diff
-          git apply stripekeys.diff
       - uses: nanasess/setup-chromedriver@master
         with:
           # temporary to match downgraded chrome

--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -19,13 +19,7 @@ final class StripeTest extends WebformCivicrmTestBase {
 
     $this->setUpExtension('mjwshared,firewall,mjwpaymentapi,com.drastikbydesign.stripe');
 
-    $params = [];
-    $result = $this->utils->wf_civicrm_api('Stripe', 'setuptest', $params);
-    $this->paymentProcessorID = $result['id'];
-    $this->utils->wf_civicrm_api('PaymentProcessor', 'create', [
-      'id' => $this->paymentProcessorID,
-      'is_test' => 0,
-    ]);
+    $this->paymentProcessorID = $this->createStripeProcessor();
 
     $this->utils->wf_civicrm_api('Setting', 'create', [
       'stripe_nobillingaddress' => 1,
@@ -216,6 +210,31 @@ final class StripeTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->selectFieldOption('civicrm_1_lineitem_2_contribution_financial_type_id', 2);
 
     $this->saveCiviCRMSettings();
+  }
+
+  private function createStripeProcessor(): int {
+    $params = [
+      'name' => 'Stripe',
+      'domain_id' => \CRM_Core_Config::domainID(),
+      'payment_processor_type_id' => 'Stripe',
+      'title' => 'Stripe',
+      'is_active' => 1,
+      'is_default' => 0,
+      'is_test' => 0,
+      'is_recur' => 1,
+      'user_name' => \CRM_Utils_Constant::value('STRIPE_PK_TEST', 'pk_test_PNlMrGPvqOxwLK6Y3A9B2EFn'),
+      'password' => \CRM_Utils_Constant::value('STRIPE_SK_TEST', 'sk_test_WHbZbmFH97YpY2y4OpVfry9W'),
+      'url_site' => 'https://api.stripe.com/v1',
+      'url_recur' => 'https://api.stripe.com/v1',
+      'class_name' => 'Payment_Stripe',
+      'billing_mode' => 1
+    ];
+    // First see if it already exists.
+    $result = $this->utils->wf_civicrm_api('PaymentProcessor', 'get', $params);
+    if ($result['count'] != 1) {
+      $result = $this->utils->wf_civicrm_api('PaymentProcessor', 'create', $params);
+    }
+    return $result['id'];
   }
 
 }


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Call to function that:
1. Is deprecated since 1.5 years
2. All it does is create a payment processor
3. Stripe doesn't use it, and webform is the only thing in universe that uses it.

After
----------------------------------------
1. Just create a payment processor.
2. Also allow for getting the keys via ENV or a DEFINE, which while they are test keys makes it easier to hide them in github actions by using github secrets.

Technical Details
----------------------------------------


Comments
----------------------------------------

