### PR TITLE
Fix test fails on drupal 10.3.7

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -351,9 +351,11 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
    *  TRUE if only one option is enabled on the element.
    * @param string $asList
    *  TRUE if element need to be rendered as select element.
+   * @param string $secondarySelector
+   *  optional secondary selector
    */
-  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL, $singleOption = FALSE, $asList = FALSE) {
-    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] a.webform-ajax-link');
+  protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL, $singleOption = FALSE, $asList = FALSE, $secondarySelector = 'li.edit') {
+    $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] ' . ($secondarySelector ? "$secondarySelector " : '') . 'a.webform-ajax-link');
     $checkbox_edit_button->click();
     $this->assertSession()->waitForField('drupal-off-canvas');
     $this->htmlOutput();

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -13,6 +13,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
 
   use WebformBrowserTestTrait;
   use \Drupal\Tests\mink_civicrm_helpers\Traits\Utils;
+  use \Drupal\Tests\system\Traits\OffCanvasTestTrait;
 
   /**
    * {@inheritdoc}
@@ -23,6 +24,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     'webform_civicrm',
     'token',
     'ckeditor5',
+    'off_canvas_test',
     'mink_civicrm_helpers',
   ];
 
@@ -357,7 +359,7 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
   protected function editCivicrmOptionElement($selector, $multiple = TRUE, $enableStatic = FALSE, $default = NULL, $type = NULL, $singleOption = FALSE, $asList = FALSE, $secondarySelector = 'li.edit') {
     $checkbox_edit_button = $this->assertSession()->elementExists('css', '[data-drupal-selector="' . $selector . '"] ' . ($secondarySelector ? "$secondarySelector " : '') . 'a.webform-ajax-link');
     $checkbox_edit_button->click();
-    $this->assertSession()->waitForField('drupal-off-canvas');
+    $this->waitForOffCanvasArea();
     $this->htmlOutput();
     if ($type) {
       $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-change-type"]')->click();


### PR DESCRIPTION
Overview
----------------------------------------
Clean version of https://github.com/colemanw/webform_civicrm/pull/1020

Before
----------------------------------------
Something changed in 10.3.7 but not sure exactly what, just the symptom is the popout edit dialog doesn't open to edit webform components.

After
----------------------------------------


Technical Details
----------------------------------------
The first commit fixes something that seems like it should have never worked, where it seems like it's clicking ALL the `li`'s in the `ul` instead of just the edit one. Maybe it just happened to work out.

The second commit changes from waitForField on a different target (which doesn't actually do anything except wait for up to 10 seconds regardless, because the return value should be checked to see if it actually appeared) to doing the same thing drupal core does in its tests of "off-canvas" popouts.

Comments
----------------------------------------
One difficulty with troubleshooting this is that the test runs fine before with the same environment locally, so it's a bit of guesswork.

Running with the whole suite now - let's see if we need to adjust slightly for some tests.