### PR TITLE
Merge POST values in confirm-form payment path for tokenized processors.

### DIFF
--- a/src/WebformCivicrmConfirmForm.php
+++ b/src/WebformCivicrmConfirmForm.php
@@ -48,6 +48,17 @@ class WebformCivicrmConfirmForm  implements WebformCivicrmConfirmFormInterface {
         $paymentProcessor = \Civi\Payment\System::singleton()->getByName($processor_type['name'], TRUE);
       }
 
+      // Merge submitted POST values into the payment params so that
+      // processor-specific fields (e.g. tokenized payment nonces) are
+      // available to doPayment(). This mirrors what contributionParams()
+      // already does for the on-site / live payment path.
+      $request = \Drupal::request();
+      foreach ($request->request->all() as $key => $value) {
+        if (!isset($paramsDoPayment[$key]) && $value !== '' && $value !== NULL) {
+          $paramsDoPayment[$key] = $value;
+        }
+      }
+
       if (method_exists($paymentProcessor, 'setSuccessUrl')) {
         $paymentProcessor->setSuccessUrl($paramsDoPayment['successURL']);
         $paymentProcessor->setCancelUrl($paramsDoPayment['cancelURL']);


### PR DESCRIPTION
Overview
----------------------------------------
Patch to allow new payment processor (Square) extension to work with Webform.

Technical Details
----------------------------------------
WebformCivicrmConfirmForm::doPayment() does not merge $_POST values into the payment params before calling $paymentProcessor->doPayment(). This means any payment processor that relies on custom POST fields (e.g. tokenized card nonces from Square Web Payments SDK, Stripe payment intents, etc.) will fail with a missing token error when the contribution is routed through the IPN/confirm-form path.
The on-site / live payment path (WebformCivicrmPostProcess::contributionParams()) already merges all POST values into the payment params

```
// WebformCivicrmPostProcess.php, contributionParams(), ~line 2284
$request = \Drupal::request();
foreach ($request->request->all() as $key => $value) {
  if (empty($params[$key])) {
    $params[$key] = $value;
  }
}

```
Comments
----------------------------------------
This affects any payment processor whose doPayment() expects values that are submitted via POST from client-side JavaScript (tokenized/iframe-based processors). Traditional CC processors that use CiviCRM's built-in billing fields are unaffected because those fields are collected by validateBillingFields() and passed through billing_params.
