### PR TITLE
Use civi's filenaming style for uploaded files

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -801,9 +801,10 @@ abstract class WebformCivicrmBase {
     if ($file) {
       $config = \CRM_Core_Config::singleton();
       $copyTo = $config->customFileUploadDir;
-      if(isset($filename)) {
-        $copyTo .= '/' . $filename;
+      if(!isset($filename)) {
+        $filename = basename($file->getFileUri());
       }
+      $copyTo .= '/' . \CRM_Utils_File::makeFileName($filename, TRUE);
       $path = \Drupal::service('file_system')->copy($file->getFileUri(), $copyTo);
       if ($path) {
         $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
It was desired to make it use the same filenaming style as core civi.

Before
----------------------------------------
It either uses drupal's style, the style used by the "sanitize" checkbox that webform file field config has, or the filename as is, depending on what/where.

After
----------------------------------------
The file stored on the civi side will always use the civi style, e.g. my_file_38d7c8d66aa6a88f3426.jpg

Technical Details
----------------------------------------


Comments
----------------------------------------
I'm not sure if it's possible to write a mink test when it requires using a filepicker dialog.