### PR TITLE
Enable is_test if payment is made using test mode processor

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -595,6 +595,17 @@ abstract class WebformCivicrmBase {
   }
 
   /**
+   * Enable is_test if payment is made using a test processor.
+   *
+   * @param array $params
+   */
+  protected function setTestMode(&$params) {
+    if (!empty($this->data['contribution'][1]['contribution'][1]['is_test'])) {
+      $params['is_test'] = TRUE;
+    }
+  }
+
+  /**
    * Get memberships for a contact
    * @param $cid
    * @return array
@@ -621,6 +632,8 @@ abstract class WebformCivicrmBase {
     if (!empty($mid)) {
       $params['id'] = $mid;
     }
+    $this->setTestMode($params);
+
     $existing = $this->utils->wf_crm_apivalues('membership', 'get', $params);
 
     if (!$existing) {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1312,6 +1312,7 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       if (isset($this->ent['contribution_recur'][1]['id'])) {
         $params['contribution_recur_id'] = $this->ent['contribution_recur'][1]['id'];
       }
+      $this->setTestMode($params);
 
       $result = $this->utils->wf_civicrm_api('membership', 'create', $params);
 
@@ -2308,6 +2309,8 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
       }
       $params['pan_truncation'] = substr($params['credit_card_number'], -4);
     }
+
+    $this->setTestMode($params);
 
     // Save this stuff for later
     unset($params['soft'], $params['soft_credit_type_id']);


### PR DESCRIPTION
Overview
----------------------------------------
Enable is_test if payment is made using test mode processor

Before
----------------------------------------
If a payment is made using a test mode processor, it currently results in a existing membership renewal

imo it should make a separate new 'test membership'

i just tested via a civi form on smaster and my membership was not extended when the contribution page was in test mode.

and it did create a Test Membership for the contact.

The issue is only with webforms where it 'knows' the contribution is a test because the payment processor is in test mode, but doesn't know that this should make the Membership a test too

After
----------------------------------------
If Test Mode is selected in civicrm settings of the webform, the contribution and membership is created with is_test = 1.

Technical Details
----------------------------------------
Add is_test flag is test mode is enabled in civi settings.

