### PR TITLE
[Test only] Add test to check pay later is sent for Membership enabled webforms.

### DIFF
--- a/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
+++ b/tests/src/FunctionalJavascript/MembershipSubmissionTest.php
@@ -283,6 +283,62 @@ final class MembershipSubmissionTest extends WebformCivicrmTestBase {
 
     $this->assertEquals('Basic Plus', $membership['membership_name']);
     $this->assertEquals('1', $membership['status_id']);
+
+    // Now lets check pay later notifications
+    // Possibly should be in it's own test but would require
+    // Duplicating a lot of above logic.
+    $this->drupalLogin($this->rootUser);
+    $this->redirectEmailsToDB();
+
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $params = [
+      'payment_processor_id' => 'Pay Later',
+      'receipt' => [
+        'receipt_from_name' => 'Admin',
+        'receipt_from_email' => 'admin@example.com',
+        'pay_later_receipt' => 'Payment by Direct Credit to: ABC. Please quote invoice number and name.',
+        'receipt_text' => 'Thank you for your contribution.',
+      ],
+    ];
+    $this->configureContributionTab($params);
+    $this->saveCiviCRMSettings();
+
+    $this->drupalLogout();
+
+    $this->drupalGet($this->webform->toUrl('canonical', ['query' => ['membership' => 2]]));
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    $this->assertSession()->waitForField('First Name');
+    $this->getSession()->getPage()->fillField('First Name', 'Sarah');
+    $this->getSession()->getPage()->fillField('Last Name', 'Sinclar');
+    $this->getSession()->getPage()->fillField('Email', 'sarah@example.com');
+    $this->assertSession()->pageTextContains('Basic Plus');
+    $this->pressButtonOverride('Next >');
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    $this->pressButtonOverride('Submit');
+    $this->htmlOutput();
+    $this->assertPageNoErrorMessages();
+
+    $this->assertSession()->pageTextContains('New submission added to CiviCRM Webform Test.');
+
+    $api_result = $this->utils->wf_civicrm_api('membership', 'get', [
+      'sequential' => 1,
+      'status_id' => "Pending",
+    ]);
+    $this->assertEquals(1, $api_result['count']);
+    $membership = reset($api_result['values']);
+    $this->assertEquals('Basic Plus', $membership['membership_name']);
+
+    $sent_email = $this->getMostRecentEmail();
+    $this->assertStringContainsString('From: Admin <admin@example.com>', $sent_email);
+    $this->assertStringContainsString('To: Sarah Sinclar <sarah@example.com>', $sent_email);
+    $this->assertStringContainsString('Payment by Direct Credit to: ABC. Please quote invoice number and name.', $sent_email);
+    $this->assertStringContainsString('Thank you for your contribution', $sent_email);
   }
 
   /**


### PR DESCRIPTION
Overview
----------------------------------------

Test to hopefully demonstrate [2593357](https://www.drupal.org/project/webform_civicrm/issues/2593357)


Before
----------------------------------------

Pay later is only tested for a Contribution.

After
----------------------------------------

Adds a test to testSubmitMembershipQueryParams to check what happens on a membership enabled page.


Comments
----------------------------------------

Wasn't sure where best to put this as involves copying logic from two different tests. Ideally we would avoid copying test code around and abstract some of the logic into a utility function.

