### PR TITLE
improvements to recording webform data in the CiviCRM activity Details field

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1635,7 +1635,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     if (!empty($this->data['activity'][$activity_number]['details']['view_link'])) {
       $params['details'] .= '<p>' . $this->submission->toLink(t('View Webform Submission'), 'canonical', [
         'absolute' => TRUE,
-      ])->toString() . '</p>' . \Drupal\Core\Link::fromTextAndUrl('View Webform Submission', $this->submission->getTokenUrl('view'))->toString();
+      ])->toString() . '</p>';
     }
     if (!empty($this->data['activity'][$activity_number]['details']['view_link_secure'])) {
       $params['details'] .= '<p>' . \Drupal\Core\Link::fromTextAndUrl('View Webform Submission', $this->submission->getTokenUrl('view'))->toString() . '</p>';

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1512,12 +1512,6 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
         // Update mode
         else {
           $params['id'] = $this->ent['activity'][$n]['id'];
-
-          // Update details when user has selected he wants to update the details
-          if (!empty($data['details']['update_existing'])) {
-            // Format details as html
-            $this->formatSubmissionDetails($params, $n);
-          }
         }
         // Allow "automatic" values to pass-thru if empty
         foreach ($params as $field => $value) {


### PR DESCRIPTION
Overview
----------------------------------------

When adding an activity to a webform, there is an option to record information about the webform in the Activity Details field. This works great when there is no activity details field in the webform. But if that field exists, then every update appends data, often leading to the same data (e.g. links back to the submission) being added over and over again. 

Before
----------------------------------------

An ever growing Details field with every submission.


After
----------------------------------------

The Details field is only populated on the initial submission and is not updated if the submission is edited.

Note: this might not work for some people who want the Details field to be always up to date?

