### PR TITLE
[Test only] Replace deprecated getOptions helper function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -150,7 +150,7 @@ jobs:
           chmod +x /home/runner/civicrm-cv/cv
           ./vendor/drush/drush/drush -y -l http://civi.localhost site-install standard --db-url='mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/fakedb' --site-name=FakeCivi
           chmod +w web/sites/default
-          /home/runner/civicrm-cv/cv core:install --cms-base-url=http://civi.localhost
+          /home/runner/civicrm-cv/cv core:install --url=http://civi.localhost
       - name: Download Civi extensions
         run: |
           mkdir -p ~/drupal/web/sites/default/files/civicrm/ext

--- a/tests/src/FunctionalJavascript/ContactRelationshipTest.php
+++ b/tests/src/FunctionalJavascript/ContactRelationshipTest.php
@@ -400,9 +400,7 @@ final class ContactRelationshipTest extends WebformCivicrmTestBase {
     $this->htmlOutput();
     $this->assertSession()->elementExists('css', '[data-drupal-selector="edit-contact-defaults"]')->click();
     $this->getSession()->getPage()->selectFieldOption('Set default contact from', 'Relationship to...');
-    $loadedRelationshipTypes = $this->getOptions('Specify Relationship(s)');
-    $type = array_search('School is Contact 1', $loadedRelationshipTypes);
-    $this->getSession()->getPage()->selectFieldOption('Specify Relationship(s)', $type);
+    $this->getSession()->getPage()->selectFieldOption('Specify Relationship(s)', 'School is Contact 1');
     $this->getSession()->getPage()->pressButton('Save');
     $this->assertSession()->assertWaitOnAjaxRequest();
 

--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -853,4 +853,35 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
     return 'credit_card_exp_date[m]';
   }
 
+  /**
+   * Copied from https://git.drupalcode.org/project/drupal/-/commit/b709c5ae30c0e839019c64ec7764aa2cc3719978
+   * Helper function to get the options of select field.
+   *
+   * @param \Behat\Mink\Element\NodeElement|string $select
+   *   Name, ID, or Label of select field to assert.
+   * @param \Behat\Mink\Element\Element $container
+   *   (optional) Container element to check against. Defaults to current page.
+   *
+   * @return array
+   *   Associative array of option keys and values.
+   *
+   * @deprecated in drupal:11.2.0 and is removed from drupal:12.0.0. There is
+   *   no direct replacement.
+   *
+   * @see https://www.drupal.org/node/3523039
+   */
+  protected function getOptions($select, ?\Behat\Mink\Element\Element $container = NULL) {
+    if (is_string($select)) {
+      $select = $this->assertSession()->selectExists($select, $container);
+    }
+    $options = [];
+    /** @var \Behat\Mink\Element\NodeElement $option */
+    foreach ($select->findAll('xpath', '//option') as $option) {
+      $label = $option->getText();
+      $value = $option->getAttribute('value') ?: $label;
+      $options[$value] = $label;
+    }
+    return $options;
+  }
+
 }


### PR DESCRIPTION
Overview
----------------------------------------
See https://git.drupalcode.org/project/drupal/-/commit/b709c5ae30c0e839019c64ec7764aa2cc3719978

Before
----------------------------------------
Drupal 11 tests will fail because of deprecation recently added to drupal 11.

After
----------------------------------------
Everybody happy.

Technical Details
----------------------------------------


Comments
----------------------------------------
