### PR TITLE
Add Contact Birth Date into a Test

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -22,6 +22,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
       'webform' => $this->webform->id(),
     ]));
     $this->enableCivicrmOnWebform();
+    $this->getSession()->getPage()->checkField("Birth Date");
 
     $params = [
       'payment_processor_id' => $payment_processor['id'],
@@ -44,6 +45,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
+    $this->getSession()->getPage()->fillField('Birth Date', '1970-01-01');
 
     $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');
@@ -52,6 +54,13 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertSession()->elementTextContains('css', '#wf-crm-billing-items .civicrm_1_contribution_1', 'Contribution Amount');
 
     $this->fillCardAndSubmit();
+
+    $api_result = $this->utils->wf_civicrm_api('contact', 'get', [
+      'sequential' => 1,
+    ]);
+    $this->assertEquals(1, $api_result['count']);
+    $contact = reset($api_result['values']);
+    $this->assertEquals('1970-01-01', $contact['birth_date']);
 
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
       'sequential' => 1,

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -55,13 +55,6 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
 
     $this->fillCardAndSubmit();
 
-    $api_result = $this->utils->wf_civicrm_api('contact', 'get', [
-      'sequential' => 1,
-    ]);
-    $this->assertEquals(1, $api_result['count']);
-    $contact = reset($api_result['values']);
-    $this->assertEquals('1970-01-01', $contact['birth_date']);
-
     $api_result = $this->utils->wf_civicrm_api('contribution', 'get', [
       'sequential' => 1,
     ]);
@@ -73,6 +66,14 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->assertEquals('10.00', $contribution['total_amount']);
     $this->assertEquals('Completed', $contribution['contribution_status']);
     $this->assertEquals('USD', $contribution['currency']);
+
+    $api_result = $this->utils->wf_civicrm_api('contact', 'get', [
+      'sequential' => 1,
+      'id' => $contribution['contact_id'],
+    ]);
+    $this->assertEquals(1, $api_result['count']);
+    $contact = reset($api_result['values']);
+    $this->assertEquals('1970-01-01', $contact['birth_date']);
 
     $sid = $this->getLastSubmissionId($this->webform);
     $this->drupalGet(Url::fromRoute('entity.webform_submission.canonical', [

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -46,6 +46,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
     $this->getSession()->getPage()->fillField('Birth Date', '1970-01-01');
+    $this->createScreenshot($this->htmlOutputDirectory . '/filled_dob.png');
 
     $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');
     $this->assertSession()->elementExists('css', '#wf-crm-billing-items');

--- a/tests/src/FunctionalJavascript/ContributionDummyTest.php
+++ b/tests/src/FunctionalJavascript/ContributionDummyTest.php
@@ -45,7 +45,7 @@ final class ContributionDummyTest extends WebformCivicrmTestBase {
     $this->getSession()->getPage()->fillField('First Name', 'Frederick');
     $this->getSession()->getPage()->fillField('Last Name', 'Pabst');
     $this->getSession()->getPage()->fillField('Email', 'fred@example.com');
-    $this->getSession()->getPage()->fillField('Birth Date', '1970-01-01');
+    $this->getSession()->getPage()->fillField('Birth Date', '01-01-1970');
     $this->createScreenshot($this->htmlOutputDirectory . '/filled_dob.png');
 
     $this->getSession()->getPage()->fillField('Contribution Amount', '10.00');


### PR DESCRIPTION
Overview
----------------------------------------
@vikascividesk is reporting that Webform CiviCRM is not submitting date values in the correct format to CiviCRM records, including Birth Date fields - https://github.com/colemanw/webform_civicrm/pull/1045 - from experience we know that Birth Date fields are handled properly. This is a test only PR to lock that in.

Before
----------------------------------------
no DOB test

After
----------------------------------------
DOB test added to an existing test

Technical Details
----------------------------------------
Screenshot from Functional JS Test:

<img width="1400" alt="image" src="https://github.com/user-attachments/assets/10ab12c8-460e-40d4-84b0-99d00d3cfb54" />

Test itself:

<img width="772" alt="image" src="https://github.com/user-attachments/assets/37db50fc-516c-4269-826b-0367da5625ca" />

Which in CiviCRM is:

<img width="793" alt="image" src="https://github.com/user-attachments/assets/7de9af8f-0bf7-4a5d-93fe-42d61ac7d53f" />

