### PR TITLE
[Test only] temporarily restrict brick versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install CiviCRM ${{ matrix.civicrm }}
         run: |
           cd ~/drupal
-          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} -W
+          COMPOSER_MEMORY_LIMIT=-1 composer require civicrm/civicrm-asset-plugin:'~1.1' civicrm/civicrm-{core,packages,drupal-8}:${{ matrix.civicrm }} brick/math:'0.14.1' brick/money:'0.11.0' -W
       - name: Download Webform
         run: |
           cd ~/drupal


### PR DESCRIPTION
Overview
----------------------------------------
This is partly fixed in core but even still will need this to prevent drupal + older civi versions getting the newer version for now.