### PR TITLE
Custom Field edit hook crashes if custom fields enabled for option values

### DIFF
--- a/src/Fields.php
+++ b/src/Fields.php
@@ -260,11 +260,13 @@ class Fields implements FieldsInterface {
         'type' => 'select',
         'default_value' => $this->utils->wf_crm_get_civi_setting('lcMessages', 'en_US'),
       ];
-      $default_communication_style = $this->utils->wf_crm_apivalues('OptionValue', 'get', [
-        'sequential' => 1,
-        'option_group_id' => "communication_style",
-        'is_default' => 1,
-      ], 'value')[0] ?? NULL;
+      $default_communication_style = $this->utils->wf_civicrm_api4('OptionValue', 'get', [
+	    'where' => [
+          ['option_group_id.name', '=', 'communication_style'],
+          ['is_default', '=', TRUE],
+	    ],
+	    'select' => ['value'],
+      ])->first()['value'] ?? NULL;
       $fields['contact_communication_style_id'] = [
         'name' => t('Communication Style'),
         'type' => 'select',


### PR DESCRIPTION
Overview
----------------------------------------
Just updating this one call from api3 to api4 seems to fix it.

It seems that in the Custom Field edit hook this call with api3 attempts to access the custom field before it's fully created, causing a fatal. You are left with a half created custom field, which causes general havoc on your system.

With api4, no such problem.

Steps to reproduce (D10, at least as far back as Civi 5.75, also on Civi master)
```
# enable adding custom fields to OptionValues
cv api4 OptionValue.create +v option_group_id.name=cg_extend_objects +v label=OptionValue +v value=OptionValue +v name=civicrm_option_value

# create a custom group that extends OptionValues
cv api4 CustomGroup.create +v name=test_group +v title=test_group +v extends=OptionValue

# create a custom field in that group
cv api4 CustomField.create +v custom_group_id.name=test_group +v html_type=Text +v label=test_field
```


Before
----------------------------------------
```

In api.php line 149:
                           
  DB Error: no such field  
                           
```

After
----------------------------------------
- Field creates as expected

Comments
----------------------------------------
Admittedly custom fields on OptionValues is a bit of a strange situation, but it seems to generally work fine apart from this.
