### PR TITLE
Issue #3590183: Check field key instead of field name to avoid accidentally deleting other hidden fields

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2233,7 +2233,7 @@ class AdminForm implements AdminFormInterface {
       }
       else {
         $field = $this->utils->wf_crm_get_field($key);
-        if ($field['type'] == 'hidden' && (!empty($val[0]) || $field['name'] == 'Payment Processor Mode')) {
+        if ($field['type'] == 'hidden' && (!empty($val[0]) || strpos($key, 'contribution_is_test') === FALSE)) {
           unset($fields[$key]);
         }
       }


### PR DESCRIPTION
reference the Drupal.org issue https://www.drupal.org/project/webform_civicrm/issues/3590183