### PR TITLE
[Test only] drupal core-dev-pinned is currently broken upstream

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,13 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - drupal: '10.4.*'
+          - drupal: '10.5.*'
             civicrm: '6.4.*'
             php: '8.2'
           - drupal: '10.5.*'
             civicrm: '6.9.x-dev'
             php: '8.3'
-          - drupal: '10.5.*'
+          - drupal: '10.6.*'
             civicrm: 'dev-master'
             php: '8.3'
           - drupal: '11.2.*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           composer config repositories.0 composer https://packages.drupal.org/8
           composer config repositories.1 path $GITHUB_WORKSPACE
           composer install --no-interaction
-          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev-pinned:${{ matrix.drupal }} -w
+          COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:${{ matrix.drupal }} -w
       # This is done differently in drupal 11. See BROWSERTEST_OUTPUT_VERBOSE below.
       - name: Suppress links to screenshots
         # There's so many! They can be useful locally if running one test, but they aren't useful here and cause massive scrolling.


### PR DESCRIPTION
Overview
----------------------------------------
Upstream needs updating, but don't know when that will be.

Before
----------------------------------------
Upstream pins to library versions that composer won't install anymore.

After
----------------------------------------
Make it more like a real install where you are subject to the randomness of library releases, but less likely to get blocked on a specific dependency.

Technical Details
----------------------------------------
Yes, it is technical.

Comments
----------------------------------------
I'm personally 50/50 on the strategy.

It's also unclear to me if this hasn't been caught upstream because (a) nobody is using pinned anywhere, (b) the holidays, (c) it's not the biggest priority upstream. But if it's (a) or (c) it suggests leaning towards not depending on it.