### PR TITLE
Block unknown users: do not 403 embedding pages

### DIFF
--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -166,8 +166,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         $this->form['#prefix'] = wf_crm_aval($this->form, '#prefix', '') . '<div class="webform-civicrm-prefix contact-unknown">' . nl2br($this->settings['prefix_unknown']) . '</div>';
       }
       if ($this->settings['block_unknown_users']) {
-        $this->form['submitted']['#access'] = $this->form['actions']['#access'] = FALSE;
-        throw new AccessDeniedHttpException();
+        $this->form['#access'] = FALSE;
       }
     }
     if (!empty($this->data['participant_reg_type'])) {


### PR DESCRIPTION
## Overview
Fixes anonymous access regression when Block unknown users is enabled.
Instead of returning a 403 for the entire page that embeds the form, only the webform output is hidden.

Issue: https://www.drupal.org/project/webform_civicrm/issues/3485026
Reference MR: https://git.drupalcode.org/project/webform_civicrm/-/merge_requests/21

## Before
With Block unknown users enabled, visiting a page that embeds a Webform CiviCRM form as an anonymous user results in a 403 for the whole page, even if the page itself should be publicly viewable.

## After
The page remains accessible. The embedded webform output is hidden for anonymous users.

## Technical Details
- Scope access control to the webform render output instead of denying the route.
- Replace throwing AccessDeniedHttpException with setting the form render array access flag:
  - $this->form['#access'] = FALSE;

## Comments
Integration Tests should run on GitHub Actions for this PR.
