### PR TITLE
add street address to existing contact

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -107,6 +107,7 @@ class ContactComponent implements ContactComponentInterface {
       'country' => ['address', 'country_id:label'],
       'county' => ['address', 'county_id:label'],
       'postal_code' => ['address', 'postal_code'],
+      'street_address' => ['address', 'street_address']
     ];
     $joinedTables = [];
     foreach ($fieldMappings as $field => $type) {

--- a/src/Plugin/WebformElement/CivicrmContact.php
+++ b/src/Plugin/WebformElement/CivicrmContact.php
@@ -523,6 +523,7 @@ class CivicrmContact extends WebformElementBase {
       'state_province' => t("State/Province"),
       'country' => t("Country"),
       'postal_code' => t("Postal Code"),
+      'street_address' => t("Street Address"),
       'phone' => t("Phone"),
     ];
     return $options;


### PR DESCRIPTION
Overview
----------------------------------------
I want to search for a contact by it's street. Therefore I added it to `ContactComponent.php`
This is quick fix adding just the street to the hard coded List of available fields to search for.

Before
----------------------------------------
The hard coded list of fields to search for with existing contact is missing street_address  

After
----------------------------------------
The hard coded list of fields to search for with existing contact is added street_address (Street)  
