### PR TITLE
Fix for missing pay later text

### DIFF
--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -58,6 +58,10 @@ function webform_civicrm_civicrm_alterMailParams(&$params, $context) {
           $submissionData = array_merge($settings['data'], $submission->getData());
           $receiptParams = $utils->getReceiptParams($submissionData, $params['tplParams']['contributionID']);
           $params['tplParams']= array_merge($params['tplParams'], $receiptParams);
+          // Manually copy over the pay_later_receipt text if it exists.
+          if (!empty($receiptParams['pay_later_receipt'])) {
+            $params['tokenContext']['contribution']['contribution_page_id.pay_later_receipt'] =  $receiptParams['pay_later_receipt'];
+          }
         }
       }
     }

--- a/webform_civicrm.module
+++ b/webform_civicrm.module
@@ -58,7 +58,7 @@ function webform_civicrm_civicrm_alterMailParams(&$params, $context) {
           $submissionData = array_merge($settings['data'], $submission->getData());
           $receiptParams = $utils->getReceiptParams($submissionData, $params['tplParams']['contributionID']);
           $params['tplParams']= array_merge($params['tplParams'], $receiptParams);
-          // Manually copy over the pay_later_receipt text if it exists.
+          // Manually copy over the pay_later_receipt text if it exists
           if (!empty($receiptParams['pay_later_receipt'])) {
             $params['tokenContext']['contribution']['contribution_page_id.pay_later_receipt'] =  $receiptParams['pay_later_receipt'];
           }


### PR DESCRIPTION
Refs: https://www.drupal.org/project/webform_civicrm/issues/2593357

Adds pay_later text to contribution.contribution_page_id.pay_later_receipt to match handling in core. Note we are currently leaving the old $pay_later_receipt variable populated for backward compadibility if sites haven't updated their message templates.

Note this fix doesn't apply to events.

Overview
----------------------------------------

In https://github.com/civicrm/civicrm-core/pull/28184 the token to hold the pay later text on memberships was changed.

To replicate add a pay later option to a webform with a membership. Submit and observe the email not working. I've added a test in https://github.com/colemanw/webform_civicrm/pull/1101 however I need to fix this so it fails appropriately. Probably makes sense once that is failing appropriately to include that in this as one PR.  But wanted to get this up and visible in case anyone else hits the issue.

There was some discussion with @eileenmcnaughton on CiviCRM chat and she was suggesting a different approach to add an additional token into CivICRM core that could then be used to handle this.  I'm not sure if that is a better approach or given that ideally we'll get testing working on pay later for both memberships and events we just rely on that to catch the different treatment of pay later text in CiviCRM core.

This leaves events broken.

Before
----------------------------------------

No pay later text shows.

After
----------------------------------------

Pay later text shows. 

Technical Details
----------------------------------------

Ideally we'd detect for membership enabled section and only add it then. 

Comments
----------------------------------------

While this does work I think there are improvements we could make here - detecting memberships being enabled, and folding in the tests - once working.
