### PR TITLE
Fix admin group removal on submitting public group option

### DIFF
--- a/src/WebformCivicrmBase.php
+++ b/src/WebformCivicrmBase.php
@@ -567,7 +567,7 @@ abstract class WebformCivicrmBase {
         'extra' => wf_crm_aval($field, 'extra', []) + wf_crm_aval($field, '#extra', []),
         'form_key' => $field['#form_key'],
       ];
-      $exposed = $this->utils->wf_crm_field_options($params, 'civicrm_live_options', $this->data);
+      $exposed = $this->utils->wf_crm_field_options($params, 'civicrm_live_options', $this->settings['data'] ?? $this->data);
       foreach ($exclude as $i) {
         unset($exposed[$i]);
       }

--- a/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/GroupsTagsSubmissionTest.php
@@ -40,6 +40,14 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
       'visibility' => "Public Pages",
     ]);
 
+    // Add contact to Group C
+    $this->utils->wf_civicrm_api4('GroupContact', 'create', [
+      'values' => [
+        'group_id' => $this->groups['GroupC'],
+        'contact_id' => $this->rootUserCid,
+      ],
+    ]);
+
     $this->drupalLogin($this->rootUser);
     $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
       'webform' => $this->webform->id(),
@@ -60,6 +68,25 @@ final class GroupsTagsSubmissionTest extends WebformCivicrmTestBase {
     $this->assertSession()->pageTextContains('GroupA');
     $this->assertSession()->pageTextContains('GroupB');
     $this->assertSession()->pageTextNotContains('GroupC');
+
+    $this->getSession()->getPage()->checkField('GroupB');
+    $this->assertSession()->checkboxChecked("GroupB");
+
+    // Submit the form.
+    $this->pressButtonOverride('Submit');
+    $this->assertPageNoErrorMessages();
+    $this->htmlOutput();
+
+    // Ensure user is still present in the admin group.
+    $contact = $this->utils->wf_civicrm_api('Contact', 'get', [
+      'sequential' => 1,
+      'return' => ["group"],
+      'contact_id' => $contactID,
+    ])['values'][0];
+    $contactGroups = explode(',', $contact['groups']);
+    $this->assertTrue(in_array($this->groups['GroupB'], $contactGroups));
+    $this->assertTrue(in_array($this->groups['GroupC'], $contactGroups));
+    $this->assertFalse(in_array($this->groups['GroupA'], $contactGroups));
   }
 
   public function testSubmitWebform() {


### PR DESCRIPTION
Overview
----------------------------------------
Fix admin group removal on submitting public group option

Before
----------------------------------------
- Enable the Groups field for an Existing Contact in the webform config, choosing "- User Select - (public groups)"
- Have a contact who is in Civi groups that are "User and User Admin only" and so won't show in a listing of public groups
- When the webform is completed after a URL is emailed to them with contact hash etc, the contact is removed from the "User and User Admin Only" groups that aren't listed on the webform.

After
----------------------------------------
Admin group remain unchanged on submitting public group from the webform.

Technical Details
----------------------------------------
The values in $this->data is normally changed during the webform submission, but $this->settings['data'] holds the original data values configured in the webform. The changes uses it instead to ensure the group options are fetched correctly.

