### PR TITLE
Core now creates ufmatches on install, so trying to create it in test setup leads to fails

### DIFF
--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -122,11 +122,12 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->saveCiviCRMSettings();
 
+    $adminUserCid = $this->getUFMatchRecord($this->adminUser->id())['contact_id'];
     // Create two memberships with the same status with the first membership
     // having an end date after the second membership's end date.
     $this->utils->wf_civicrm_api('membership', 'create', [
       'membership_type_id' => 'Basic',
-      'contact_id' => 2,
+      'contact_id' => $adminUserCid,
       'join_date' => '08/10/21',
       'start_date' => '08/10/21',
       'end_date' => '08/10/22',
@@ -136,7 +137,7 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->utils->wf_civicrm_api('membership', 'create', [
       'membership_type_id' => 'Basic',
-      'contact_id' => 2,
+      'contact_id' => $adminUserCid,
       'join_date' => '01/01/21',
       'start_date' => '01/01/21',
       'end_date' => '01/01/22',

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -98,13 +98,18 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       'id' => 'civicrm_webform_test',
       'title' => 'CiviCRM Webform Test.' . $CiviCRM_version,
     ]);
-    $this->rootUserCid = $this->createIndividual()['id'];
-    // Create CiviCRM contact for rootUser.
-    $this->utils->wf_civicrm_api('UFMatch', 'create', [
-      'uf_id' => $this->rootUser->id(),
-      'uf_name' => $this->rootUser->getAccountName(),
-      'contact_id' => $this->rootUserCid,
-    ]);
+    if (version_compare(\CRM_Core_BAO_Domain::version(), '5.79.alpha1', '<')) {
+      $this->rootUserCid = $this->createIndividual()['id'];
+      // Create CiviCRM contact for rootUser.
+      $this->utils->wf_civicrm_api('UFMatch', 'create', [
+        'uf_id' => $this->rootUser->id(),
+        'uf_name' => $this->rootUser->getAccountName(),
+        'contact_id' => $this->rootUserCid,
+      ]);
+    }
+    else {
+      $this->rootUserCid = $this->getUFMatchRecord($this->rootUser->id())['contact_id'];
+    }
   }
 
   protected function tearDown(): void {


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
ufmatch record needs to be created manually in setup

After
----------------------------------------
As of 5.79, it gets autocreated on install. Trying to do so manually leads to errors.

Technical Details
----------------------------------------
See https://github.com/civicrm/civicrm-core/pull/31046

Comments
----------------------------------------