### PR TITLE
[Test only] Add void to test class declaration as per updated parent

### DIFF
--- a/tests/src/FunctionalJavascript/CiviCrmTestBase.php
+++ b/tests/src/FunctionalJavascript/CiviCrmTestBase.php
@@ -57,7 +57,7 @@ abstract class CiviCrmTestBase extends WebDriverTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function changeDatabasePrefix() {
+  protected function changeDatabasePrefix(): void {
     parent::changeDatabasePrefix();
     $connection_info = Database::getConnectionInfo('default');
     // CiviCRM does not leverage table prefixes, so we unset it. This way any


### PR DESCRIPTION
Overview
----------------------------------------
They recently added void here so tests are failing on drupal 11: https://git.drupalcode.org/project/drupal/-/commit/5d589fbeaeb8858dc7de823339fa5eeeb834545d
