### PR TITLE
Removes unneeded unset

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1012,8 +1012,6 @@ class Utils implements UtilsInterface {
     $contributionData = wf_crm_aval($data, 'contribution:1:contribution:1');
     $params = ['id' => $contributionID];
     $params['payment_processor_id'] = $contributionData['payment_processor_id'] ?? $data['civicrm_1_contribution_1_contribution_payment_processor_id'] ?? NULL;
-    unset($params['payment_processor']);
-
     $params['financial_type_id'] = $contributionData['financial_type_id'] ?? $data['civicrm_1_contribution_1_contribution_financial_type_id_raw'] ?? NULL;
     $params['currency'] = wf_crm_aval($data, "contribution:1:currency");
 


### PR DESCRIPTION
Overview
----------------------------------------
We create an array and populate it - but do not populate the key 'payment_processor'. Then we call unset.

Before
----------------------------------------
This seems unnecessary?

After
----------------------------------------
Removes  an unneeded unset.

Technical Details
----------------------------------------

Comments
----------------------------------------
I didn't actually check the origin of this I should and will note below.
