### PR TITLE
autocomplete not working properly when display fields contains contact id

### DIFF
--- a/src/ContactComponent.php
+++ b/src/ContactComponent.php
@@ -160,7 +160,7 @@ class ContactComponent implements ContactComponentInterface {
     if ($str) {
       $searchFields = [];
       foreach ($display_fields as $fld) {
-        $searchFields[] = [$fld, 'CONTAINS', $str];
+        $searchFields[] = [$fld, 'LIKE', '%' . $str . '%'];
       }
       $params['where'][] = ['OR', $searchFields];
     }

--- a/tests/src/FunctionalJavascript/ExistingContactElementTest.php
+++ b/tests/src/FunctionalJavascript/ExistingContactElementTest.php
@@ -177,6 +177,15 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
    * searchable with all display field values.
    */
   public function testDisplayFields() {
+    // Fill with more than the widget displays, and that would come first
+    // before our desired contact
+    for ($i = 1; $i < 21; $i++) {
+      $this->createIndividual([
+        'first_name' => 'Aaron',
+        'last_name' => 'Aardvark' . $i,
+        'source' => '',
+      ]);
+    }
     $this->createIndividual([
       'first_name' => 'James',
       'last_name' => 'Doe',
@@ -209,6 +218,22 @@ final class ExistingContactElementTest extends WebformCivicrmTestBase {
     // Search on source value and verify if the contact is selected.
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'Webform Testing');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
+    $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
+
+    // Edit contact element and change to display contact id.
+    $this->drupalGet($this->webform->toUrl('edit-form'));
+    $editContact = [
+      'selector' => 'edit-webform-ui-elements-civicrm-1-contact-1-contact-existing-operations',
+      'widget' => 'Autocomplete',
+      'results_display' => ['display_name', 'id'],
+      'default' => '- None -',
+    ];
+    $this->editContactElement($editContact);
+
+    // Now see if name search still works
+    $this->drupalGet($this->webform->toUrl('canonical'));
+    $this->fillContactAutocomplete('token-input-edit-civicrm-1-contact-1-contact-existing', 'James');
     $this->assertFieldValue('edit-civicrm-1-contact-1-contact-first-name', 'James');
     $this->assertFieldValue('edit-civicrm-1-contact-1-contact-last-name', 'Doe');
   }


### PR DESCRIPTION
Overview
----------------------------------------
autocomplete not working properly when display fields contains contact id.

Before
----------------------------------------
1. Have more than 12 contacts in your database (this just makes it easier to see)
1. Create a form with Existing Contact and make it an autocomplete.
1. For the display fields include contact id, e.g. display name and contact id.
1. Visit the form and try to use the autocomplete. It will match on everything.

After
----------------------------------------
Better

Technical Details
----------------------------------------
Something about CONTAINS has changed when the field is non-string. Sometime between 6.4 and 6.12.

Comments
----------------------------------------
First run includes just the failing test, then second commit includes a fix.
