### PR TITLE
Refresh Payment Processor options on changing test mode value

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1157,6 +1157,7 @@ class AdminForm implements AdminFormInterface {
     }
     $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_financial_type_id", "..:custom");
     $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_payment_processor_id", "..:contribution");
+    $this->addAjaxItem("contribution:sets:contribution", "civicrm_1_contribution_1_contribution_is_test", "..:contribution");
 
     //Add Currency.
     $this->form['contribution']['sets']['contribution']['contribution_1_settings_currency'] = [


### PR DESCRIPTION
Overview
----------------------------------------
Refresh Payment Processor options on changing test mode value

Before
----------------------------------------

1) Go to CiviCRM tab on a webform 
2) try to switch from user select to any other payment processor (e.g. stripe) then change the payment processor mode (e.g. live to test).
3) Return to that setting after saving, it will show that the user select payment processor is shown rather than the one you switched to (e.g user select instead of stripe).
4) If you don't also change the processor mode this bug doesn't happen. Also if you try to switch the mode before the processor, you have to switch the processor twice, but then the bug does not occur.

After
----------------------------------------
Switching the test mode option refreshes the contribution section to update test payment processor ids in the PP field.

Technical Details
----------------------------------------
Add an ajax refresh on the payment mode field.

Comments
----------------------------------------
@stesi561 has added a test on https://github.com/colemanw/webform_civicrm/pull/1073