### PR TITLE
Update StripeTest.php - logout user

### DIFF
--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -38,6 +38,8 @@ final class StripeTest extends WebformCivicrmTestBase {
     ]));
     $this->setUpSettings();
 
+    $this->drupalLogout();
+    
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();
     $edit = [


### PR DESCRIPTION
Overview
----------------------------------------
Noticed that a Client's Stripe Transactions were failing - but only for not logged in users. So added logout to make sure we always have a Stripe test for anonymous.
