### PR TITLE
Also when we're not renewing we may need to switch Membership Types

### DIFF
--- a/src/WebformCivicrmPostProcess.php
+++ b/src/WebformCivicrmPostProcess.php
@@ -1265,19 +1265,17 @@ class WebformCivicrmPostProcess extends WebformCivicrmBase implements WebformCiv
 
       // Search for existing membership to renew - must belong to same domain and organization
       // But not necessarily the same membership type to allow for upsell
-      if (!empty($params['num_terms'])) {
-        $type = $types[$params['membership_type_id']];
-        foreach ($existing as $mem) {
-          $existing_type = $types[$mem['membership_type_id']];
-          if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
-            $params['id'] = $mem['id'];
-            // If we have an exact match, look no further
-            if ($mem['membership_type_id'] == $params['membership_type_id']) {
-              $is_active = $mem['is_active'];
-              $membershipStatus = $mem['status'];
-              $membershipEndDate = $mem['end_date'];
-              break;
-            }
+      $type = $types[$params['membership_type_id']];
+      foreach ($existing as $mem) {
+        $existing_type = $types[$mem['membership_type_id']];
+        if ($type['domain_id'] == $existing_type['domain_id'] && $type['member_of_contact_id'] == $existing_type['member_of_contact_id']) {
+          $params['id'] = $mem['id'];
+          // If we have an exact match, look no further
+          if ($mem['membership_type_id'] == $params['membership_type_id']) {
+            $is_active = $mem['is_active'];
+            $membershipStatus = $mem['status'];
+            $membershipEndDate = $mem['end_date'];
+            break;
           }
         }
       }


### PR DESCRIPTION
Overview
----------------------------------------
Also when we're not adding #terms to the webform, one should be able to switch Membership Types.

Before this change:
Webform CiviCRM creates a New Membership even if the Membership Type belongs to the same (sub) organization.

After this change:
Webform CiviCRM updates the Membership if the Membership Type belongs to the same (sub) organization.
