### PR TITLE
Use str_ends_with function over strpos to fix false notice

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -379,7 +379,7 @@ function webform_civicrm_civicrm_buildForm($formName, $form) {
         }
         $elements = $webform->getElementsDecodedAndFlattened();
         foreach (array_keys($elements) as $element_form_key) {
-          if (strpos($element_form_key, "custom_$fid") !== FALSE) {
+          if (str_ends_with($element_form_key, "custom_$fid") !== FALSE) {
             $nodes[] = $webform->toLink()->toString();
           }
         }


### PR DESCRIPTION
Overview
----------------------------------------
When deleting a custom field, the UI erroneously displays the message “This field is used in the following webforms:” even when the field isn't actually used. 

This issue arises in rare scenarios where there are over 100 custom fields in the system. For example, if a webform includes the field custom_354 and you attempt to delete custom_35, the warning appears because the code mistakenly matches the substring custom_35 within identifiers like civicrm_1_contact_1_cg42_custom_358 or civicrm_1_contact_1_cg42_custom_359. This PR resolves the issue by using the str_ends_with function for precise matching.

