### PR TITLE
[Tests only] Now need to reset the container after switching the theme

### DIFF
--- a/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
+++ b/tests/src/FunctionalJavascript/WebformCivicrmTestBase.php
@@ -96,6 +96,10 @@ abstract class WebformCivicrmTestBase extends CiviCrmTestBase {
       ->set('admin', 'claro')
       ->save();
 
+    // Reset container after switching theme
+    // See https://www.drupal.org/project/drupal/issues/3555844
+    $this->container = \Drupal::getContainer();
+
     $this->adminUser = $this->createUser([
       'access content',
       'administer CiviCRM',


### PR DESCRIPTION
Overview
----------------------------------------


Before
----------------------------------------
Setting the theme procedurally now causes a problem where drupalLogin doesn't carry over the logged-in user to the backend.

After
----------------------------------------
Work around it for now.

Technical Details
----------------------------------------
See https://www.drupal.org/project/drupal/issues/3555844

Comments
----------------------------------------

