### PR TITLE
Rename uploaded files using webform filename pattern (and tokens)

### DIFF
--- a/src/Plugin/WebformHandler/CivicrmWebformHandler.php
+++ b/src/Plugin/WebformHandler/CivicrmWebformHandler.php
@@ -32,11 +32,19 @@ class CivicrmWebformHandler extends WebformHandlerBase {
   protected $civicrm;
 
   /**
+   * The Token Manager service.
+   *
+   * @var \Drupal\webform\WebformTokenManager
+   */
+  public $tokenManager;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->civicrm = $container->get('civicrm');
+    $instance->tokenManager = $container->get('webform.token_manager');
 
     return $instance;
   }

--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -776,13 +776,18 @@ abstract class WebformCivicrmBase {
    * Copies a drupal file into the Civi file system
    *
    * @param int $id: drupal file id
+   * @param string $filename drupal filename
    * @return int|null Civi file id
    */
-  public static function saveDrupalFileToCivi($id) {
+  public static function saveDrupalFileToCivi($id, $filename = NULL) {
     $file = File::load($id);
     if ($file) {
       $config = \CRM_Core_Config::singleton();
-      $path = \Drupal::service('file_system')->copy($file->getFileUri(), $config->customFileUploadDir);
+      $copyTo = $config->customFileUploadDir;
+      if(isset($filename)) {
+        $copyTo .= '/' . $filename;
+      }
+      $path = \Drupal::service('file_system')->copy($file->getFileUri(), $copyTo);
       if ($path) {
         $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'create', [
           'uri' => str_replace($config->customFileUploadDir, '', $path),

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -48,6 +48,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
   private $database;
 
   /**
+   * @var \Drupal\webform_civicrm\Plugin\WebformHandler
+   */
+  private $handler;
+
+  /**
    * @var \Drupal\webform\WebformSubmissionInterface
    */
   private $submission;
@@ -79,10 +84,10 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
 
     $handler_collection = $this->node->getHandlers('webform_civicrm');
     $instance_ids = $handler_collection->getInstanceIds();
-    $handler = $handler_collection->get(reset($instance_ids));
+    $this->handler = $handler_collection->get(reset($instance_ids));
     $this->database = \Drupal::database();
 
-    $this->settings = $handler->getConfiguration()['settings'];
+    $this->settings = $this->handler->getConfiguration()['settings'];
     $this->data = $this->settings['data'];
     $this->enabled = $this->utils->wf_crm_enabled_fields($this->node);
     $this->all_fields = $this->utils->wf_crm_get_fields();
@@ -2549,7 +2554,11 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           }
         }
         elseif ($dataType == 'File') {
-          if (empty($val[0]) || !($val = $this->saveDrupalFileToCivi($val[0]))) {
+          // Replace filename (with tokens) if set.
+          if (isset($component['#file_name']) && $component['#file_name']) {
+            $newFilename = $this->handler->tokenManager->replace($component['#file_name'], $this->submission);
+          }
+          if (empty($val[0]) || !($val = $this->saveDrupalFileToCivi($val[0], $newFilename))) {
             // This field can't be emptied due to the nature of file uploads
             continue;
           }


### PR DESCRIPTION
Overview
----------------------------------------
Webform hast the feature of setting specific filenames for `File` type fields. This allows to rename in the server uploaded files with specific names or using tokens. Description [here](https://www.drupal.org/node/2943067)
This feature does not work in Webform CiviCRM, the uploaded files are stored in with the original filename.. why? because how processes are executed in this order:

1. On webform submission (or before if uploads are inline), the file is uploaded to the server, usually in the `private://` location with original filename
2. `webform_civicrm` handler is executed first and and copies the filename from the first private location to `files/civicrm/custom` with the original name.  
ref: https://github.com/colemanw/webform_civicrm/blob/6.2.5/src/WebformCivicrmBase.php#L782
3. After that the webform code is executed and moves the file from private to final destination and applies the renaming (and replacing tokens if needed).  
ref: https://git.drupalcode.org/project/webform/-/blob/6.2.2/src/Plugin/WebformElement/WebformManagedFileBase.php?ref_type=tags#L1217
This is where webform calculates the final filename based on this pattern:
ref: https://git.drupalcode.org/project/webform/-/blob/6.2.2/src/Plugin/WebformElement/WebformManagedFileBase.php?ref_type=tags#L1249

So we need this feature to work in `webform_civicrm`, and after some research I found this solution

Before
----------------------------------------
Uploaded files are always saved with the original local name

After
----------------------------------------
Uploaded files are saved, following the filename pattern defined in the field settings

Technical Details
----------------------------------------
This is a solution I came up with, it could be better alternatives, but basically I had to copy how to calculate the filename from filename pattern in webform module.
`CivicrmWebformHandler` needs to have a reference to the `webform.token_manager` service to do the calculation of filename.. this could be beneficial for using Drupal tokens in other sections of the module's handler


Comments
----------------------------------------
Open to suggestions
