### PR TITLE
Refresh Existing Contact #allow_create flag when CiviCRM settings are saved

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2040,10 +2040,25 @@ class AdminForm implements AdminFormInterface {
 
     $this->addEnabledElements($enabled);
     $this->setPaging();
-    // Update existing contact fields
+    // Refresh the allow_create flag on existing "Existing Contact" fields.
+    // It is derived from the presence of name/email fields on the form and may
+    // have changed, but insertComponent() only writes the recomputed value when
+    // adding a *new* element (see its guard) - so existing elements keep a stale
+    // value. Bring them back in sync here.
     foreach ($existing as $fid => $id) {
-      if (substr($fid, -8) === 'existing') {
-        $stop = null;
+      if (!str_ends_with($fid, '_contact_existing')) {
+        continue;
+      }
+      $element = $this->webform->getElementDecoded($fid);
+      if ($element === NULL) {
+        continue;
+      }
+      [, $c] = explode('_', $fid);
+      $contact_type = wf_crm_aval($this->settings['data']['contact'], "$c:contact:1:contact_type");
+      $allow_create = $this->utils->wf_crm_name_field_exists($enabled + $this->settings, $c, $contact_type);
+      if ((int) wf_crm_aval($element, '#allow_create', 0) !== (int) $allow_create) {
+        $element['#allow_create'] = $allow_create;
+        $this->webform->setElementProperties($fid, $element);
       }
     }
   }

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -2046,6 +2046,7 @@ class AdminForm implements AdminFormInterface {
     // adding a *new* element (see its guard) - so existing elements keep a stale
     // value. Bring them back in sync here.
     foreach ($existing as $fid => $id) {
+      // find field which ends with '_contact_existing'
       if (!str_ends_with($fid, '_contact_existing')) {
         continue;
       }

--- a/tests/src/FunctionalJavascript/SaveSettingsTest.php
+++ b/tests/src/FunctionalJavascript/SaveSettingsTest.php
@@ -180,6 +180,8 @@ final class SaveSettingsTest extends WebformCivicrmTestBase {
    * @param int $expected
    */
   private function assertExistingContactAllowCreate($expected) {
+    // Reload the webform to ensure fresh data
+    \Drupal::entityTypeManager()->getStorage('webform')->resetCache();
     $webform = Webform::load($this->webform->id());
     $element = $webform->getElementDecoded('civicrm_1_contact_1_contact_existing');
     $this->assertNotNull($element, 'Existing Contact element is present.');

--- a/tests/src/FunctionalJavascript/SaveSettingsTest.php
+++ b/tests/src/FunctionalJavascript/SaveSettingsTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\webform_civicrm\FunctionalJavascript;
 
 use Drupal\Core\Url;
+use Drupal\webform\Entity\Webform;
 
 /**
  * Tests settings on the webform.
@@ -142,6 +143,47 @@ final class SaveSettingsTest extends WebformCivicrmTestBase {
       'civicrm_1_activity_1_activity_activity_type_id',
     ];
     $this->assertElementsOnBuildForm($elements, TRUE);
+  }
+
+  /**
+   * The Existing Contact #allow_create flag must be refreshed on save when the
+   * name/email fields that drive it are removed from an existing form.
+   */
+  function testExistingContactAllowCreateRefresh() {
+    // addFieldsOnWebform() enables First Name + Last Name, so contact creation
+    // is possible and allow_create should be stored as 1.
+    $this->addFieldsOnWebform();
+    $this->assertExistingContactAllowCreate(1);
+
+    // Remove both name fields, leaving no field that can create a contact.
+    $this->drupalGet(Url::fromRoute('entity.webform.civicrm', [
+      'webform' => $this->webform->id(),
+    ]));
+    $this->getSession()->getPage()->uncheckField('civicrm_1_contact_1_contact_first_name');
+    $this->getSession()->getPage()->uncheckField('civicrm_1_contact_1_contact_last_name');
+    $this->saveCiviCRMSettings(TRUE);
+
+    // Confirm removal of the now-unneeded webform fields.
+    $this->assertSession()->waitForField('edit-delete');
+    $this->pressButtonOverride('edit-delete');
+    $this->assertSession()->waitForField('nid');
+    $this->assertSession()->pageTextContains('Saved CiviCRM settings');
+    $this->assertPageNoErrorMessages();
+
+    // allow_create must now be refreshed to 0 on the (pre-existing) element.
+    $this->assertExistingContactAllowCreate(0);
+  }
+
+  /**
+   * Assert the stored #allow_create value of contact 1's Existing Contact field.
+   *
+   * @param int $expected
+   */
+  private function assertExistingContactAllowCreate($expected) {
+    $webform = Webform::load($this->webform->id());
+    $element = $webform->getElementDecoded('civicrm_1_contact_1_contact_existing');
+    $this->assertNotNull($element, 'Existing Contact element is present.');
+    $this->assertSame($expected, (int) ($element['#allow_create'] ?? 0));
   }
 
   /**


### PR DESCRIPTION
### Problem

An "Existing Contact" element's `#allow_create` flag never updates once the element is on the form. If you later remove the last name/email field for that contact, `#allow_create` stays stuck at `1`, so the form keeps trying to create contacts (and can error out during processing) even though there are no fields to create one from. The reverse is also true — adding name/email fields to a contact that already has an Existing Contact element won't flip the flag to `1`.

### Root cause

`#allow_create` is derived from the presence of name/email fields via `wf_crm_name_field_exists()` and is recomputed in `AdminForm::insertComponent()`. But `insertComponent()` only writes the value back when **adding a new** element — its final guard skips elements that already exist:

```php
// AdminForm::insertComponent()
if (empty($enabled[$field['form_key']])) {   // false for an existing field
  $enabled[$field['form_key']] = $field;
}
```

`addEnabledElements()` likewise only rewrites array (new) entries, not the string (existing) ones. So for any Existing Contact field already on the form, the recomputed `allow_create` is discarded and the stored value goes stale.

There was even a long-empty stub left in `postProcess()` marking where this was meant to be handled:

```php
// Update existing contact fields
foreach ($existing as $fid => $id) {
  if (substr($fid, -8) === 'existing') {
    $stop = null;
  }
}
```

### Fix

Implement that stub: on save, for each existing `*_contact_existing` field, recompute `allow_create` (same calculation `insertComponent()` uses) and write it back via `setElementProperties()` when it differs. The trailing `$webform->save()` in the settings-form submit handler persists the change.

### Test

`SaveSettingsTest::testExistingContactAllowCreateRefresh()` — enables First/Last Name (asserts stored `#allow_create == 1`), then removes both name fields via the settings form + delete confirmation (asserts it refreshes to `0`).

### Notes

- Behaviour change is limited to the moment CiviCRM settings are saved; it does not touch front-end submission handling.
- Existing forms pick up the corrected value the next time their CiviCRM settings are saved.