### PR TITLE
Support Toggle html type

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -938,6 +938,7 @@ class Utils implements UtilsInterface {
       'Select' => ['type' => 'select'],
       'Multi-Select' => ['type' => 'select', 'extra' => ['multiple' => 1]],
       'Radio' => ['type' => 'select', 'extra' => ['aslist' => 0]],
+      'Toggle' => ['type' => 'select', 'extra' => ['aslist' => 0]],
       'CheckBox' => ['type' => 'select', 'extra' => ['multiple' => 1]],
       'Text'  => ['type' => 'textfield'],
       'TextArea' => ['type' => 'textarea'],
@@ -1116,7 +1117,7 @@ class Utils implements UtilsInterface {
     }
     return FALSE;
   }
-  
+
   /**
    * @return string Which field is the tag display field in this version of civi?
    */


### PR DESCRIPTION
Overview
----------------------------------------
A new custom field type, Toggle, was introduced in CiviCRM 6.10 for Yes/No data. Custom fields of this type do not currently appear in the CiviCRM Webform field listing.

This PR adds support for the new Toggle field type.