### PR TITLE
[test only] try to reduce test output that we can't do anything about anyway

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
           unzip 2.1.zip
           # temp patch for php 8.4
           cd com.aghstrategies.uscounties-2.1
-          curl -L -O https://github.com/agh1/com.aghstrategies.uscounties/pull/13.patch
+          curl -L -O https://patch-diff.githubusercontent.com/raw/agh1/com.aghstrategies.uscounties/pull/13.patch
           git apply 13.patch
       - name: Temp patch authnet sdk
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,11 +197,12 @@ jobs:
           PHPUNITARGS=--verbose
           PHPUNIT10=`~/drupal/vendor/bin/phpunit --version | cut -d ' ' -f 2 | php -r 'echo (int) version_compare(stream_get_contents(STDIN), "10", ">=");'`
           if [ "$PHPUNIT10" == "1" ]; then
-            PHPUNITARGS="--display-skipped --display-deprecations --display-errors --display-warnings --display-notices"
+            PHPUNITARGS="--display-skipped --display-errors --display-warnings --display-notices"
           fi
+          sed -i -e 's/displayDetailsOnTestsThatTriggerDeprecations="true"/displayDetailsOnTestsThatTriggerDeprecations="false"/' core/phpunit.xml.dist
           ../vendor/bin/phpunit $PHPUNITARGS -c core modules/contrib/webform_civicrm
         env:
-          SYMFONY_DEPRECATIONS_HELPER: 999999
+          SYMFONY_DEPRECATIONS_HELPER: 'disabled'
           SIMPLETEST_DB: mysql://root:@127.0.0.1:${{ job.services.mysql.ports[3306] }}/db
           SIMPLETEST_BASE_URL: http://127.0.0.1:8080
           MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu", "--disable-dev-shm-usage", "--disable-background-networking", "--no-sandbox", "--headless"]}}, "http://127.0.0.1:9515"]'


### PR DESCRIPTION
Overview
----------------------------------------
Drupal 11+ and symfony and php and everybody (even phpunit itself!) wants to deprecate everything, adding more deprecations seemingly daily. This makes the log output useless (12000 lines of deprecations), and we speculate adds to the resource usage of already really heavy tests.

Before
----------------------------------------
Lots

After
----------------------------------------
Unfortunately the only way I can find to make it quieter is to turn it off completely, including ones we want. That's not desirable but hopefully they will come up in other ways.

Technical Details
----------------------------------------


Comments
----------------------------------------
If it turns out it doesn't help with resource usage and intermittent fails, we can always add it back.

This also includes a fix for curl to github intermittently failing, possibly due to recent infrastructure changes at github.