### PR TITLE
Fix for missing class "CRM_Core_DAO" not found

### DIFF
--- a/webform_civicrm.install
+++ b/webform_civicrm.install
@@ -467,6 +467,7 @@ function _recursiveKeyReplace(array &$elements, $searchKey, $replacementKey) {
  * Update usage of group to crmgroup
  */
 function webform_civicrm_update_8008() {
+  Drupal::service('civicrm')->initialize();
   $webforms = Webform::loadMultiple();
 
   foreach ($webforms as $webform) {


### PR DESCRIPTION
Overview
----------------------------------------
While doing a drush update I kept getting

```
  [notice] Update started: webform_civicrm_update_8008
>  [error]  Class "CRM_Core_DAO" not found 
>  [error]  Update failed: webform_civicrm_update_8008
```

Technical Details
----------------------------------------

I don't fully understand, but my guess is that when loading the Webforms that might trigger some CiviCRM related items, and since it's not loaded it borks. Adding the line above makes the upgrade work properly
