### PR TITLE
test card features seems to have changed at stripe?

### DIFF
--- a/tests/src/FunctionalJavascript/StripeTest.php
+++ b/tests/src/FunctionalJavascript/StripeTest.php
@@ -126,7 +126,7 @@ final class StripeTest extends WebformCivicrmTestBase {
     $this->getSession()->wait(3000);
 
     $this->assertSession()->waitForElementVisible('css', 'input[name="cardnumber"]');
-    $this->getSession()->getPage()->fillField('cardnumber', '4111 1111 1111 1111');
+    $this->getSession()->getPage()->fillField('cardnumber', '4242 4242 4242 4242');
     $this->getSession()->getPage()->fillField('exp-date', '11 / ' . $expYear);
     $this->getSession()->getPage()->fillField('cvc', '123');
     $this->getSession()->getPage()->fillField('postal', '12345');


### PR DESCRIPTION
Overview
----------------------------------------
I'm not sure 4111111111111111 was ever a valid test card for stripe but maybe always worked. Now it seems that it doesn't trigger the postal code to appear (which is normal for some countries's cards but it used to show up for this one).

Before
----------------------------------------
Fails on trying to fill out non-existent postal code field.

After
----------------------------------------
Use a card that triggers the widget to make postal code appear.

Technical Details
----------------------------------------

Comments
----------------------------------------
