### PR TITLE
Replace stripe extension (latest release) with git clone (stripe master)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,9 @@ jobs:
           # Apparently we have to install it, otherwise stripe gives a dependency error even with install=0. I think that's a bug, but let's just do it. This is a fake install anyway.
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=mjwshared
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=firewall
-          /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.drastikbydesign.stripe
+          # [Temporary]: we need stripe master - it has an unreleased fix for a Brick deprecation
+          # /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.drastikbydesign.stripe
+          git clone https://lab.civicrm.org/extensions/stripe.git com.drastikbydesign.stripe
           /home/runner/civicrm-cv/cv api3 Extension.download install=1 key=com.donordepot.authnetecheck
           /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.iatspayments.civicrm
           # For uscounties, it hasn't had a release in a few years so no longer appears in the ext feed, so just download directly. If it ever does need an update, would need to update here.


### PR DESCRIPTION
Temporary: replace stripe extension (latest release) with git clone (stripe master) due to an unreleased fix.

Overview
----------------------------------------
`BigDecimal::getIntegralPart() is deprecated and will be removed in 0.15. It will be re-introduced as returning BigInteger in 0.16. in Brick\Math\BigDecimal->getIntegralPart() (line 752 of /home/runner/drupal/vendor/brick/math/src/BigDecimal.php).`
