### PR TITLE
fix contact refs, take 1

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2466,9 +2466,14 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         if (is_array($val)) {
           $this->data[$ent][$c][$table][$n][$name] = [];
           foreach ($val as $v) {
-            if (is_numeric($v) && !empty($this->ent['contact'][$v]['id'])) {
-              $tableName = $isStandardCustom ? $ent : $table;
-              $this->data[$ent][$c][$tableName][$n][$name][] = $this->ent['contact'][$v]['id'];
+            if (is_numeric($v)) {
+              if (!empty($this->ent['contact'][$v]['id'])) {
+                $tableName = $isStandardCustom ? $ent : $table;
+                $this->data[$ent][$c][$tableName][$n][$name][] = $this->ent['contact'][$v]['id'];
+              }
+              elseif ($contactPrefillMode) {
+                $this->data[$ent][$c]['update_contact_ref'][$n][$name] = $v;
+              }
             }
           }
         }
@@ -2898,20 +2903,15 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     $updateParams = [
       'id' => $cid,
     ];
-    $skipKeys = [];
+    // Iterate over all contact refs that we should update.
     foreach ($params['update_contact_ref'] as $n => $refKeys) {
       foreach ($refKeys as $refKey => $val) {
-        // Skip contact ref that doesn't have a valid contact ids.
-        if (empty($this->ent['contact'][$val]['id'])) {
+        $contactRefValue = $this->ent['contact'][$val]['id'] ?? NULL;
+        // Skip contact ref that doesn't have a valid contact id.
+        if (!$contactRefValue) {
           continue;
         }
-        foreach ($params['contact'] as $contactParams) {
-          foreach ($contactParams as $key => $value) {
-            if (strpos($key, "{$refKey}_") === 0 && !isset($updateParams[$key]) && !in_array($key, $skipKeys)) {
-              $updateParams[$key] = $value;
-            }
-          }
-        }
+        $updateParams[$refKey] = $contactRefValue;
       }
     }
     if (count($updateParams) > 1) {


### PR DESCRIPTION
Overview
----------------------------------------
Contact Reference fields are not properly populated. This is the  same issue @jitendrapurohit clarified on @pradpnayak
's Pull Request here: https://github.com/colemanw/webform_civicrm/pull/798

Before
----------------------------------------

1. In CiviCRM, create a custom field that is a contact reference field
2. In Webform, create two contacts. One contact just has name. The second contact includes the custom contact reference field with "user select" as the option
3. Fill out the form. For the custom contact reference field, choose "Contact 1"

Contact 1 and Contact 2 are both entered in CiviCRM. But the custom contact reference field for Contact 2 is blank.


After
----------------------------------------

The contact reference field is filled in.

Technical Details
----------------------------------------
The old code had several problems:

1. When iterating over the contact reference fields, the  'update_contact_ref' key was properly set when the value is not an array, but was not set when the value was an array.
2. Additionally, when saving the contact reference field, the right value was not being saved
3. Lastly, as identified in the original pull request, there is a field name check that was incorrect and unnecessary to begin with so I've removed it.

Comments
----------------------------------------

There are still problems that need to be addressed in a future commit:

1. If the contact reference field is a multi-value field, the user submitting the form gets their contact inserted along with the selected contact
2. If the contact reference field is set to "Contact 1" in the CiviCRM tab (instead of "user select") it is never set.
