### PR TITLE
Add option to hide existing membership status message

### DIFF
--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1052,7 +1052,7 @@ class AdminForm implements AdminFormInterface {
       '#type' => 'checkbox',
       '#title' => t('Show existing membership status message'),
       '#description' => t('When a contact with an existing membership fills out the form, display a message showing their current membership status and expiry date.'),
-      '#default_value' => (bool) wf_crm_aval($this->data, 'membership_options:show_status_message', 1, TRUE),
+      '#default_value' => (bool) wf_crm_aval($this->settings, 'membership_options:show_status_message', 1, TRUE),
       '#parents' => ['membership_options', 'show_status_message'],
     ];
     for ($c = 1, $cMax = count($this->data['contact']); $c <= $cMax; ++$c) {

--- a/src/AdminForm.php
+++ b/src/AdminForm.php
@@ -1048,6 +1048,13 @@ class AdminForm implements AdminFormInterface {
       '#group' => 'webform_civicrm',
       '#attributes' => ['class' => ['civi_icon_fa-id-badge']],
     ];
+    $this->form['membership']['membership_show_status_message'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Show existing membership status message'),
+      '#description' => t('When a contact with an existing membership fills out the form, display a message showing their current membership status and expiry date.'),
+      '#default_value' => (bool) wf_crm_aval($this->data, 'membership_options:show_status_message', 1, TRUE),
+      '#parents' => ['membership_options', 'show_status_message'],
+    ];
     for ($c = 1, $cMax = count($this->data['contact']); $c <= $cMax; ++$c) {
       $num = wf_crm_aval($this->data, "membership:{$c}:number_of_membership", 0);
       $this->form['membership'][$c]["membership_{$c}_number_of_membership"] = [

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -186,7 +186,8 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         }
         // Membership
         if (!empty($this->data['membership'][$c]['number_of_membership'])) {
-          $this->loadMemberships($c, $contact['id']);
+          $showMessage = (bool) wf_crm_aval($this->data, 'membership_options:show_status_message', 1, TRUE);
+          $this->loadMemberships($c, $contact['id'], $showMessage);
         }
         if ($c == 1 && !empty($this->data['billing']['number_number_of_billing'])) {
           $this->info['contribution'][1]['contribution'][1] = $this->loadBillingAddress($contact['id']);
@@ -456,7 +457,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
    * @param int $c
    * @param int $cid
    */
-  private function loadMemberships($c, $cid) {
+  private function loadMemberships($c, $cid, $showMessage = TRUE) {
     $today = date('Y-m-d');
     foreach ($this->findMemberships($cid) as $num => $membership) {
       // Only show 1 expired membership, and only if there are no active ones
@@ -464,16 +465,18 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         break;
       }
       $type = $membership['membership_type_id'];
-      $msg = t('@type membership for @contact has a status of "@status".', [
-        '@type' => $this->getMembershipTypeField($type, 'name'),
-        '@contact' => $this->info['contact'][$c]['contact'][1]['display_name'],
-        '@status' => $membership['status'],
-      ]);
-      if (!empty($membership['end_date'])) {
-        $end = ['@date' => \CRM_Utils_Date::customFormat($membership['end_date'])];
-        $msg .= ' ' . ($membership['end_date'] > $today ? t('Expires @date.', $end) : t('Expired @date.', $end));
+      if ($showMessage) {
+        $msg = t('@type membership for @contact has a status of "@status".', [
+          '@type' => $this->getMembershipTypeField($type, 'name'),
+          '@contact' => $this->info['contact'][$c]['contact'][1]['display_name'],
+          '@status' => $membership['status'],
+        ]);
+        if (!empty($membership['end_date'])) {
+          $end = ['@date' => \CRM_Utils_Date::customFormat($membership['end_date'])];
+          $msg .= ' ' . ($membership['end_date'] > $today ? t('Expires @date.', $end) : t('Expired @date.', $end));
+        }
+        $this->setMessage($msg);
       }
-      $this->setMessage($msg);
       for ($n = 1; $n <= $this->data['membership'][$c]['number_of_membership']; ++$n) {
         $fid = "civicrm_{$c}_membership_{$n}_membership_membership_type_id";
         if (empty($info['membership'][$c]['membership'][$n]) && ($this->getData($fid) == $type ||

--- a/src/WebformCivicrmPreProcess.php
+++ b/src/WebformCivicrmPreProcess.php
@@ -186,7 +186,7 @@ class WebformCivicrmPreProcess extends WebformCivicrmBase implements WebformCivi
         }
         // Membership
         if (!empty($this->data['membership'][$c]['number_of_membership'])) {
-          $showMessage = (bool) wf_crm_aval($this->data, 'membership_options:show_status_message', 1, TRUE);
+          $showMessage = (bool) wf_crm_aval($this->settings, 'membership_options:show_status_message', 1, TRUE);
           $this->loadMemberships($c, $contact['id'], $showMessage);
         }
         if ($c == 1 && !empty($this->data['billing']['number_number_of_billing'])) {


### PR DESCRIPTION
When using webform_civicrm with membership forms, the existing membership status message is always shown to contacts with an active/expired membership.

Some use cases require hiding this message (e.g. renewal forms where the status info is redundant or confusing for the user).

## Proposed changes
- Adds a checkbox "Show existing membership status message" in the Memberships tab of the CiviCRM webform settings.
- Defaults to enabled (TRUE) to preserve existing behavior for all current installations.
- Passes the option as a parameter to `loadMemberships()`, which conditionally calls `$this->setMessage()`.

## Backward compatibility
Fully backward compatible. Default value is TRUE (checkbox checked), so no existing configuration is affected.