### PR TITLE
Remove extra slash

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -800,11 +800,12 @@ abstract class WebformCivicrmBase {
     $file = File::load($id);
     if ($file) {
       $config = \CRM_Core_Config::singleton();
-      $copyTo = $config->customFileUploadDir;
+      // Get the custom file upload directory and ensure it ends with a single slash.
+      $copyTo = \CRM_Utils_File::addTrailingSlash($config->customFileUploadDir, '/');
       if(!isset($filename)) {
         $filename = basename($file->getFileUri());
       }
-      $copyTo .= '/' . \CRM_Utils_File::makeFileName($filename, TRUE);
+      $copyTo .= \CRM_Utils_File::makeFileName($filename, TRUE);
       $path = \Drupal::service('file_system')->copy($file->getFileUri(), $copyTo);
       if ($path) {
         $result = \Drupal::service('webform_civicrm.utils')->wf_civicrm_api('file', 'create', [


### PR DESCRIPTION
Overview
----------------------------------------
An extra leading slash is getting saved as part of the URI in the database.
For example, the file path is:
$path us 
`/var/www/web/TEST/web/sites/default/files/civicrm/custom//skvare_test_image_two_A_ea18dc9589b20b8163a70a370cdfd124.jpg`

When running:
 
`str_replace($config->customFileUploadDir, '', $path)`, it only removes `/var/www/web/TEST/web/sites/default/files/civicrm/custom/` but leaves the leading  `/`  at the start of the file name.

Before
----------------------------------------
URI contains:

`/skvare_test_image_two_A_ea18dc9589b20b8163a70a370cdfd124.jpg`


After
----------------------------------------
URI should not have a leading slash:  

`skvare_test_image_two_A_ea18dc9589b20b8163a70a370cdfd124.jpg`
