### PR TITLE
Proposal Fix #3587394 - Reload live options from CiviCRM so labels stay in sync

### DIFF
--- a/src/Plugin/WebformElement/CivicrmOptions.php
+++ b/src/Plugin/WebformElement/CivicrmOptions.php
@@ -325,6 +325,12 @@ class CivicrmOptions extends OptionsBase {
    * @inheritDoc
    */
   protected function format($type, array &$element, WebformSubmissionInterface $webform_submission, array $options = []) {
+    // Reload live options from CiviCRM so labels stay in sync
+    if (!empty($element['#civicrm_live_options']) && $webform_submission && $webform_submission->getWebform()->getHandlers()->has('webform_civicrm')) {
+      $data = $webform_submission->getWebform()->getHandler('webform_civicrm')->getConfiguration()['settings']['data'] ?? [];
+      $element['#options'] = $this->getFieldOptions($element, $data) + $element['#options'];
+    }
+
     $value = parent::format($type, $element, $webform_submission, $options);
     $format = $this->getItemFormat($element);
     if (!str_ends_with($element['#form_key'], '_address_state_province_id')) {


### PR DESCRIPTION
Added functionality to reload live options from CiviCRM to keep labels in sync

Overview
----------------------------------------
When a CiviCRM event is created after the webform was last saved, tokens like:

[webform_submission:values:civicrm_1_participant_1_participant_event_id]

render the raw value (e.g. 435-7) instead of the event title.

The participant is correctly registered in CiviCRM. Only the label is wrong.

Technical Details
----------------------------------------
Create a webform with a Participant section, Event field set to Live Options, Allow URL Load enabled.
Add an Email handler with this in the body:
Save the webform.
In CiviCRM, create a new event (don't re-save the webform).
Open the form with ?event1= and submit.
Check the email and the submission view.
Expected: the event title.
Actual: the raw value (e.g. 435-7).

Comments
----------------------------------------
* https://www.drupal.org/project/webform_civicrm/issues/3587394
* https://github.com/colemanw/webform_civicrm/pull/947
