### PR TITLE
Fix problem with State Province Id lost after validation

### DIFF
--- a/src/FieldOptions.php
+++ b/src/FieldOptions.php
@@ -29,7 +29,7 @@ class FieldOptions implements FieldOptionsInterface {
         list($contact_types, $sub_types) = $utils->wf_crm_get_contact_types();
         $ret = wf_crm_aval($sub_types, $data['contact'][$c]['contact'][1]['contact_type'], []);
       }
-      elseif ((strpos($name, 'state_province_id') !== false) || (isset($field['type']) && $field['type'] === 'civicrm_number')) {
+      elseif (isset($field['type']) && $field['type'] === 'civicrm_number') {
         return [];
       }
       elseif ($name === 'relationship_type_id') {


### PR DESCRIPTION
Overview
----------------------------------------
After selecting CRM field State/Province on webform and submitting form, field value is lost if other field return error and form is not submitted.
Country is selected but this field is empty

Technical Details
----------------------------------------
Simple as it is, add contact to form with full address and submit form, add other field that return error after submit, form will not process.

Comments
----------------------------------------
[https://www.drupal.org/project/webform_civicrm/issues/3529524](https://www.drupal.org/project/webform_civicrm/issues/3529524)