### PR TITLE
Fixing civicrm date format

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2582,21 +2582,20 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
           $timestamp = $val . $time;
           // Check if the $timestamp is not empty
           if (!empty($timestamp)) {
-            // Remove the time portion if present (everything after 'T')
+            // Remove the time portion (everything after 'T').
             $timestamp = preg_replace('/T.*/', '', $timestamp);
-
-            // Check if the length of the remaining timestamp is exactly 8 characters (YYYYMMDD format)
+            // Validate if $timestamp length is exactly 8 characters.
             if (strlen($timestamp) === 8) {
-                // Create a DateTime object from the timestamp using 'Ymd' format (YYYYMMDD)
-                $formatted_date = \DateTime::createFromFormat('Ymd', $timestamp);
+              // Convert $timestamp to DateTime object using 'Ymd' format.
+              $formatted_date = \DateTime::createFromFormat('Ymd', $timestamp);
             } else {
-                // If the length is not 8, set $formatted_date to false
-                $formatted_date = false;
+              // Set $formatted_date to false if length is not 8.
+              $formatted_date = false;
             }
-
-            // If the $formatted_date is valid, format it as 'Y-m-d' (YYYY-MM-DD), otherwise set $val to an empty string
+            // Format valid date as 'Y-m-d'.
+            // otherwise set $val to an empty string.
             $val = $formatted_date ? $formatted_date->format('Y-m-d') : '';            
-        }
+          }
         // The admin can change a number field to use checkbox/radio/select/grid widget and we'll sum the result
         elseif ($field['type'] === 'number' || $field['type'] === 'civicrm_number') {
           $sum = 0;

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2595,8 +2595,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             }
 
             // If the $formatted_date is valid, format it as 'Y-m-d' (YYYY-MM-DD), otherwise set $val to an empty string
-            $val = $formatted_date ? $formatted_date->format('Y-m-d') : '';
-            
+            $val = $formatted_date ? $formatted_date->format('Y-m-d') : '';            
         }
         // The admin can change a number field to use checkbox/radio/select/grid widget and we'll sum the result
         elseif ($field['type'] === 'number' || $field['type'] === 'civicrm_number') {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2579,6 +2579,24 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
             $time = substr($time, -6);
           }
           $val .= $time;
+          $timestamp = $val . $time;
+          // Check if the $timestamp is not empty
+          if (!empty($timestamp)) {
+            // Remove the time portion if present (everything after 'T')
+            $timestamp = preg_replace('/T.*/', '', $timestamp);
+
+            // Check if the length of the remaining timestamp is exactly 8 characters (YYYYMMDD format)
+            if (strlen($timestamp) === 8) {
+                // Create a DateTime object from the timestamp using 'Ymd' format (YYYYMMDD)
+                $formatted_date = \DateTime::createFromFormat('Ymd', $timestamp);
+            } else {
+                // If the length is not 8, set $formatted_date to false
+                $formatted_date = false;
+            }
+
+            // If the $formatted_date is valid, format it as 'Y-m-d' (YYYY-MM-DD), otherwise set $val to an empty string
+            $val = $formatted_date ? $formatted_date->format('Y-m-d') : '';
+            
         }
         // The admin can change a number field to use checkbox/radio/select/grid widget and we'll sum the result
         elseif ($field['type'] === 'number' || $field['type'] === 'civicrm_number') {


### PR DESCRIPTION
Overview:
Webform CiviCRM was not submitting the date values in the correct format to CiviCRM records. This patch ensures proper handling of date values in Webform CiviCRM, preventing incorrect date storage and formatting issues.

**Before** 
The date values were being saved in an incorrect format, such as "June 1st, 400", instead of the expected "June 1986" format. This was caused by improper parsing of the date input before submission to CiviCRM. **Please see date-format-before-apply-patch.png**
![date-format-before-apply-patch](https://github.com/user-attachments/assets/3ab6cada-3443-4389-9947-ce42a152605c)



**After** 
After applying the patch, Webform CiviCRM now submits the date in the correct format (Y-m-d), ensuring that CiviCRM correctly stores the selected year and month. **Please see date-format-after-apply-patch.png.png**
![date-format-after-apply-patch](https://github.com/user-attachments/assets/ccb87ae5-f140-4f41-917a-08a9a67e1b33)


Technical Details:

Concatenates $val with $time to create a timestamp.
Uses preg_replace('/T.*/', '', $timestamp) to remove the time component and retain only the date part.
Ensures the extracted date has exactly 8 characters (YYYYMMDD).
Converts the valid date into a DateTime object and reformats it to Y-m-d.
If the extracted value is invalid, assigns an empty string ('') to $val.