### PR TITLE
Fix check permissions in civicrm_api call

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -632,9 +632,7 @@ class Utils implements UtilsInterface {
     if (!$entity) {
       return [];
     }
-    $params += [
-      'checkPermissions' => FALSE,
-    ];
+    $params['checkPermissions'] = FALSE;
     $result = civicrm_api4($entity, $operation, $params, $index);
     return $result;
   }
@@ -658,9 +656,7 @@ class Utils implements UtilsInterface {
       return [];
     }
 
-    $params += [
-      'check_permissions' => FALSE,
-    ];
+    $params['check_permissions'] = FALSE;
     if ($operation == 'transact') {
       $utils = \Drupal::service('webform_civicrm.utils');
       $result = $utils->wf_civicrm_api3_contribution_transact($params);


### PR DESCRIPTION
Overview
----------------------------------------

I found that with my setup searching for existing contacts by city did not work.
After fideling around I found that checkpermissions was not set `FALSE` before calling the civicrm_api4.


Technical Details
------------------------

This was due to the behaviour of `+=` for php arrays, which won't overwrite existing elements. 
As the element `$params['checkPermissions']` was set true earlier, the element was not overwritten by `+=` and so the explicit join did not work.

I added a quick fix, setting the element in the common way. Also one other function.

Comments
----------------

However I found, that the extension is using `+=` quit often. But I wonder if there is a need for it?
