### PR TITLE
Always put the element for "Other" at last.

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -509,6 +509,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
           $element['#attributes']['class'][] = 'civicrm-enabled';
           if ($element['#type'] == 'webform_radios_other') {
             $element['other']['#attributes']['class'][] = 'civicrm-enabled';
+            $element['other']['#weight'] = 100;
           }
           $dt = NULL;
           if (!empty($field['data_type'])) {


### PR DESCRIPTION
Overview
----------------------------------------
When switching elements to "Radios Other", the "Other" element is rendered on top of the radios.

Before
----------------------------------------
![image](https://github.com/user-attachments/assets/6a717689-563c-46f9-a544-8fe66ee72823)


After
----------------------------------------
![image](https://github.com/user-attachments/assets/bdb51558-1322-490a-a016-8d5b9a3c02ce)
