### PR TITLE
add js dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,15 +26,12 @@ jobs:
           - drupal: '10.6.*'
             civicrm: '6.16.x'
             php: '8.3'
-          - drupal: '10.6.*'
-            civicrm: 'dev-master'
-            php: '8.3'
           - drupal: '11.4.*'
             civicrm: '6.18.x-dev'
             php: '8.3'
           - drupal: '11.x-dev'
             civicrm: 'dev-master'
-            php: '8.3'
+            php: '8.4'
     name: Drupal ${{ matrix.drupal }} | CiviCRM ${{ matrix.civicrm }}
     services:
       mysql:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,10 @@ jobs:
           # /home/runner/civicrm-cv/cv api3 Extension.download install=0 key=com.aghstrategies.uscounties
           curl -L -O https://github.com/agh1/com.aghstrategies.uscounties/archive/2.1.zip
           unzip 2.1.zip
+          # temp patch for php 8.4
+          cd com.aghstrategies.uscounties-2.1
+          curl -L -O https://github.com/agh1/com.aghstrategies.uscounties/pull/13.patch
+          git apply 13.patch
       - name: Temp patch authnet sdk
         run: |
           cd ~/drupal/web/sites/default/files/civicrm/ext/com.donordepot.authnetecheck/vendor/authorizenet/authorizenet

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,7 +203,7 @@ jobs:
           SYMFONY_DEPRECATIONS_HELPER: 999999
           SIMPLETEST_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080
-          MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'
+          MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu", "--disable-dev-shm-usage", "--disable-background-networking", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'
           BROWSERTEST_OUTPUT_FILE: 'true'
           BROWSERTEST_OUTPUT_VERBOSE: 'false'
           BROWSERTEST_OUTPUT_DIRECTORY: '/home/runner/drupal/web/sites/simpletest/browser_output'

--- a/webform_civicrm.libraries.yml
+++ b/webform_civicrm.libraries.yml
@@ -7,12 +7,22 @@ admin:
     # TODO should only be loaded if there is a select list?
     # @link https://github.com/colemanw/webform_civicrm/blob/8f285b94c4ba444fc894b24f2d23a7c52c92731b/includes/wf_crm_admin_component.inc#L97
     js/webform_civicrm_options.js: {}
+  dependencies:
+    - core/jquery
+    - core/once
+    - core/drupal
+    - core/drupalSettings
 forms:
   css:
     component:
       css/webform_civicrm_forms.css: {}
   js:
     js/webform_civicrm_forms.js: {}
+  dependencies:
+    - core/jquery
+    - core/once
+    - core/drupal
+    - core/drupalSettings
 payment:
   js:
     js/webform_civicrm_payment.js: {}


### PR DESCRIPTION
Overview
----------------------------------------
These have probably always been missing, but it worked out ok before.

Before
----------------------------------------
After commit https://github.com/drupal/core/commit/36fea56e99fc187e31e3d0484282cbf386d48e06 in 11.4.x-dev, there are various javascript-related issues.

After
----------------------------------------
Add js dependencies and the problems seem to go away.

Technical Details
----------------------------------------
See https://www.drupal.org/project/drupal/issues/1945262. I didn't read the whole thing because it's too long but my takeaway was that it seemed like drupal is now more dependent on js dependencies being declared.

Comments
----------------------------------------
