### PR TITLE
"Disable saving of submissions" setting causes crash on submission

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -321,10 +321,13 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     }
     // Write record; we do this when creating, updating, or saving a draft of a webform submission.
     $record = $this->formatSubmission();
-    $this->database->merge('webform_civicrm_submissions')
-      ->key('sid', $record['sid'])
-      ->fields($record)
-      ->execute();
+    //If 'Disable saving of submissions' is enabled, sid is null
+   if (!is_null($record['sid'])){ 
+     $this->database->merge('webform_civicrm_submissions')
+       ->key('sid', $record['sid'])
+       ->fields($record)
+       ->execute();
+   }  
 
     // Calling an IPN payment processor will result in a redirect so this happens after everything else
     if ($this->contributionIsIncomplete && !$this->contributionIsPayLater && !empty($this->ent['contribution'][1]['id']) && !$this->submission->isDraft()) {

--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -322,12 +322,12 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
     // Write record; we do this when creating, updating, or saving a draft of a webform submission.
     $record = $this->formatSubmission();
     //If 'Disable saving of submissions' is enabled, sid is null
-   if (!is_null($record['sid'])){ 
-     $this->database->merge('webform_civicrm_submissions')
-       ->key('sid', $record['sid'])
-       ->fields($record)
-       ->execute();
-   }  
+    if (!is_null($record['sid'])){ 
+      $this->database->merge('webform_civicrm_submissions')
+        ->key('sid', $record['sid'])
+        ->fields($record)
+        ->execute();
+    }  
 
     // Calling an IPN payment processor will result in a redirect so this happens after everything else
     if ($this->contributionIsIncomplete && !$this->contributionIsPayLater && !empty($this->ent['contribution'][1]['id']) && !$this->submission->isDraft()) {


### PR DESCRIPTION
Overview
----------------------------------------
"Disable saving of submissions" setting causes crash on submission

Before
----------------------------------------
Set the "Disable saving of submissions" to checked.
Submit webform.
Get a crash on submission: "The website encountered an unexpected error. Try again later."
<img width="459" height="42" alt="image" src="https://github.com/user-attachments/assets/d22de251-626d-473f-997f-0db1c91a918a" />
The values are recorded in CiviCRM.

The watchdog error is
`Drupal\Core\Entity\EntityStorageException: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'sid' cannot be null: INSERT INTO "webform_civicrm_submissions" ("sid", "contact_id", "civicrm_data") VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2); Array ( [:db_insert_placeholder_0] => [:db_insert_placeholder_1] => -2- [:db_insert_placeholder_2] => a:1:{s:7:"contact";a:1:{i:1;a:2:{s:2:"id";s:1:"2";s:3:"cg4";a:1:{i:1;i:8;}}}} ) in Drupal\Core\Entity\Sql\SqlContentEntityStorage->save() (line 815 of /var/www/html/drupal11/web/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php).`

`Backtrace	
#0 /var/www/html/drupal11/web/modules/contrib/webform/src/WebformSubmissionStorage.php(1003): Drupal\Core\Entity\Sql\SqlContentEntityStorage->save()`

After
----------------------------------------
Set the "Disable saving of submissions" to checked.
Submit webform.
Webform re-directs correctly without crashing.
The values are recorded in CiviCRM.

Technical Details
----------------------------------------
The change now checks for a null sid value before attempting to write to "webform_civicrm_submissions" table.

Comments
----------------------------------------
The alternative is to write a custom webform handler to delete submissions as soon as they are made.
