### PR TITLE
prevent type error when user can't access existing contact element

### DIFF
--- a/js/webform_civicrm_forms.js
+++ b/js/webform_civicrm_forms.js
@@ -14,7 +14,7 @@ var wfCivi = (function (D, $, drupalSettings, once) {
     var formClass = getFormClass(nid);
     var defaults = $(formClass).data('form-defaults') || {};
 
-    if (cid.charAt(0) === '-') {
+    if (cid && cid.charAt(0) === '-') {
       resetFields(num, nid, true, 'show', toHide, hideOrDisable, showEmpty, 500, defaults);
       // Fill name fields with name typed
       if (cid.length > 1) {


### PR DESCRIPTION
Overview
----------------------------------------
See https://www.drupal.org/project/webform_civicrm/issues/3518323.

Before
----------------------------------------
Visibility controls that affect the presence of this field sometimes have a type error.

After
----------------------------------------
No type error.

Comments
----------------------------------------
Sorry for not having a handle on creating a test case - but given the simplicity of the fix hopefully it's acceptable nonetheless.
