### PR TITLE
Add zindex for autocomplete elements

### DIFF
--- a/js/webform_civicrm_contact.js
+++ b/js/webform_civicrm_contact.js
@@ -15,6 +15,7 @@
             noResultsText: field.data('none-prompt'),
             resultsFormatter: formatChoices,
             searchingText: "Searching...",
+              zindex: 1299,
             enableHTML: true
           };
         }


### PR DESCRIPTION
Overview
----------------------------------------
Otherwise it ends up under the popup :-)

Minimum required is >1261, but 1299 is a nice number. This is Olivero specific, but that's still the Drupal core theme - so looks like a good plan.

<img width="2600" height="1636" alt="image" src="https://github.com/user-attachments/assets/922c3d66-b2dc-439c-823b-7dd11040a41e" />

