### PR TITLE
work around failing iats test

### DIFF
--- a/tests/src/FunctionalJavascript/ContributionIatsTest.php
+++ b/tests/src/FunctionalJavascript/ContributionIatsTest.php
@@ -160,7 +160,7 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->pressButtonOverride('Submit');
     $this->assertSession()->assertWaitOnAjaxRequest();
-    $this->createScreenshot($this->htmlOutputDirectory . 'faps169.png');
+    $this->createScreenshot($this->htmlOutputDirectory . '/faps169.png');
     $this->assertPageNoErrorMessages();
     $this->htmlOutput();
 
@@ -399,8 +399,12 @@ final class ContributionIatsTest extends WebformCivicrmTestBase {
 
     $this->enableBillingSection();
 
+    // For some reason it needs a delay or else it gives a warning about not being able to find the financial type and then most of the fields don't get added, including the email field which is then what it fails on later.
+    sleep(5);
+
     $this->pressButtonOverride('Save Settings');
     $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->assertPageNoErrorMessages();
 
     $this->drupalGet($this->webform->toUrl('canonical'));
     $this->assertPageNoErrorMessages();


### PR DESCRIPTION
Overview
----------------------------------------
After iats update this test started failing. Not clear it's really about iats but this seems to fix it.

Before
----------------------------------------
It doesn't add all the fields to the form when you save the config, and has a warning about financial type. But they're all selected just fine so not sure why it doesn't see them.

After
----------------------------------------
The delay seems to make it work.

Technical Details
----------------------------------------
?????

Comments
----------------------------------------
