### PR TITLE
bugfix for contact creation failure after numeric search (issue 3474064)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 6.x
   schedule:
-    # Run Monday/Thursday at 12:13 GMT
+    # Run Monday/Thursday at 12:13 GMT.
     - cron: '13 12 * * 1,4'
   workflow_dispatch:
     inputs:

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -2640,7 +2640,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       $component = $this->node->getElement("civicrm_{$c}_contact_1_contact_existing");
       $existing_contact_val = $this->submissionValue($component['#form_key']);
       // Fields are hidden if value is empty (no selection) or a numeric contact id
-      if (!$existing_contact_val[0] || is_numeric($existing_contact_val[0])) {
+      if (!$existing_contact_val[0] || ((is_numeric($existing_contact_val[0])) && ((int)$existing_contact_val[0] > 0))) {
         $type = ($table == 'contact' && strpos($name, 'name')) ? 'name' : $table;
         $component += ['#hide_fields' => []];
         if (in_array($type, $component['#hide_fields'])) {


### PR DESCRIPTION
Overview
----------------------------------------
After searching for a number and then pressing "Create New" for a contact on a webform, the contact is not created.

Technical Details
----------------------------------------
The issue is described in greater detail here:

https://www.drupal.org/project/webform_civicrm/issues/3474064

It persists in webform_civicrm version 6.3.1.
