### PR TITLE
Fix calculation of tax on line item amount

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1686,6 +1686,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
    * Calculate line-items for this webform submission
    */
   private function tallyLineItems() {
+    $submittedFormValues = $this->form_state->getUserInput();
     // Contribution
     $fid = 'civicrm_1_contribution_1_contribution_total_amount';
     if (isset($this->enabled[$fid]) || $this->getData($fid) > 0) {
@@ -1703,7 +1704,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if (isset($this->enabled[$fid])) {
       foreach ($this->data['lineitem'][1]['contribution'] as $n => $lineitem) {
         $fid = "civicrm_1_lineitem_{$n}_contribution_line_total";
-        if ($this->getData($fid) != 0) {
+        if (!isset($submittedFormValues[$fid]) || $this->getData($fid) != 0) {
           $this->line_items[] = [
             'qty' => 1,
             'unit_price' => $lineitem['line_total'],
@@ -1738,6 +1739,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             };
 
             if ($price) {
+              $member_name = NULL;
               if (!empty($this->data['contact'][$c]['contact'][$n])) {
                 $member_contact = $this->data['contact'][$c]['contact'][$n];
                 if (!empty($member_contact['first_name']) && !empty($member_contact['last_name'])) {


### PR DESCRIPTION
Overview
----------------------------------------
Fix calculation of tax on line item amount if the field is displayed on payment page.

Before
----------------------------------------
To replicate:
- Create a webform with contribution amount and line item amount.
- Ensure financial type set on both the field has 15% GST applied to it.
- Ensure both the field are set to display on second page (payment page).
- Submit the webform.
- On payment table, only contribution amount row displays 15% tax. 
- Line item amount is displayed without tax amount.

![image](https://github.com/user-attachments/assets/dc2e6617-6f8d-4dcc-b99b-0f97d8204297)

After
----------------------------------------
Fixed

![image](https://github.com/user-attachments/assets/e900a46e-0d98-427e-871e-dc070219709e)

Technical Details
----------------------------------------
Consider tax amount for line item if its included in the webform.

